### PR TITLE
Improve memory read/write

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
       run: |
             make check
             make tests
+            make misalign
     - name: diverse configurations
       run: |
             make distclean ENABLE_EXT_C=0 check

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,15 @@ check: $(BIN)
 	    fi; \
 	)
 
+EXPECTED_aes = Dec 15 2022 16:35:12 Test results AES-128 ECB encryption: PASSED! AES-128 ECB decryption: PASSED! AES-128 CBC encryption: PASSED! AES-128 CBC decryption: PASSED! AES-128 CFB encryption: PASSED! AES-128 CFB decryption: PASSED! AES-128 OFB encryption: PASSED! AES-128 OFB decryption: PASSED! AES-128 CTR encryption: PASSED! AES-128 CTR decryption: PASSED! AES-128 XTS encryption: PASSED! AES-128 XTS decryption: PASSED! AES-128 validate CMAC : PASSED! AES-128 Poly-1305 mac : PASSED! AES-128 GCM encryption: PASSED! AES-128 GCM decryption: PASSED! AES-128 CCM encryption: PASSED! AES-128 CCM decryption: PASSED! AES-128 OCB encryption: PASSED! AES-128 OCB decryption: PASSED! AES-128 SIV encryption: PASSED! AES-128 SIV decryption: PASSED! AES-128 GCMSIV encrypt: PASSED! AES-128 GCMSIV decrypt: PASSED! AES-128 EAX encryption: PASSED! AES-128 EAX decryption: PASSED! AES-128 key wrapping  : PASSED! AES-128 key unwrapping: PASSED! AES-128 FF1 encryption: PASSED! AES-128 FPE decryption: PASSED! +-> Let's do some extra tests AES-128 OCB encryption: PASSED! AES-128 OCB decryption: PASSED! AES-128 GCMSIV encrypt: PASSED! AES-128 GCMSIV decrypt: PASSED! AES-128 GCMSIV encrypt: PASSED! AES-128 GCMSIV decrypt: PASSED! AES-128 SIV encryption: PASSED! AES-128 SIV decryption: PASSED! AES-128 SIV encryption: PASSED! AES-128 SIV decryption: PASSED! AES-128 EAX encryption: PASSED! AES-128 EAX decryption: PASSED! AES-128 EAX encryption: PASSED! AES-128 EAX decryption: PASSED! AES-128 Poly-1305 mac : PASSED! inferior exit code 0
+misalign: $(BIN)
+	$(Q)$(PRINTF) "Running aes.elf ... "; 
+ifeq ($(shell $(BIN) --misalign $(OUT)/aes.elf | uniq), $(EXPECTED_aes))
+	$(Q)$(call notice, [OK]); 
+else
+	$(Q)$(PRINTF) "Failed.\n"; 
+endif
+
 include mk/external.mk
 
 # Non-trivial demonstration programs

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ OBJS := \
 	riscv.o \
 	elf.o \
 	cache.o \
+	mpool.o \
 	$(OBJS_EXT) \
 	main.o
 

--- a/src/io.h
+++ b/src/io.h
@@ -43,4 +43,11 @@ void memory_write(memory_t *m,
                   uint32_t addr,
                   const uint8_t *src,
                   uint32_t size);
+
+void memory_write_w(memory_t *m, uint32_t addr, const uint8_t *src);
+
+void memory_write_s(memory_t *m, uint32_t addr, const uint8_t *src);
+
+void memory_write_b(memory_t *m, uint32_t addr, const uint8_t *src);
+
 void memory_fill(memory_t *m, uint32_t addr, uint32_t size, uint8_t val);

--- a/src/mpool.c
+++ b/src/mpool.c
@@ -1,0 +1,154 @@
+/*
+ * rv32emu is freely redistributable under the MIT License. See the file
+ * "LICENSE" for information on usage and redistribution of this file.
+ */
+#include <stdlib.h>
+#include <string.h>
+#if !defined(_WIN32)
+#define USE_MMAP 1
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
+
+#include "mpool.h"
+
+typedef struct memchunk {
+    struct memchunk *next;
+} memchunk_t;
+
+typedef struct area {
+    char *mapped;
+    struct area *next;
+} area_t;
+
+typedef struct mpool {
+    size_t chunk_count;
+    size_t page_count;
+    size_t chunk_size;
+    struct memchunk *free_chunk_head;
+    area_t area;
+} mpool_t;
+
+static void *mem_arena(size_t sz)
+{
+#if defined(USE_MMAP)
+    void *p =
+        mmap(0, sz, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
+    if (p == MAP_FAILED)
+        return NULL;
+#else
+    void *p = malloc(sz);
+    if (!p)
+        return NULL;
+#endif
+    return p;
+}
+
+mpool_t *mpool_create(size_t pool_size, size_t chunk_size)
+{
+    mpool_t *new_mp = malloc(sizeof(mpool_t));
+    if (!new_mp)
+        return NULL;
+
+    new_mp->area.next = NULL;
+    size_t pgsz = getpagesize();
+    if (pool_size < chunk_size + sizeof(memchunk_t))
+        pool_size += sizeof(memchunk_t);
+    size_t page_count = (pool_size + pgsz - 1) / pgsz;
+    char *p = mem_arena(page_count * pgsz);
+    if (!p) {
+        free(new_mp);
+        return NULL;
+    }
+
+    new_mp->area.mapped = p;
+    new_mp->page_count = page_count;
+    new_mp->chunk_count = pool_size / (sizeof(memchunk_t) + chunk_size);
+    new_mp->chunk_size = chunk_size;
+    new_mp->free_chunk_head = (memchunk_t *) p;
+    memchunk_t *cur = new_mp->free_chunk_head;
+    for (size_t i = 0; i < new_mp->chunk_count - 1; i++) {
+        cur->next =
+            (memchunk_t *) ((char *) cur + (sizeof(memchunk_t) + chunk_size));
+        cur = cur->next;
+    }
+    cur->next = NULL;
+    return new_mp;
+}
+
+static void *mpool_extend(mpool_t *mp)
+{
+    size_t pool_size = mp->page_count * getpagesize();
+    char *p = mem_arena(pool_size);
+    if (!p)
+        return NULL;
+    area_t *new_area = malloc(sizeof(area_t));
+    new_area->mapped = p;
+    new_area->next = NULL;
+    size_t chunk_count = pool_size / (sizeof(memchunk_t) + mp->chunk_size);
+    mp->free_chunk_head = (memchunk_t *) p;
+    memchunk_t *cur = mp->free_chunk_head;
+    for (size_t i = 0; i < chunk_count - 1; i++) {
+        cur->next = (memchunk_t *) ((char *) cur +
+                                    (sizeof(memchunk_t) + mp->chunk_size));
+        cur = cur->next;
+    }
+    mp->chunk_count += chunk_count;
+    /* insert new mapped */
+    area_t *cur_area = &mp->area;
+    while (cur_area->next) {
+        cur_area = cur_area->next;
+    }
+    cur_area->next = new_area;
+    return p;
+}
+
+void *mpool_alloc(mpool_t *mp)
+{
+    if (!mp->chunk_count && !(mpool_extend(mp)))
+        return NULL;
+    char *ptr = (char *) mp->free_chunk_head + sizeof(memchunk_t);
+    mp->free_chunk_head = mp->free_chunk_head->next;
+    mp->chunk_count--;
+    return ptr;
+}
+
+void *mpool_calloc(mpool_t *mp)
+{
+    if (!mp->chunk_count && !(mpool_extend(mp)))
+        return NULL;
+    char *ptr = (char *) mp->free_chunk_head + sizeof(memchunk_t);
+    mp->free_chunk_head = mp->free_chunk_head->next;
+    mp->chunk_count--;
+    memset(ptr, 0, mp->chunk_size);
+    return ptr;
+}
+
+void mpool_free(mpool_t *mp, void *target)
+{
+    memchunk_t *ptr = (memchunk_t *) ((char *) target - sizeof(memchunk_t));
+    ptr->next = mp->free_chunk_head;
+    mp->free_chunk_head = ptr;
+    mp->chunk_count++;
+}
+
+void mpool_destory(mpool_t *mp)
+{
+#if defined(USE_MMAP)
+    size_t mem_size = mp->page_count * getpagesize();
+    area_t *cur = &mp->area, *tmp = NULL;
+    while (cur) {
+        tmp = cur;
+        cur = cur->next;
+        munmap(tmp->mapped, mem_size);
+    }
+#else
+    area_t *cur = &mp->area, *tmp = NULL;
+    while (cur) {
+        tmp = cur;
+        cur = cur->next;
+        free(tmp->mapped);
+    }
+#endif
+    free(mp);
+}

--- a/src/mpool.h
+++ b/src/mpool.h
@@ -1,0 +1,43 @@
+/*
+ * rv32emu is freely redistributable under the MIT License. See the file
+ * "LICENSE" for information on usage and redistribution of this file.
+ */
+#pragma once
+
+#include <stddef.h>
+
+struct mpool;
+
+/**
+ * mpool_create - create a new memory pool
+ * @pool_size: the size of memory pool
+ * @chunk_size: the size of memory chunk, pool would be divided into several
+ * chunks
+ */
+struct mpool *mpool_create(size_t pool_size, size_t chunk_size);
+
+/**
+ * mpool_alloc - allocate a memory chunk from target memory pool
+ * @mp: a pointer points to the target memory pool
+ */
+void *mpool_alloc(struct mpool *mp);
+
+/**
+ * mpool_calloc - allocate a memory chunk from target memory pool
+ * @mp: a pointer points to the target memory pool
+ */
+void *mpool_calloc(struct mpool *mp);
+
+/**
+ * mpool_calloc - allocate a memory chunk from target memory pool and set it to
+ * zero
+ * @mp: a pointer points to target memory pool
+ * @target: a pointer points to the target memory chunk
+ */
+void mpool_free(struct mpool *mp, void *target);
+
+/**
+ * mpool_destory - destory a memory pool
+ * @mp: a pointer points to the target memory pool
+ */
+void mpool_destory(struct mpool *mp);

--- a/src/riscv.h
+++ b/src/riscv.h
@@ -107,6 +107,9 @@ typedef struct {
     /* system */
     riscv_on_ecall on_ecall;
     riscv_on_ebreak on_ebreak;
+
+    /* enable misaligned memory access */
+    bool allow_misalign;
 } riscv_io_t;
 
 /* create a RISC-V emulator */

--- a/src/syscall.c
+++ b/src/syscall.c
@@ -142,8 +142,8 @@ static void syscall_gettimeofday(riscv_t *rv)
     if (tv) {
         struct timeval tv_s;
         rv_gettimeofday(&tv_s);
-        memory_write(s->mem, tv + 0, (const uint8_t *) &tv_s.tv_sec, 4);
-        memory_write(s->mem, tv + 8, (const uint8_t *) &tv_s.tv_usec, 4);
+        memory_write_w(s->mem, tv + 0, (const uint8_t *) &tv_s.tv_sec);
+        memory_write_w(s->mem, tv + 8, (const uint8_t *) &tv_s.tv_usec);
     }
 
     if (tz) {
@@ -176,8 +176,8 @@ static void syscall_clock_gettime(riscv_t *rv)
     if (tp) {
         struct timespec tp_s;
         rv_clock_gettime(&tp_s);
-        memory_write(s->mem, tp + 0, (const uint8_t *) &tp_s.tv_sec, 4);
-        memory_write(s->mem, tp + 8, (const uint8_t *) &tp_s.tv_nsec, 4);
+        memory_write_w(s->mem, tp + 0, (const uint8_t *) &tp_s.tv_sec);
+        memory_write_w(s->mem, tp + 8, (const uint8_t *) &tp_s.tv_nsec);
     }
 
     /* success */

--- a/src/syscall_sdl.c
+++ b/src/syscall_sdl.c
@@ -110,7 +110,7 @@ static void event_push(riscv_t *rv, event_t event)
     uint32_t count;
     memory_read(s->mem, (void *) &count, event_count, sizeof(uint32_t));
     count += 1;
-    memory_write(s->mem, event_count, (void *) &count, sizeof(uint32_t));
+    memory_write_w(s->mem, event_count, (void *) &count);
 }
 
 static inline uint32_t round_pow2(uint32_t x)


### PR DESCRIPTION
After analyzing the data collected during the execution of the Dhrystone benchmark, we found that the primary performance bottleneck lies in memory read/write operations. To address this issue, we modified the implementation of memory read/write by eliminating unnecessary checks and replacing slow operations with more efficient ones. Additionally, we integrated a simple memory pool and resolved the issue of disabled unaligned memory access, the user can add argument `--misalign` to enable misaligned memory access.

After analyzing the performance results from running Dhrystone, we observed a significant improvement following our enhancements to the memory I/O. 

| Test | 66200d0 | improvement | Speedup |
|--------| -------- | -------- |-------- |
| Dhrystone  | 815 DMIPS    |  1245 DMIPS | +52.7% |

See: #122 