### PR TITLE
Enforce zero register in floating point operation

### DIFF
--- a/emulate.c
+++ b/emulate.c
@@ -1143,6 +1143,10 @@ static inline bool op_fp(struct riscv_t *rv, uint32_t insn)
         return false;
     }
 
+    /* enforce zero register */
+    if (rd == rv_reg_zero)
+        rv->X[rv_reg_zero] = 0;
+
     /* step over instruction */
     rv->PC += 4;
     return true;


### PR DESCRIPTION
Passed 5 more tests in riscv-arch-test:
    fclass_b1-01
    fcvt.wu.s_b23-01
    flt_b19-01
    fmv.x.w_b1-01
    fmv.x.w_b24-01