### PR TITLE
Fix memory leak

### DIFF
--- a/src/elf.c
+++ b/src/elf.c
@@ -138,7 +138,7 @@ elf_t *elf_new()
     e->hdr = NULL;
     e->raw_size = 0;
     e->symbols = map_init(int, char *, map_cmp_uint);
-    e->raw_data = malloc(1);
+    e->raw_data = NULL;
     return e;
 }
 

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -111,6 +111,7 @@ void rv_delete(riscv_t *rv)
 {
     assert(rv);
     block_map_clear(&rv->block_map);
+    free(rv->block_map.map);
     free(rv);
 }
 


### PR DESCRIPTION
Remove the unnecessary memory allocation in elf new and free the block map memory after emuation is complete. These two changes resolve the memory leak and allow the valgrind check to pass.