### PR TITLE
Check instruction misalignment for RV32C in the op_branch function

### DIFF
--- a/riscv.c
+++ b/riscv.c
@@ -486,7 +486,11 @@ static bool op_branch(struct riscv_t *rv, uint32_t inst)
     // perform branch action
     if (taken) {
         rv->PC += imm;
+#ifdef ENABLE_RV32C
+        if (rv->PC & 0x1)
+#else
         if (rv->PC & 0x3)
+#endif
             rv_except_inst_misaligned(rv, pc);
     } else {
         // step over instruction


### PR DESCRIPTION
I encountered a signal SIGABRT error.
```
000104b2
00027798  _dl_aux_init
0002779a
0002779e
00000000
rv32emu: io.c:76: memory_read_ifetch: Assertion `c' failed.
fish: Job 1, 'build/rv32emu ~/petzone/llvm/da…' terminated by signal SIGABRT (Abort)
```

Why:
The conditions are equal making the `beqz` takes action to jump to the `PC`, which points to 0x2798a. Then the instruction misalignment checking mechanism makes the `PC` was reset to zero in the op_branch function. This makes next instruction fetch got problem in memory_read_ifetch() function.
```
00027798 <_dl_aux_init>:
   27798:	411c         lw	    a5,0(a0)
   2779a:	eca1a223     sw     a0,-316(gp) # 6f218 <_dl_auxv>
   2779e:	1e078663     beqz   a5,2798a <_dl_aux_init+0x1f2> -----+
   ...                                                                 |
   2798a:	8082         ret    <----------------------------------+ 
                                     The `beqz` should jump to here (0x2798a), but the program counter PC
                                     was reset to zero, making the `beqz` instruction cannot be executed completely.
   ^^^^^
```

How:
According to the chapter, "1.2 Instruction Length Encoding" in the specification [(riscv-spec-v2.2.pdf)](https://riscv.org/wp-content/uploads/2017/05/riscv-spec-v2.2.pdf), the least significant two bits of `PC` is possible to be 00b, 01b, and 10b with RV32C. The gcc and clang implemented the CB format with `01b` and other parts in this project did so, so I add a corresponding check too.