### PR TITLE
SDL: Allow window resizing

### DIFF
--- a/docs/syscall.md
+++ b/docs/syscall.md
@@ -98,6 +98,8 @@ These system calls are solely for the convenience of accessing the [SDL library]
 
 If a window does not already exist, one will be created with the specified `width` and `height`. The `screen` buffer will replace the content of the framebuffer, passing a different `width` or `height` compared to the size of the window is undefined behavior. This system call additionally polls events from the SDL library, and, if necessary, update the internal input specific event queue.
 
+The width and height are merely the virutal dimensions of the screen; they are unrelated to the window's real size. The system call would deal with resizing events internally when they occurred.
+
 ### `setup_queue` - Setup input system's dedicated event and submission queue
 
 **system call number**: `0xC0DE`

--- a/src/syscall_sdl.c
+++ b/src/syscall_sdl.c
@@ -141,7 +141,7 @@ static bool check_sdl(struct riscv_t *rv, uint32_t width, uint32_t height)
         }
         window = SDL_CreateWindow("rv32emu", SDL_WINDOWPOS_UNDEFINED,
                                   SDL_WINDOWPOS_UNDEFINED, width, height,
-                                  0 /* flags */);
+                                  SDL_WINDOW_RESIZABLE);
         if (!window) {
             fprintf(stderr, "Window could not be created! SDL_Error: %s\n",
                     SDL_GetError());
@@ -231,7 +231,10 @@ void syscall_draw_frame(struct riscv_t *rv)
     memory_read(s->mem, pixels_ptr, screen, width * height * 4);
     SDL_UnlockTexture(texture);
 
-    SDL_RenderCopy(renderer, texture, NULL, &(SDL_Rect){0, 0, width, height});
+    int actual_width, actual_height;
+    SDL_GetWindowSize(window, &actual_width, &actual_height);
+    SDL_RenderCopy(renderer, texture, NULL,
+                   &(SDL_Rect){0, 0, actual_width, actual_height});
     SDL_RenderPresent(renderer);
 }
 


### PR DESCRIPTION
Support window resizing by automatically updating the saved width/height of the window and rendering with that size without the need of reallocating the internal texture.

Close #73