### PR TITLE
Consolidate CI/CD test for gdbstub

### DIFF
--- a/.ci/gdbstub-test.sh
+++ b/.ci/gdbstub-test.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+export PATH=`pwd`/toolchain/riscv/bin:$PATH
+
 GDB=
 prefixes=("${CROSS_COMPILE}" "riscv32-unknown-elf" "riscv-none-elf")
 for prefix in "${prefixes[@]}"; do

--- a/.ci/riscv-tests.sh
+++ b/.ci/riscv-tests.sh
@@ -1,23 +1,9 @@
 #!/usr/bin/env bash
 
-. .ci/common.sh
-
-check_platform
-
-mkdir -p toolchain
-
-# GNU Toolchain for RISC-V
-GCC_VER=2023.01.04
-TOOLCHAIN_REPO=https://github.com/riscv-collab/riscv-gnu-toolchain/releases
-
 # Install RISCOF
 python3 -m pip install git+https://github.com/riscv/riscof
 
 set -x
-
-wget -q \
-    ${TOOLCHAIN_REPO}/download/${GCC_VER}/riscv32-elf-ubuntu-22.04-nightly-${GCC_VER}-nightly.tar.gz -O- \
-| tar -C toolchain -xz
 
 export PATH=`pwd`/toolchain/riscv/bin:$PATH
 

--- a/.ci/riscv-toolchain-install.sh
+++ b/.ci/riscv-toolchain-install.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+. .ci/common.sh
+
+check_platform
+
+mkdir -p toolchain
+
+# GNU Toolchain for RISC-V
+GCC_VER=2023.01.04
+TOOLCHAIN_REPO=https://github.com/riscv-collab/riscv-gnu-toolchain/releases
+
+wget -q \
+    ${TOOLCHAIN_REPO}/download/${GCC_VER}/riscv32-elf-ubuntu-22.04-nightly-${GCC_VER}-nightly.tar.gz -O- \
+| tar -C toolchain -xz

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,9 +8,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3.4.0
     - name: install-dependencies
-      run: | 
+      run: |
             sudo apt-get update
             sudo apt-get install libsdl2-dev
+            sh .ci/riscv-toolchain-install.sh
+      shell: bash
     - name: default build
       run: make
     - name: check + tests
@@ -30,6 +32,9 @@ jobs:
       run: |
             sh .ci/riscv-tests.sh
       shell: bash
+    - name: gdbstub test
+      run: |
+            make gdbstub-test
 
   coding_style:
     runs-on: ubuntu-22.04

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ OBJS_EXT += gdbstub.o breakpoint.o
 CFLAGS += -D'GDBSTUB_COMM="$(GDBSTUB_COMM)"'
 LDFLAGS += $(GDBSTUB_LIB) -lpthread
 gdbstub-test: $(BIN)
-	$(Q)tests/gdbstub.sh && $(call notice, [OK])
+	$(Q).ci/gdbstub-test.sh && $(call notice, [OK])
 endif
 
 # For tail-call elimination, we need a specific set of build flags applied.

--- a/src/riscv_private.h
+++ b/src/riscv_private.h
@@ -87,6 +87,8 @@ struct riscv_internal {
     /* gdbstub instance */
     gdbstub_t gdbstub;
 
+    bool debug_mode;
+
     /* GDB instruction breakpoint */
     breakpoint_map_t breakpoint_map;
 


### PR DESCRIPTION
We can't get expected result when running `make gdbstub-test` under the old version of  `rv32emu`. That's because the implementation of `rv_step` changed from returning after stepping single instruction to returning after a block execution. To solve the issue, I simply take gdbstub mode as a special case for  `rv_step`, which will return directly after executing one instruction, so we can check whether the breakpoint hit after every return.

After the changed, we can add the test of gdbstub mode in CICD now. The workflow of CICD is also changed a little bit since we'll need `riscv32-gdb` for the test on gdbstub.