### PR TITLE
Manage breakpoints with red-black tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ GDBSTUB_LIB := $(GDBSTUB_OUT)/libgdbstub.a
 $(GDBSTUB_LIB): mini-gdbstub/Makefile
 	$(MAKE) -C $(dir $<) O=$(dir $@)
 $(OUT)/emulate.o: $(GDBSTUB_LIB)
-OBJS_EXT += gdbstub.o
+OBJS_EXT += gdbstub.o breakpoint.o
 CFLAGS += -D ENABLE_GDBSTUB -D'GDBSTUB_COMM="$(GDBSTUB_COMM)"'
 LDFLAGS += $(GDBSTUB_LIB)
 gdbstub-test: $(BIN)

--- a/breakpoint.c
+++ b/breakpoint.c
@@ -1,0 +1,60 @@
+#include "breakpoint.h"
+#include <assert.h>
+
+static inline int cmp(const void *arg0, const void *arg1)
+{
+    riscv_word_t *a = (riscv_word_t *) arg0, *b = (riscv_word_t *) arg1;
+    return (*a < *b) ? _CMP_LESS : (*a > *b) ? _CMP_GREATER : _CMP_EQUAL;
+}
+
+breakpoint_map_t breakpoint_map_new()
+{
+    return map_init(riscv_word_t, breakpoint_t, cmp);
+}
+
+bool breakpoint_map_insert(breakpoint_map_t map, riscv_word_t addr)
+{
+    breakpoint_t bp = (breakpoint_t){.addr = addr, .orig_insn = 0};
+    map_iter_t it;
+    map_find(map, &it, &addr);
+    /* We don't expect to set breakpoint at duplicate address */
+    if (!map_at_end(map, &it))
+        return false;
+    return map_insert(map, &addr, &bp);
+}
+
+static bool breakpoint_map_find_it(breakpoint_map_t map,
+                                   riscv_word_t addr,
+                                   map_iter_t *it)
+{
+    map_find(map, it, &addr);
+    if (map_at_end(map, it)) {
+        return false;
+    }
+
+    return true;
+}
+
+breakpoint_t *breakpoint_map_find(breakpoint_map_t map, riscv_word_t addr)
+{
+    map_iter_t it;
+    if (!breakpoint_map_find_it(map, addr, &it))
+        return NULL;
+
+    return (breakpoint_t *) map_iter_value(&it, breakpoint_t *);
+}
+
+bool breakpoint_map_del(breakpoint_map_t map, riscv_word_t addr)
+{
+    map_iter_t it;
+    if (!breakpoint_map_find_it(map, addr, &it))
+        return false;
+
+    map_erase(map, &it);
+    return true;
+}
+
+void breakpoint_map_destroy(breakpoint_map_t map)
+{
+    map_delete(map);
+}

--- a/breakpoint.h
+++ b/breakpoint.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "map.h"
+#include "riscv.h"
+
+typedef struct {
+    riscv_word_t addr;
+    uint32_t orig_insn;
+} breakpoint_t;
+
+typedef map_t breakpoint_map_t;
+
+breakpoint_map_t breakpoint_map_new();
+bool breakpoint_map_insert(breakpoint_map_t map, riscv_word_t addr);
+breakpoint_t *breakpoint_map_find(breakpoint_map_t map, riscv_word_t addr);
+bool breakpoint_map_del(breakpoint_map_t map, riscv_word_t addr);
+void breakpoint_map_destroy(breakpoint_map_t map);

--- a/emulate.c
+++ b/emulate.c
@@ -1688,10 +1688,13 @@ void rv_debug(struct riscv_t *rv)
                       GDBSTUB_COMM)) {
         return;
     }
+    rv->breakpoint_map = breakpoint_map_new();
 
     if (!gdbstub_run(&rv->gdbstub, (void *) rv)) {
         return;
     }
+
+    breakpoint_map_destroy(rv->breakpoint_map);
     gdbstub_close(&rv->gdbstub);
 }
 

--- a/riscv_private.h
+++ b/riscv_private.h
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 
 #ifdef ENABLE_GDBSTUB
+#include "breakpoint.h"
 #include "mini-gdbstub/include/gdbstub.h"
 #endif
 #include "riscv.h"
@@ -146,8 +147,7 @@ struct riscv_t {
     gdbstub_t gdbstub;
 
     /* GDB instruction breakpoint */
-    bool breakpoint_specified;
-    riscv_word_t breakpoint_addr;
+    breakpoint_map_t breakpoint_map;
 #endif
 
 #ifdef ENABLE_RV32F

--- a/tests/gdbstub.sh
+++ b/tests/gdbstub.sh
@@ -7,24 +7,36 @@ PID=$!
 if ps -p $PID > /dev/null
 then
     tmpfile=/tmp/rv32emu-gdbstub.$PID
-    riscv32-unknown-elf-gdb --batch \
-        -ex "file build/puzzle.elf" \
-        -ex "target remote :1234" \
-        -ex "break *0x10700" \
-        -ex "continue" \
-        -ex "print \$pc" \
-        -ex "del 1" \
-        -ex "stepi" \
-        -ex "stepi" \
-        -ex "continue" > ${tmpfile}
+    breakpoint_arr=(0x10700 0x10800 0x10900)
+    GDB_COMMANDS="riscv32-unknown-elf-gdb --batch "
+    GDB_COMMANDS+="-ex 'file build/puzzle.elf' "
+    GDB_COMMANDS+="-ex 'target remote :1234' "
+    for t in ${breakpoint_arr[@]}; do
+        GDB_COMMANDS+="-ex 'break *$t' "
+    done
+    for i in {1..3}; do
+        GDB_COMMANDS+="-ex 'continue' "
+        GDB_COMMANDS+="-ex 'print \$pc' "
+    done
+    for i in {1..3}; do
+        GDB_COMMANDS+="-ex 'del $i' "
+    done
+    GDB_COMMANDS+="-ex 'stepi' "
+    GDB_COMMANDS+="-ex 'stepi' "
+    GDB_COMMANDS+="-ex 'continue' "
+
+    eval ${GDB_COMMANDS} > ${tmpfile}
 
     # check if we stop at the breakpoint
-    expected=$(grep -rw "Breakpoint 1 at" ${tmpfile} | awk {'print $4'})
-    ans=$(grep -r "$1 =" ${tmpfile} | awk {'print $5'})
-    if [ "$expected" != "$ans" ]; then
-        # Fail
-        exit 1
-    fi
+    for i in {1..3}
+    do
+        expected=$(grep -rw "Breakpoint ${i} at" ${tmpfile} | awk {'print $4'})
+        ans=$(grep -r "\$${i} =" ${tmpfile} | awk {'print $5'})
+        if [ "$expected" != "$ans" ]; then
+            # Fail
+            exit 1
+        fi
+    done
     # Pass and wait
     exit 0
     wait $PID


### PR DESCRIPTION
This patch enables `rv32emu` to set more than one breakpoint (should be infinite if we assume our memory is always enough to
create a new tree node).

Note that it's still bad to query the PC address in every instruction step. This patch only aims to fix the limitation of the breakpoint number in a short time. We may make use of the emulator's trap mechanism to avoid frequently querying the RB tree
1. Replace the instruction of the breakpoint's address with a breakpoint instruction
2. Query the RB tree when the emulator hit the trap when executing such instruction