### PR TITLE
Add Dockerfile as advanced preparation for CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:20.04
+
+# Set timezone, otherwise it can takes a rather long time to setup
+# Adjust this according to your timezone
+ENV TZ=Asia/Taipei
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get update && apt-get install -y \
+  git \
+  build-essential \
+  libsdl2-dev \
+  gcc-riscv64-unknown-elf
+
+COPY . /usr/src/rv32emu
+WORKDIR /usr/src/rv32emu

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ make quake
 
 The usage and limitations of Doom and Quake demo are listed in [docs/demo.md](docs/demo.md).
 
+RUN in Docker
+```shell
+docker build --pull --no-cache -t rv32emu .
+docker run --name rv32emu --rm -it rv32emu
+```
+or you can directly make
+```shell
+docker run --name rv32emu --rm rv32emu make
+```
+
 ## riscv-arch-test
 
 The RISC-V Architectural Tests, [riscv-arch-test](https://github.com/riscv-non-isa/riscv-arch-test), is the basic set of tests that can ensure the risc-v model's behavior that matches RISC-V specifications while implementing specific software.(not a **substitute for rigorous design verification**)


### PR DESCRIPTION
As it describes in issue #21, there are several test suites, and we want to run in CI pipeline

Therefore, we may need a container-based approach in the near future. Plus, this can align the development environment.