### PR TITLE
Update mini-gdbstub for the on_interrupt feature

### DIFF
--- a/src/emulate.c
+++ b/src/emulate.c
@@ -236,6 +236,7 @@ void rv_debug(riscv_t *rv)
     }
 
     rv->breakpoint_map = breakpoint_map_new();
+    rv->is_interrupted = false;
 
     if (!gdbstub_run(&rv->gdbstub, (void *) rv))
         return;

--- a/src/riscv_private.h
+++ b/src/riscv_private.h
@@ -89,6 +89,10 @@ struct riscv_internal {
 
     /* GDB instruction breakpoint */
     breakpoint_map_t breakpoint_map;
+
+    /* The flag to notify interrupt from GDB client: it should
+     * be accessed by atomic operation when starting the GDBSTUB. */
+    bool is_interrupted;
 #endif
 
 #if RV32_HAS(EXT_F)


### PR DESCRIPTION
I'm glad to introduce the new feature on the `mini-gdbstub` library. With this update, we can receive the interrupt from the GDB client, thus breaking the original flow of the emulator if needed. When the emulator runs in the `cont` method, it will have a chance to receive an interrupt. Once received, the `on_interrupt` method will be executed concurrently, which set the `is_interrupt` to force to break the loop of the `cont` method.

It's a very useful feature to debug your emulator when it hangs in an unexpected infinite loop without stopping. With the help of GDB and debug information, you can interrupt the emulator and force it to stop,  then look at which line of code it is stuck on or the status of the emulator(e.g. register, memory).