### PR TITLE
Apply bidirectional queue design to the input system

### DIFF
--- a/src/syscall.c
+++ b/src/syscall.c
@@ -37,7 +37,8 @@
 #if RV32_HAS(SDL)
 #define __SYSCALL_LIST_EXT \
     _(draw_frame, 0xBEEF)  \
-    _(poll_event, 0xC0DE)
+    _(setup_queue, 0xC0DE) \
+    _(submit_queue, 0xFEED)
 #else
 #define __SYSCALL_LIST_EXT
 #endif
@@ -316,7 +317,8 @@ static void syscall_open(struct riscv_t *rv)
 
 #if RV32_HAS(SDL)
 extern void syscall_draw_frame(struct riscv_t *rv);
-extern void syscall_poll_event(struct riscv_t *rv);
+extern void syscall_setup_queue(struct riscv_t *rv);
+extern void syscall_submit_queue(struct riscv_t *rv);
 #endif
 
 void syscall_handler(struct riscv_t *rv)


### PR DESCRIPTION
This commit splits the input system into two parts, event and submission, and introduces two system calls, setup_queue and submit, the former is used to assist in the creation of queues, which is part of the communication bridge between the user application code and the emulator, and the latter is used to notify the emulator that a submission (or a command) should be processed. The design of these system calls is heavily based on Linux io_uring interface.