### PR TITLE
Fix set PC restriction when RV32C is enabled

### DIFF
--- a/elf.c
+++ b/elf.c
@@ -300,7 +300,9 @@ bool elf_get_data_section_range(elf_t *e, uint32_t *start, uint32_t *end)
 
 bool elf_load(elf_t *e, struct riscv_t *rv, memory_t *mem)
 {
-    rv_set_pc(rv, e->hdr->e_entry); /* set the entry point */
+    /* set the entry point */
+    if (!rv_set_pc(rv, e->hdr->e_entry))
+        return false;
 
     /* loop over all of the program headers */
     for (int p = 0; p < e->hdr->e_phnum; ++p) {

--- a/emulate.c
+++ b/emulate.c
@@ -1851,7 +1851,11 @@ riscv_user_t rv_userdata(struct riscv_t *rv)
 bool rv_set_pc(struct riscv_t *rv, riscv_word_t pc)
 {
     assert(rv);
+#ifdef ENABLE_RV32C
+    if (pc & 1)
+#else
     if (pc & 3)
+#endif
         return false;
 
     rv->PC = pc;


### PR DESCRIPTION
I think it's fine for PC to just align 0x1 when RV32C is enabled. Otherwise, I have to re-config my riscv-gcc even if `rv32emu` does support compressed instruction :(