### PR TITLE
Cache JIT-compiled functions

### DIFF
--- a/jit.h
+++ b/jit.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 
 #include "c2mir/c2mir.h"
+#include "map.h"
 #include "mir.h"
 #include "riscv_private.h"
 
@@ -46,6 +47,8 @@ struct riscv_jit_t {
     uint8_t optimize_level;
     uint32_t insn_len;
     struct block_map_t *block_map;
+    /* cache of compiled functions */
+    map_t funcs;
     FILE *codegen_log;
     FILE *code_log;
     FILE *cache;


### PR DESCRIPTION
The size of the block map is fixed, and it will be emptied when the capacity reaches 80%
which will cause MIR to repeatedly compile the same block.
Solution: use the red-black tree to retain the compiled JIT function as a cache during
execution, which can avoid repeated compilation and do not need to change the size of the
 block map.

When loading the cache, the block map will adjust the capacity according to the number
of MIR modules.