### PR TITLE
Remove the computed-goto option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,21 +55,6 @@ $(OUT)/syscall_sdl.o: CFLAGS += $(shell sdl2-config --cflags)
 LDFLAGS += $(shell sdl2-config --libs)
 endif
 
-# Whether to enable computed goto
-ENABLE_COMPUTED_GOTO ?= 1
-ifeq ($(call has, COMPUTED_GOTO), 1)
-ifeq ("$(CC_IS_CLANG)$(CC_IS_GCC)",)
-$(warning Computed goto is only supported in clang and gcc.)
-override ENABLE_COMPUTED_GOTO := 0
-endif
-endif
-$(call set-feature, COMPUTED_GOTO)
-ifeq ($(call has, COMPUTED_GOTO), 1)
-ifeq ("$(CC_IS_GCC)", "1")
-$(OUT)/emulate.o: CFLAGS += -fno-gcse -fno-crossjumping
-endif
-endif
-
 ENABLE_GDBSTUB ?= 1
 $(call set-feature, GDBSTUB)
 ifeq ($(call has, GDBSTUB), 1)

--- a/src/feature.h
+++ b/src/feature.h
@@ -43,11 +43,6 @@
 #define RV32_FEATURE_SDL 1
 #endif
 
-/* Use computed goto to accelerate the interpreter */
-#ifndef RV32_FEATURE_COMPUTED_GOTO
-#define RV32_FEATURE_COMPUTED_GOTO 1
-#endif
-
 /* GDB remote debugging */
 #ifndef RV32_FEATURE_GDBSTUB
 #define RV32_FEATURE_GDBSTUB 1


### PR DESCRIPTION
Remove the computed-goto option. According to #95, computed-goto has been replaced by tail-call optimization (TCO). Therefore, the option about computed-goto is unnecessary.
