### PR TITLE
Extend basic block without aggressive memory copy

### DIFF
--- a/src/decode.h
+++ b/src/decode.h
@@ -259,6 +259,14 @@ typedef struct rv_insn {
      */
     bool tailcall;
     bool (*impl)(riscv_t *, const struct rv_insn *);
+
+    /* We employ two pointers, branch taken and branch untaken, to avoid the
+     * significant overhead resulting from aggressive memory copy. Instead of
+     * copying the entire IR array, these pointers respectively point to the
+     * first IR of the first basic block in the path of the taken and untaken
+     * branches, so we can jump to the specific IR array directly.
+     */
+    struct rv_insn *branch_taken, *branch_untaken;
 } rv_insn_t;
 
 /* decode the RISC-V instruction */


### PR DESCRIPTION
Due to the significant overhead associated with using aggressive memory copy, we opted to use a pointer to the IR of the basic block we intend to merge, rather than copying the IR to the basic block we wish to extend. 

The performance results obtained from running CoreMark using different implementation strategies for EBB are presented below. As we can see, aggressive memory copy substantially degrades performance.

* Model:  Core i7-8700

|Test| aggressive memcpy|Compiler | Iterations / Sec |Speedup|
|--------| -------- |-------- | -------- |-------- |
| BB  | |clang-15 |  971.951     |       |
| BB  | |gcc-12   |  963.336     |       |
| EBB  |O|clang-15 |  1013.070|+4.2% |
| EBB   |O |gcc-12   |  1020.391    | +6%|
| EBB | X|clang-15 |  1160.894    |+19.4% |
| EBB|X |gcc-12   |  1167.938    | +21.2%|