### PR TITLE
Update mini-gdbstub and the corresponding API

### DIFF
--- a/src/state.h
+++ b/src/state.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <stdio.h>
+#include <stdlib.h>
 #include "io.h"
 #include "map.h"
 #include "riscv.h"


### PR DESCRIPTION
It is possible that a GDB user will query an access for invalid register or memory address. In such case, GDBstub should [respond `E NN` (where `NN` is an errno) for the error](https://sourceware.org/gdb/onlinedocs/gdb/Packets.html). However, both the original implementations of  `mini-gdbstub` and `rv32emu` just simply assume that those operations will always succeed, which may lead to some annoying problems. For example, a segmentation fault happens on the emulator when we request to read a memory chunk that our emulator didn't write before yet. For this reason, this patch updates the library `mini-gdbstub` and the implementation of `rv32emu` itself to make debug mode experience on `rv32emu` better.

By the way, it is worth noting that running the command `make gdbstub-test` will have a fail result. But this is not caused by this patch, because it seems to be broken on the main branch for a long time :(. I'll fix this in other patches and maybe we should run `make gdbstub-test` in CICD in the future to make sure it always runs correctly.