### PR TITLE
Implement environment call properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,7 @@ Current progress of this emulator in riscv-arch-test(RV32):
     - `M`: Standard Extension for Integer Multiplication and Division
     - `C`: Standard Extension for Compressed Instruction
     - `Zifencei`: Instruction-Fetch Fence
-* Failed Tests
     - `privilege`: RISCV Privileged Specification
-        + 1 system calls
-            * `ecall`
 * Unsupported tests (runnable but incomplete)
     - `F` Standard Extension for Single-Precision Floating-Point
 

--- a/src/main.c
+++ b/src/main.c
@@ -199,7 +199,7 @@ int main(int argc, char **args)
         .mem_write_b = MEMIO(write_b),
 
         /* system */
-        .on_ecall = syscall_handler,
+        .on_ecall = ecall_handler,
         .on_ebreak = ebreak_handler,
     };
 

--- a/src/riscv.h
+++ b/src/riscv.h
@@ -130,6 +130,9 @@ riscv_word_t rv_get_reg(struct riscv_t *, uint32_t reg);
 /* system call handler */
 void syscall_handler(struct riscv_t *rv);
 
+/* environment call handler */
+void ecall_handler(struct riscv_t *rv);
+
 /* breakpoint exception handler */
 void ebreak_handler(struct riscv_t *rv);
 

--- a/src/syscall.c
+++ b/src/syscall.c
@@ -336,7 +336,6 @@ void syscall_handler(struct riscv_t *rv)
 #undef _
     default:
         fprintf(stderr, "unknown syscall %d\n", (int) syscall);
-        rv_halt(rv);
         break;
     }
 }


### PR DESCRIPTION
Implement ecall instruction with control and status registers (CSRs) 
to pass the riscv-arch-test with all privilege tests.

riscv-arch-test result:
```shell
Check ebreak                    ... OK 
Check ecall                     ... OK 
Check misalign1-jalr-01         ... OK 
Check misalign2-jalr-01         ... OK 
Check misalign-beq-01           ... OK 
Check misalign-bge-01           ... OK 
Check misalign-bgeu-01          ... OK 
Check misalign-blt-01           ... OK 
Check misalign-bltu-01          ... OK 
Check misalign-bne-01           ... OK 
Check misalign-jal-01           ... OK 
Check misalign-lh-01            ... OK 
Check misalign-lhu-01           ... OK 
Check misalign-lw-01            ... OK 
Check misalign-sh-01            ... OK 
Check misalign-sw-01            ... OK
```
