### PR TITLE
Fix comment format typo in map.h

### DIFF
--- a/src/map.h
+++ b/src/map.h
@@ -30,7 +30,7 @@ static inline int map_cmp_uint(const void *arg0, const void *arg1)
     return (*a < *b) ? _CMP_LESS : (*a > *b) ? _CMP_GREATER : _CMP_EQUAL;
 }
 
-/**
+/*
  * Store the key, data, and values of each element in the tree.
  * This is the main basis of the entire tree aside from the root struct.
  *


### PR DESCRIPTION
Spotted an small format typo in map.h