### PR TITLE
Implement ebreak properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,9 @@ Current progress of this emulator in riscv-arch-test(RV32):
 * Passed Tests
     - `I`: Base Integer Instruction Set
     - `M`: Standard Extension for Integer Multiplication and Division
+    - `C`: Standard Extension for Compressed Instruction
     - `Zifencei`: Instruction-Fetch Fence
 * Failed Tests
-    - `C`: Standard Extension for Compressed Instruction
-        + `cebreak`
     - `privilege`: RISCV Privileged Specification
         + 2 system calls
             * `ebreak`

--- a/src/main.c
+++ b/src/main.c
@@ -186,7 +186,7 @@ int main(int argc, char **args)
 
         /* system */
         .on_ecall = syscall_handler,
-        .on_ebreak = rv_halt,
+        .on_ebreak = ebreak_handler,
     };
 
     state_t *state = state_new();

--- a/src/riscv.h
+++ b/src/riscv.h
@@ -125,6 +125,9 @@ riscv_word_t rv_get_reg(struct riscv_t *, uint32_t reg);
 /* system call handler */
 void syscall_handler(struct riscv_t *rv);
 
+/* breakpoint exception handler */
+void ebreak_handler(struct riscv_t *rv);
+
 /* halt the core */
 void rv_halt(struct riscv_t *);
 


### PR DESCRIPTION
This commit adds the instruction `c.ebreak` into rv32emu.

Input the following command, and the `c.ebreak ` test will pass.
> make arch-test RISCV_DEVICE=C