### PR TITLE
Fix the implementations of FCVT.S.W and FCVT.S.WU

### DIFF
--- a/src/emulate.c
+++ b/src/emulate.c
@@ -1028,10 +1028,10 @@ RVOP(fclasss, {
 })
 
 /* FCVT.S.W */
-RVOP(fcvtsw, { rv->F_int[ir->rd] = rv->X[ir->rs1]; })
+RVOP(fcvtsw, { rv->F[ir->rd] = (int32_t) rv->X[ir->rs1]; })
 
 /* FCVT.S.WU */
-RVOP(fcvtswu, { rv->F_int[ir->rd] = rv->X[ir->rs1]; })
+RVOP(fcvtswu, { rv->F[ir->rd] = rv->X[ir->rs1]; })
 
 /* FMV.W.X */
 RVOP(fmvwx, { rv->F_int[ir->rd] = rv->X[ir->rs1]; })


### PR DESCRIPTION
The implementations of FCVT.S.W and FCVT.S.WU in the commit 04ce561 are incorrect. In fact, instead of updating the bit representation of the float number directly, a correct implementation should convert the signed/unsigned number to float number while keeping the value of integer numbers. As a result, I use implicit conversion between integer and float at line 1031 and 1034 and assigned the converted value to rv->F rather than rv->F_int, which represent the float number itself and its representation, respectively.