### PR TITLE
Introduce basic block

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,8 +96,9 @@ all: $(BIN)
 OBJS := \
 	map.o \
 	utils.o \
-	decode.o \
 	emulate.o \
+	decode.o \
+	riscv.o \
 	io.o \
 	elf.o \
 	main.o \

--- a/src/decode.h
+++ b/src/decode.h
@@ -219,7 +219,6 @@ enum {
 /* clang-format on */
 
 enum {
-    INSN_UNKNOWN = 0,
     INSN_16 = 2,
     INSN_32 = 4,
 };
@@ -236,21 +235,36 @@ struct rv_insn_t {
 #if RV32_HAS(EXT_C)
     uint8_t shamt;
 #endif
+
+    /* instruction length */
+    uint8_t insn_len;
 };
 
-/* sign extend a 16 bit value */
-static inline uint32_t sign_extend_h(const uint32_t x)
-{
-    return (int32_t) ((int16_t) x);
-}
+/* translated basic block */
+struct block {
+    /* number of instructions encompased */
+    uint32_t insn_number;
+    /* address range of the basic block */
+    uint32_t pc_start, pc_end;
+    /* maximum of instructions encompased */
+    uint32_t insn_capacity;
+    /* block predictoin */
+    struct block *predict;
+    /* memory blocks */
+    struct rv_insn_t *ir;
+};
 
-/* sign extend an 8 bit value */
-static inline uint32_t sign_extend_b(const uint32_t x)
-{
-    return (int32_t) ((int8_t) x);
-}
+struct block_map {
+    /* max number of entries in the block map */
+    uint32_t block_capacity;
+    /* number of entries currently in the map */
+    uint32_t size;
+    /* block map */
+    struct block **map;
+};
+
+/* clear all block in the block map */
+void block_map_clear(struct block_map *map);
 
 /* decode the RISC-V instruction */
-bool rv_decode(struct rv_insn_t *rv_insn,
-               const uint32_t insn,
-               uint8_t *insn_len);
+bool rv_decode(struct rv_insn_t *ir, const uint32_t insn);

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -1,0 +1,131 @@
+/*
+ * rv32emu is freely redistributable under the MIT License. See the file
+ * "LICENSE" for information on usage and redistribution of this file.
+ */
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "riscv_private.h"
+
+/* initialize the block map */
+static void block_map_init(struct block_map *map, const uint8_t bits)
+{
+    map->block_capacity = 1 << bits;
+    map->size = 0;
+    map->map = calloc(map->block_capacity, sizeof(struct block *));
+}
+
+riscv_user_t rv_userdata(struct riscv_t *rv)
+{
+    assert(rv);
+    return rv->userdata;
+}
+
+bool rv_set_pc(struct riscv_t *rv, riscv_word_t pc)
+{
+    assert(rv);
+#if RV32_HAS(EXT_C)
+    if (pc & 1)
+#else
+    if (pc & 3)
+#endif
+        return false;
+
+    rv->PC = pc;
+    return true;
+}
+
+riscv_word_t rv_get_pc(struct riscv_t *rv)
+{
+    assert(rv);
+    return rv->PC;
+}
+
+void rv_set_reg(struct riscv_t *rv, uint32_t reg, riscv_word_t in)
+{
+    assert(rv);
+    if (reg < RV_NUM_REGS && reg != rv_reg_zero)
+        rv->X[reg] = in;
+}
+
+riscv_word_t rv_get_reg(struct riscv_t *rv, uint32_t reg)
+{
+    assert(rv);
+    if (reg < RV_NUM_REGS)
+        return rv->X[reg];
+
+    return ~0U;
+}
+
+struct riscv_t *rv_create(const struct riscv_io_t *io, riscv_user_t userdata)
+{
+    assert(io);
+
+    struct riscv_t *rv = calloc(1, sizeof(struct riscv_t));
+
+    /* copy over the IO interface */
+    memcpy(&rv->io, io, sizeof(struct riscv_io_t));
+
+    /* copy over the userdata */
+    rv->userdata = userdata;
+
+    /* initialize the block map */
+    block_map_init(&rv->block_map, 10);
+
+    /* reset */
+    rv_reset(rv, 0U);
+
+    return rv;
+}
+
+void rv_halt(struct riscv_t *rv)
+{
+    rv->halt = true;
+}
+
+bool rv_has_halted(struct riscv_t *rv)
+{
+    return rv->halt;
+}
+
+void rv_delete(struct riscv_t *rv)
+{
+    assert(rv);
+    block_map_clear(&rv->block_map);
+    free(rv);
+}
+
+void rv_reset(struct riscv_t *rv, riscv_word_t pc)
+{
+    assert(rv);
+    memset(rv->X, 0, sizeof(uint32_t) * RV_NUM_REGS);
+
+    /* set the reset address */
+    rv->PC = pc;
+
+    /* set the default stack pointer */
+    rv->X[rv_reg_sp] = DEFAULT_STACK_ADDR;
+
+    /* reset the csrs */
+    rv->csr_mtvec = 0;
+    rv->csr_cycle = 0;
+    rv->csr_mstatus = 0;
+
+#if RV32_HAS(EXT_F)
+    /* reset float registers */
+    memset(rv->F, 0, sizeof(float) * RV_NUM_REGS);
+    rv->csr_fcsr = 0;
+#endif
+
+    rv->halt = false;
+}
+
+/* FIXME: provide real implementation */
+void rv_stats(struct riscv_t *rv)
+{
+    printf("CSR cycle count: %" PRIu64 "\n", rv->csr_cycle);
+}

--- a/src/riscv.h
+++ b/src/riscv.h
@@ -111,7 +111,7 @@ struct riscv_io_t {
 struct riscv_t *rv_create(const struct riscv_io_t *io, riscv_user_t user_data);
 
 /* delete a RISC-V emulator */
-void rv_delete(struct riscv_t *);
+void rv_delete(struct riscv_t *rv);
 
 /* reset the RISC-V processor */
 void rv_reset(struct riscv_t *, riscv_word_t pc);

--- a/src/riscv_private.h
+++ b/src/riscv_private.h
@@ -10,6 +10,7 @@
 #include "breakpoint.h"
 #include "mini-gdbstub/include/gdbstub.h"
 #endif
+#include "decode.h"
 #include "riscv.h"
 
 #define RV_NUM_REGS 32
@@ -96,6 +97,20 @@ struct riscv_t {
     uint32_t csr_mip;
     uint32_t csr_mbadaddr;
 
-    /* current instruction length */
-    uint8_t insn_len;
+    /* current instruction is compressed or not */
+    bool compressed;
+    /* basic block map */
+    struct block_map block_map;
 };
+
+/* sign extend a 16 bit value */
+static inline uint32_t sign_extend_h(const uint32_t x)
+{
+    return (int32_t) ((int16_t) x);
+}
+
+/* sign extend an 8 bit value */
+static inline uint32_t sign_extend_b(const uint32_t x)
+{
+    return (int32_t) ((int8_t) x);
+}


### PR DESCRIPTION
This commit introduces the basic block in emulator, meaning that it makes emulator decode and execute numerous instructions at a time.

Complete the first requirement in #88 .

TODO:
1. Implementing an efficient way to look in a hash map for a code block matching the current program counter as wip/jit does;
2. Reducing IR dispatch cost means of computed-goto.
