### PR TITLE
Improve red-black tree performance

### DIFF
--- a/src/map.c
+++ b/src/map.c
@@ -1,12 +1,540 @@
-#include "map.h"
+/*
+ * rv32emu is freely redistributable under the MIT License. See the file
+ * "LICENSE" for information on usage and redistribution of this file.
+ */
+
+/* clang-format off */
+
+/*
+ * This map implementation has undergone extensive modifications, heavily
+ * relying on the rb.h header file from jemalloc.
+ * See https://github.com/jemalloc/jemalloc/blob/dev/include/jemalloc/internal/rb.h .
+ * The original rb.h file served as the foundation and source of inspiration
+ * for adapting and tailoring it specifically for this map implementation.
+ * Therefore, credit and sincere thanks are extended to jemalloc for their
+ * invaluable work.
+ */
+
+/* clang-format on */
+
+#include <assert.h>
 #include <memory.h>
 
-static map_node *map_create_node(void *key,
-                                 void *value,
-                                 size_t ksize,
-                                 size_t vsize)
+#include "map.h"
+
+/*
+ * Each node in the red-black tree consumes at least 1 byte of space (for the
+ * linkage if nothing else, so there are a maximum of sizeof(void *) << 3 rb
+ * tree nodes in any process (and thus, at most sizeof(void *) << 3 nodes in any
+ * rb tree). The choice of algorithm bounds the depth of a tree to twice the
+ * binary log of the number of elements in the tree; the following bound
+ * follows.
+ */
+#define RB_MAX_DEPTH (sizeof(void *) << 4)
+
+/* Left accessors */
+static inline map_node_t *rbnode_get_left(map_node_t *node)
 {
-    map_node *node = malloc(sizeof(map_node));
+    return node->link.left;
+}
+
+static inline void rbnode_set_left(map_node_t *node, map_node_t *left)
+{
+    node->link.left = left;
+}
+
+/* Right accessors */
+static inline map_node_t *rbnode_get_right(map_node_t *node)
+{
+    return (map_node_t *) (((uintptr_t) node->link.right_red) & ~3);
+}
+
+static inline void rbnode_set_right(map_node_t *node, map_node_t *right)
+{
+    node->link.right_red =
+        (map_node_t *) (((uintptr_t) right) |
+                        (((uintptr_t) node->link.right_red) & 1));
+}
+
+/* Color accessors */
+static inline map_color_t rbnode_get_color(const map_node_t *node)
+{
+    return (map_color_t) (((uintptr_t) node->link.right_red) & 1);
+}
+
+static inline void rbnode_set_color(map_node_t *node, map_color_t color)
+{
+    node->link.right_red =
+        (map_node_t *) (((uintptr_t) node->link.right_red & ~3) |
+                        (uintptr_t) color);
+}
+
+static inline void rbnode_set_red(map_node_t *node)
+{
+    node->link.right_red =
+        (map_node_t *) (((uintptr_t) node->link.right_red) | 1);
+}
+
+static inline void rbnode_set_black(map_node_t *node)
+{
+    node->link.right_red =
+        (map_node_t *) (((uintptr_t) node->link.right_red) & ~3);
+}
+
+/* Node initializer */
+static inline void rbnode_init(map_node_t *node)
+{
+    assert((((uintptr_t) node) & (0x1)) == RB_BLACK);
+    rbnode_set_left(node, NULL);
+    rbnode_set_right(node, NULL);
+    rbnode_set_red(node);
+}
+
+/* Internal utility macros */
+#define rbnode_rotate_left(x_type, x_field, x_node, r_node)    \
+    do {                                                       \
+        (r_node) = rbnode_get_right((x_node));                 \
+        rbnode_set_right((x_node), rbnode_get_left((r_node))); \
+        rbnode_set_left((r_node), (x_node));                   \
+    } while (0)
+
+#define rbnode_rotate_right(x_type, x_field, x_node, r_node)   \
+    do {                                                       \
+        (r_node) = rbnode_get_left((x_node));                  \
+        rbnode_set_left((x_node), rbnode_get_right((r_node))); \
+        rbnode_set_right((r_node), (x_node));                  \
+    } while (0)
+
+typedef struct {
+    map_node_t *node;
+    int cmp;
+} rb_path_entry_t;
+
+static map_node_t *rb_search(map_t rbtree, const map_node_t *keynode)
+{
+    int cmp;
+    map_node_t *ret = rbtree->root;
+    while (ret && (cmp = (rbtree->cmp)(keynode->key, ret->key)) != 0) {
+        if (cmp < 0) {
+            ret = rbnode_get_left(ret);
+        } else {
+            ret = rbnode_get_right(ret);
+        }
+    }
+    return ret;
+}
+
+static void rb_insert(map_t rbtree, map_node_t *node)
+{
+    rb_path_entry_t path[RB_MAX_DEPTH];
+    rb_path_entry_t *pathp;
+    rbnode_init(node);
+    /* Wind. */
+    path->node = rbtree->root;
+    for (pathp = path; pathp->node; pathp++) {
+        int cmp = pathp->cmp = (rbtree->cmp)(node->key, pathp->node->key);
+        if (cmp == 0) {
+            break; /* If the key matches something, don't insert */
+        }
+        if (cmp < 0) {
+            pathp[1].node = rbnode_get_left(pathp->node);
+        } else {
+            pathp[1].node = rbnode_get_right(pathp->node);
+        }
+    }
+    pathp->node = node;
+    /* A loop invariant we maintain is that all nodes with
+     * out-of-date summaries live in path[0], path[1], ..., *pathp.
+     * To maintain this, we have to summarize node, since we
+     * decrement pathp before the first iteration.
+     */
+    assert(!rbnode_get_left(node));
+    assert(!rbnode_get_right(node));
+    /* Unwind. */
+    for (pathp--; (uintptr_t) pathp >= (uintptr_t) path; pathp--) {
+        map_node_t *cnode = pathp->node;
+        if (pathp->cmp < 0) {
+            map_node_t *left = pathp[1].node;
+            rbnode_set_left(cnode, left);
+            if (rbnode_get_color(left) == RB_BLACK)
+                return;
+            map_node_t *leftleft = rbnode_get_left(left);
+            if (leftleft && (rbnode_get_color(leftleft) == RB_RED)) {
+                /* Fix up 4-node. */
+                map_node_t *tnode;
+                rbnode_set_black(leftleft);
+                rbnode_rotate_right(map_node_t, link, cnode, tnode);
+                cnode = tnode;
+            }
+        } else {
+            map_node_t *right = pathp[1].node;
+            rbnode_set_right(cnode, right);
+            if (rbnode_get_color(right) == RB_BLACK)
+                return;
+            map_node_t *left = rbnode_get_left(cnode);
+            if (left && (rbnode_get_color(left) == RB_RED)) {
+                /* Split 4-node. */
+                rbnode_set_black(left);
+                rbnode_set_black(right);
+                rbnode_set_red(cnode);
+            } else {
+                /* Lean left. */
+                map_node_t *tnode;
+                map_color_t tcolor = rbnode_get_color(cnode);
+                rbnode_rotate_left(map_node_t, link, cnode, tnode);
+                rbnode_set_color(tnode, tcolor);
+                rbnode_set_red(cnode);
+                cnode = tnode;
+            }
+        }
+        pathp->node = cnode;
+    }
+    /* Set root, and make it black. */
+    rbtree->root = path->node;
+    rbnode_set_black(rbtree->root);
+}
+
+static void rb_remove(map_t rbtree, map_node_t *node)
+{
+    rb_path_entry_t path[RB_MAX_DEPTH];
+    rb_path_entry_t *pathp = NULL;
+    rb_path_entry_t *nodep = NULL;
+    /* Wind. */
+    path->node = rbtree->root;
+    for (pathp = path; pathp->node; pathp++) {
+        int cmp = pathp->cmp = (rbtree->cmp)(node->val, pathp->node->val);
+        if (cmp < 0) {
+            pathp[1].node = rbnode_get_left(pathp->node);
+        } else {
+            pathp[1].node = rbnode_get_right(pathp->node);
+            if (cmp == 0) {
+                /* Find node's successor, in preparation for swap. */
+                pathp->cmp = 1;
+                nodep = pathp;
+                for (pathp++; pathp->node; pathp++) {
+                    pathp->cmp = -1;
+                    pathp[1].node = rbnode_get_left(pathp->node);
+                }
+                break;
+            }
+        }
+    }
+    assert(nodep->node == node);
+    pathp--;
+    if (pathp->node != node) {
+        /* Swap node with its successor. */
+        map_color_t tcolor = rbnode_get_color(pathp->node);
+        rbnode_set_color(pathp->node, rbnode_get_color(node));
+        rbnode_set_left(pathp->node, rbnode_get_left(node));
+        /* If node's successor is its right child, the following code
+         * will do the wrong thing for the right child pointer.
+         * However, it doesn't matter, because the pointer will be
+         * properly set when the successor is pruned.
+         */
+        rbnode_set_right(pathp->node, rbnode_get_right(node));
+        rbnode_set_color(node, tcolor);
+        /* The pruned leaf node's child pointers are never accessed
+         * again, so don't bother setting them to nil.
+         */
+        nodep->node = pathp->node;
+        pathp->node = node;
+        if (nodep == path) {
+            rbtree->root = nodep->node;
+        } else {
+            if (nodep[-1].cmp < 0) {
+                rbnode_set_left(nodep[-1].node, nodep->node);
+            } else {
+                rbnode_set_right(nodep[-1].node, nodep->node);
+            }
+        }
+    } else {
+        map_node_t *left = rbnode_get_left(node);
+        if (left) {
+            /* node has no successor, but it has a left child.
+             * Splice node out, without losing the left child.
+             */
+            assert(rbnode_get_color(node) == RB_BLACK);
+            assert(rbnode_get_color(left) == RB_RED);
+            rbnode_set_black(left);
+            if (pathp == path) {
+                rbtree->root = left;
+                /* Nothing to summarize -- the subtree rooted at the
+                 * node's left child hasn't changed, and it's now the
+                 * root.
+                 */
+            } else {
+                if (pathp[-1].cmp < 0) {
+                    rbnode_set_left(pathp[-1].node, left);
+                } else {
+                    rbnode_set_right(pathp[-1].node, left);
+                }
+            }
+            return;
+        } else if (pathp == path) {
+            /* The tree only contained one node. */
+            rbtree->root = NULL;
+            return;
+        }
+    }
+    /* We've now established the invariant that the node has no right
+     * child (well, morally; we didn't bother nulling it out if we
+     * swapped it with its successor), and that the only nodes with
+     * out-of-date summaries live in path[0], path[1], ..., pathp[-1].
+     */
+    if (rbnode_get_color(pathp->node) == RB_RED) {
+        /* Prune red node, which requires no fixup. */
+        assert(pathp[-1].cmp < 0);
+        rbnode_set_left(pathp[-1].node, NULL);
+        return;
+    }
+    /* The node to be pruned is black, so unwind until balance is
+     * restored.
+     */
+    pathp->node = NULL;
+    for (pathp--; (uintptr_t) pathp >= (uintptr_t) path; pathp--) {
+        assert(pathp->cmp != 0);
+        if (pathp->cmp < 0) {
+            rbnode_set_left(pathp->node, pathp[1].node);
+            if (rbnode_get_color(pathp->node) == RB_RED) {
+                map_node_t *right = rbnode_get_right(pathp->node);
+                map_node_t *rightleft = rbnode_get_left(right);
+                map_node_t *tnode;
+                if (rightleft && (rbnode_get_color(rightleft) == RB_RED)) {
+                    /* In the following diagrams, ||, //, and \\
+                     * indicate the path to the removed node.
+                     *
+                     *      ||
+                     *    pathp(r)
+                     *  //        \
+                     * (b)        (b)
+                     *           /
+                     *          (r)
+                     *
+                     */
+                    rbnode_set_black(pathp->node);
+                    rbnode_rotate_right(map_node_t, link, right, tnode);
+                    rbnode_set_right(pathp->node, tnode);
+                    rbnode_rotate_left(map_node_t, link, pathp->node, tnode);
+                } else {
+                    /*      ||
+                     *    pathp(r)
+                     *  //        \
+                     * (b)        (b)
+                     *           /
+                     *          (b)
+                     *
+                     */
+                    rbnode_rotate_left(map_node_t, link, pathp->node, tnode);
+                }
+                /* Balance restored, but rotation modified subtree
+                 * root.
+                 */
+                assert((uintptr_t) pathp > (uintptr_t) path);
+                if (pathp[-1].cmp < 0) {
+                    rbnode_set_left(pathp[-1].node, tnode);
+                } else {
+                    rbnode_set_right(pathp[-1].node, tnode);
+                }
+                return;
+            } else {
+                map_node_t *right = rbnode_get_right(pathp->node);
+                map_node_t *rightleft = rbnode_get_left(right);
+                if (rightleft && (rbnode_get_color(rightleft) == RB_RED)) {
+                    /*      ||
+                     *    pathp(b)
+                     *  //        \
+                     * (b)        (b)
+                     *           /
+                     *          (r)
+                     */
+                    map_node_t *tnode;
+                    rbnode_set_black(rightleft);
+                    rbnode_rotate_right(map_node_t, link, right, tnode);
+                    rbnode_set_right(pathp->node, tnode);
+                    rbnode_rotate_left(map_node_t, link, pathp->node, tnode);
+                    /* Balance restored, but rotation modified
+                     * subtree root, which may actually be the tree
+                     * root.
+                     */
+                    if (pathp == path) {
+                        /* Set root. */
+                        rbtree->root = tnode;
+                    } else {
+                        if (pathp[-1].cmp < 0) {
+                            rbnode_set_left(pathp[-1].node, tnode);
+                        } else {
+                            rbnode_set_right(pathp[-1].node, tnode);
+                        }
+                    }
+                    return;
+                } else {
+                    /*      ||
+                     *    pathp(b)
+                     *  //        \
+                     * (b)        (b)
+                     *           /
+                     *          (b)
+                     */
+                    map_node_t *tnode;
+                    rbnode_set_red(pathp->node);
+                    rbnode_rotate_left(map_node_t, link, pathp->node, tnode);
+                    pathp->node = tnode;
+                }
+            }
+        } else {
+            map_node_t *left;
+            rbnode_set_right(pathp->node, pathp[1].node);
+            left = rbnode_get_left(pathp->node);
+            if (rbnode_get_color(left) == RB_RED) {
+                map_node_t *tnode;
+                map_node_t *leftright = rbnode_get_right(left);
+                map_node_t *leftrightleft = rbnode_get_left(leftright);
+                if (leftrightleft &&
+                    (rbnode_get_color(leftrightleft) == RB_RED)) {
+                    /*      ||
+                     *    pathp(b)
+                     *   /        \\
+                     * (r)        (b)
+                     *   \
+                     *   (b)
+                     *   /
+                     * (r)
+                     */
+                    map_node_t *unode;
+                    rbnode_set_black(leftrightleft);
+                    rbnode_rotate_right(map_node_t, link, pathp->node, unode);
+                    rbnode_rotate_right(map_node_t, link, pathp->node, tnode);
+                    rbnode_set_right(unode, tnode);
+                    rbnode_rotate_left(map_node_t, link, unode, tnode);
+                } else {
+                    /*      ||
+                     *    pathp(b)
+                     *   /        \\
+                     * (r)        (b)
+                     *   \
+                     *   (b)
+                     *   /
+                     * (b)
+                     */
+                    assert(leftright);
+                    rbnode_set_red(leftright);
+                    rbnode_rotate_right(map_node_t, link, pathp->node, tnode);
+                    rbnode_set_black(tnode);
+                }
+                /* Balance restored, but rotation modified subtree
+                 * root, which may actually be the tree root.
+                 */
+                if (pathp == path) {
+                    /* Set root. */
+                    rbtree->root = tnode;
+                } else {
+                    if (pathp[-1].cmp < 0) {
+                        rbnode_set_left(pathp[-1].node, tnode);
+                    } else {
+                        rbnode_set_right(pathp[-1].node, tnode);
+                    }
+                }
+                return;
+            } else if (rbnode_get_color(pathp->node) == RB_RED) {
+                map_node_t *leftleft = rbnode_get_left(left);
+                if (leftleft && (rbnode_get_color(leftleft) == RB_RED)) {
+                    /*        ||
+                     *      pathp(r)
+                     *     /        \\
+                     *   (b)        (b)
+                     *   /
+                     * (r)
+                     */
+                    map_node_t *tnode;
+                    rbnode_set_black(pathp->node);
+                    rbnode_set_red(left);
+                    rbnode_set_black(leftleft);
+                    rbnode_rotate_right(map_node_t, link, pathp->node, tnode);
+                    /* Balance restored, but rotation modified
+                     * subtree root.
+                     */
+                    assert((uintptr_t) pathp > (uintptr_t) path);
+                    if (pathp[-1].cmp < 0) {
+                        rbnode_set_left(pathp[-1].node, tnode);
+                    } else {
+                        rbnode_set_right(pathp[-1].node, tnode);
+                    }
+                    return;
+                } else {
+                    /*        ||
+                     *      pathp(r)
+                     *     /        \\
+                     *   (b)        (b)
+                     *   /
+                     * (b)
+                     */
+                    rbnode_set_red(left);
+                    rbnode_set_black(pathp->node);
+                    /* Balance restored. */
+                    return;
+                }
+            } else {
+                map_node_t *leftleft = rbnode_get_left(left);
+                if (leftleft && (rbnode_get_color(leftleft) == RB_RED)) {
+                    /*               ||
+                     *             pathp(b)
+                     *            /        \\
+                     *          (b)        (b)
+                     *          /
+                     *        (r)
+                     */
+                    map_node_t *tnode;
+                    rbnode_set_black(leftleft);
+                    rbnode_rotate_right(map_node_t, link, pathp->node, tnode);
+                    /* Balance restored, but rotation modified        */
+                    /* subtree root, which may actually be the tree   */
+                    /* root.                                          */
+                    if (pathp == path) {
+                        /* Set root. */
+                        rbtree->root = tnode;
+                    } else {
+                        if (pathp[-1].cmp < 0) {
+                            rbnode_set_left(pathp[-1].node, tnode);
+                        } else {
+                            rbnode_set_right(pathp[-1].node, tnode);
+                        }
+                    }
+                    return;
+                } else {
+                    /*               ||
+                     *             pathp(b)
+                     *            /        \\
+                     *          (b)        (b)
+                     *          /
+                     *        (b)
+                     */
+                    rbnode_set_red(left);
+                }
+            }
+        }
+    }
+    /* Set root. */
+    rbtree->root = path->node;
+    assert(rbnode_get_color(rbtree->root) == RB_BLACK);
+}
+
+static void rb_destroy_recurse(map_t rbtree, map_node_t *node)
+{
+    if (!node)
+        return;
+    rb_destroy_recurse(rbtree, rbnode_get_left(node));
+    rbnode_set_left((node), NULL);
+    rb_destroy_recurse(rbtree, rbnode_get_right(node));
+    rbnode_set_right((node), NULL);
+    free(node);
+}
+
+static map_node_t *map_create_node(void *key,
+                                   void *value,
+                                   size_t ksize,
+                                   size_t vsize)
+{
+    map_node_t *node = malloc(sizeof(map_node_t));
 
     /* Allocate memory for the keys and values */
     node->key = malloc(ksize);
@@ -31,7 +559,7 @@ static map_node *map_create_node(void *key,
     return node;
 }
 
-static void map_delete_node(map_t UNUSED, map_node *node)
+static void map_delete_node(map_t UNUSED, map_node_t *node)
 {
     free(node->key);
     free(node->val);
@@ -39,59 +567,56 @@ static void map_delete_node(map_t UNUSED, map_node *node)
 }
 
 /* Constructor */
-map_t map_new(size_t s1,
-              size_t s2,
-              int (*cmp)(const map_node *, const map_node *))
+map_t map_new(size_t s1, size_t s2, int (*cmp)(const void *, const void *))
 {
-    map_t tree = (map_internal_t *) malloc(sizeof(map_internal_t));
+    map_t tree = (map_t) malloc(sizeof(map_head_t));
     tree->key_size = s1;
     tree->val_size = s2;
-    internal_map_new(tree);
+    tree->cmp = cmp;
+    tree->root = NULL;
     return tree;
 }
 
 /* Add function */
 bool map_insert(map_t obj, void *key, void *val)
 {
-    map_node *node = map_create_node(key, val, obj->key_size, obj->val_size);
-    internal_map_insert(obj, node);
+    map_node_t *node = map_create_node(key, val, obj->key_size, obj->val_size);
+    rb_insert(obj, node);
     return true;
 }
 
 /* Get functions */
 void map_find(map_t obj, map_iter_t *it, void *key)
 {
-    map_node *tmp_node = (map_node *) malloc(sizeof(map_node));
-    tmp_node->key = key;
-    it->node = internal_map_search(obj, tmp_node);
-    free(tmp_node);
+    map_node_t tmp_node = {.key = key};
+    it->node = rb_search(obj, &tmp_node);
 }
 
 bool map_empty(map_t obj)
 {
-    return (NULL == obj->root);
+    return !obj->root;
 }
 
 /* Iteration */
 bool map_at_end(map_t UNUSED, map_iter_t *it)
 {
-    return (NULL == it->node);
+    return !it->node;
 }
 
 /* Remove functions */
 void map_erase(map_t obj, map_iter_t *it)
 {
-    if (NULL == it->node)
+    if (!it->node)
         return;
-    internal_map_remove(obj, it->node);
+    rb_remove(obj, it->node);
     map_delete_node(obj, it->node);
 }
 
 /* Empty map */
 void map_clear(map_t obj)
 {
-    internal_map_destroy(obj, cb, NULL);
-    // FIXME: Not freeing all nodes
+    rb_destroy_recurse(obj, obj->root);
+    obj->root = NULL;
 }
 
 /* Destructor */

--- a/src/map.c
+++ b/src/map.c
@@ -1,111 +1,16 @@
-/*
- * rv32emu is freely redistributable under the MIT License. See the file
- * "LICENSE" for information on usage and redistribution of this file.
- */
-
-#include <assert.h>
-#include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
-
 #include "map.h"
+#include <memory.h>
 
-struct map_internal {
-    struct map_node *head;
-
-    /* Properties */
-    size_t key_size, element_size, size;
-
-    map_iter_t it_end, it_most, it_least;
-
-    int (*comparator)(const void *, const void *);
-};
-
-typedef enum { RB_RED = 0, RB_BLACK } map_color_t;
-
-/*
- * Get parent of node
- * @node: pointer to the rb node
- *
- * Return: rb parent node of @node
- */
-static inline map_node_t *rb_parent(const map_node_t *node)
+static map_node *map_create_node(void *key,
+                                 void *value,
+                                 size_t ksize,
+                                 size_t vsize)
 {
-    return (map_node_t *) (node->parent_color & ~1LU);
-}
-
-/*
- * Get color of node
- * @node: pointer to the rb node
- *
- * Return: color of @node
- */
-static inline map_color_t rb_color(const map_node_t *node)
-{
-    return (map_color_t) (node->parent_color & 1LU);
-}
-
-/*
- * Set parent of node
- * @node: pointer to the rb node
- * @parent: pointer to the new parent node
- */
-static inline void rb_set_parent(map_node_t *node, map_node_t *parent)
-{
-    node->parent_color = (unsigned long) parent | (node->parent_color & 1LU);
-}
-
-/*
- * Set color of node
- * @node: pointer to the rb node
- * @color: new color of the node
- */
-static inline void rb_set_color(map_node_t *node, map_color_t color)
-{
-    node->parent_color = (node->parent_color & ~1LU) | color;
-}
-
-/*
- * Set parent and color of node
- * @node: pointer to the rb node
- * @parent: pointer to the new parent node
- * @color: new color of the node
- */
-static inline void rb_set_parent_color(map_node_t *node,
-                                       map_node_t *parent,
-                                       map_color_t color)
-{
-    node->parent_color = (unsigned long) parent | color;
-}
-
-/*
- * Check if node is red
- * @node: Node to check
- *
- * Return: false when @node is NULL or not red, true if @node is red
- */
-static inline bool rb_is_red(map_node_t *node)
-{
-    return node && (rb_color(node) == RB_RED);
-}
-
-/* Create a node to be attached in the map internal tree structure */
-static map_node_t *map_create_node(void *key,
-                                   void *value,
-                                   size_t ksize,
-                                   size_t vsize)
-{
-    map_node_t *node = malloc(sizeof(struct map_node));
+    map_node *node = malloc(sizeof(map_node));
 
     /* Allocate memory for the keys and values */
     node->key = malloc(ksize);
-    node->data = malloc(vsize);
-
-    /* Setup the pointers */
-    node->left = node->right = NULL;
-
-    /* Set the color to read by default */
-    rb_set_parent_color(node, NULL, RB_RED);
+    node->val = malloc(vsize);
 
     /*
      * Copy over the key and values
@@ -119,636 +24,79 @@ static map_node_t *map_create_node(void *key,
         memcpy(node->key, key, ksize);
 
     if (!value)
-        memset(node->data, 0, vsize);
+        memset(node->val, 0, vsize);
     else
-        memcpy(node->data, value, vsize);
+        memcpy(node->val, value, vsize);
 
     return node;
 }
 
-static void map_delete_node(map_t obj UNUSED, map_node_t *node)
+static void map_delete_node(map_t UNUSED, map_node *node)
 {
     free(node->key);
-    free(node->data);
+    free(node->val);
     free(node);
 }
 
-/*
- * Perform left rotation with "node". The following happens (with respect
- * to "C"):
- *
- *         B                C
- *        / \              / \
- *       A   C     =>     B   D
- *            \          /
- *             D        A
- *
- * Returns the new node pointing in the spot of the original node.
- */
-static map_node_t *map_rotate_left(map_t obj, map_node_t *node)
+/* Constructor */
+map_t map_new(size_t s1,
+              size_t s2,
+              int (*cmp)(const map_node *, const map_node *))
 {
-    map_node_t *r = node->right, *rl = r->left, *parent = rb_parent(node);
-
-    /* Adjust */
-    rb_set_parent(r, parent);
-    r->left = node;
-
-    node->right = rl;
-    rb_set_parent(node, r);
-
-    if (node->right)
-        rb_set_parent(node->right, node);
-
-    if (parent) {
-        if (parent->right == node)
-            parent->right = r;
-        else
-            parent->left = r;
-    }
-
-    if (node == obj->head)
-        obj->head = r;
-
-    return r;
+    map_t tree = (map_internal_t *) malloc(sizeof(map_internal_t));
+    tree->key_size = s1;
+    tree->val_size = s2;
+    internal_map_new(tree);
+    return tree;
 }
 
-/*
- * Perform a right rotation with "node". The following happens (with respect
- * to "C"):
- *
- *         C                B
- *        / \              / \
- *       B   D     =>     A   C
- *      /                      \
- *     A                        D
- *
- * Return the new node pointing in the spot of the original node.
- */
-static map_node_t *map_rotate_right(map_t obj, map_node_t *node)
+/* Add function */
+bool map_insert(map_t obj, void *key, void *val)
 {
-    map_node_t *l = node->left, *lr = l->right, *parent = rb_parent(node);
-
-    /* Adjust */
-    rb_set_parent(l, parent);
-    l->right = node;
-
-    node->left = lr;
-    rb_set_parent(node, l);
-
-    if (node->left)
-        rb_set_parent(node->left, node);
-
-    if (parent) {
-        if (parent->right == node)
-            parent->right = l;
-        else
-            parent->left = l;
-    }
-
-    if (node == obj->head)
-        obj->head = l;
-
-    return l;
-}
-
-static void map_l_l(map_t obj,
-                    map_node_t *node UNUSED,
-                    map_node_t *parent UNUSED,
-                    map_node_t *grandparent,
-                    map_node_t *uncle UNUSED)
-{
-    /* Rotate to the right according to grandparent */
-    grandparent = map_rotate_right(obj, grandparent);
-
-    /* Swap grandparent and uncle's colors */
-    map_color_t c1 = rb_color(grandparent), c2 = rb_color(grandparent->right);
-
-    rb_set_color(grandparent, c2);
-    rb_set_color(grandparent->right, c1);
-}
-
-static void map_l_r(map_t obj,
-                    map_node_t *node,
-                    map_node_t *parent,
-                    map_node_t *grandparent,
-                    map_node_t *uncle)
-{
-    /* Rotate to the left according to parent */
-    parent = map_rotate_left(obj, parent);
-
-    /* Refigure out the identity */
-    node = parent->left;
-    grandparent = rb_parent(parent);
-    uncle =
-        (grandparent->left == parent) ? grandparent->right : grandparent->left;
-
-    /* Apply left-left case */
-    map_l_l(obj, node, parent, grandparent, uncle);
-}
-
-static void map_r_r(map_t obj,
-                    map_node_t *node UNUSED,
-                    map_node_t *parent UNUSED,
-                    map_node_t *grandparent,
-                    map_node_t *uncle UNUSED)
-{
-    /* Rotate to the left according to grandparent */
-    grandparent = map_rotate_left(obj, grandparent);
-
-    /* Swap grandparent and uncle's colors */
-    map_color_t c1 = rb_color(grandparent), c2 = rb_color(grandparent->left);
-
-    rb_set_color(grandparent, c2);
-    rb_set_color(grandparent->left, c1);
-}
-
-static void map_r_l(map_t obj,
-                    map_node_t *node,
-                    map_node_t *parent,
-                    map_node_t *grandparent,
-                    map_node_t *uncle)
-{
-    /* Rotate to the right according to parent */
-    parent = map_rotate_right(obj, parent);
-
-    /* Refigure out the identity */
-    node = parent->right;
-    grandparent = rb_parent(parent);
-    uncle =
-        (grandparent->left == parent) ? grandparent->right : grandparent->left;
-
-    /* Apply right-right case */
-    map_r_r(obj, node, parent, grandparent, uncle);
-}
-
-static void map_fix_colors(map_t obj, map_node_t *node)
-{
-    /* If root, set the color to black */
-    if (node == obj->head) {
-        rb_set_color(node, RB_BLACK);
-        return;
-    }
-
-    /* If node's parent is black or node is root, back out. */
-    if (rb_color(rb_parent(node)) == RB_BLACK && rb_parent(node) != obj->head)
-        return;
-
-    /* Find out the identity */
-    map_node_t *parent = rb_parent(node), *grandparent = rb_parent(parent),
-               *uncle;
-
-    if (!rb_parent(parent))
-        return;
-
-    /* Find out the uncle */
-    if (grandparent->left == parent)
-        uncle = grandparent->right;
-    else
-        uncle = grandparent->left;
-
-    if (rb_is_red(uncle)) {
-        /* If the uncle is red, change color of parent and uncle to black */
-        rb_set_color(uncle, RB_BLACK);
-        rb_set_color(parent, RB_BLACK);
-
-        /* Change color of grandparent to red. */
-        rb_set_color(grandparent, RB_RED);
-
-        /* Call this on the grandparent */
-        map_fix_colors(obj, grandparent);
-    } else {
-        /* If the uncle is black. */
-        if (parent == grandparent->left && node == parent->left)
-            map_l_l(obj, node, parent, grandparent, uncle);
-        else if (parent == grandparent->left && node == parent->right)
-            map_l_r(obj, node, parent, grandparent, uncle);
-        else if (parent == grandparent->right && node == parent->left)
-            map_r_l(obj, node, parent, grandparent, uncle);
-        else if (parent == grandparent->right && node == parent->right)
-            map_r_r(obj, node, parent, grandparent, uncle);
-    }
-}
-
-/*
- * Fix the red-black tree post-BST deletion. This may involve multiple
- * recolors and/or rotations depending on which node was deleted, what color
- * it was, and where it was in the tree at the time of deletion.
- *
- * These fixes occur up and down the path of the tree, and each rotation is
- * guaranteed constant time. As such, there is a maximum of O(lg n) operations
- * taking place during the fixup procedure.
- */
-static void map_delete_fixup(map_t obj,
-                             map_node_t *node,
-                             map_node_t *p,
-                             bool y_is_left,
-                             map_node_t *y UNUSED)
-{
-    map_node_t *w;
-    map_color_t lc, rc;
-
-    if (!node)
-        return;
-
-    while (node != obj->head && rb_color(node) == RB_BLACK) {
-        if (y_is_left) { /* if left child */
-            w = p->right;
-
-            if (rb_is_red(w)) {
-                rb_set_color(w, RB_BLACK);
-                rb_set_color(p, RB_RED);
-                p = map_rotate_left(obj, p)->left;
-                w = p->right;
-            }
-
-            lc = !w->left ? RB_BLACK : rb_color(w->left);
-            rc = !w->right ? RB_BLACK : rb_color(w->right);
-
-            if (lc == RB_BLACK && rc == RB_BLACK) {
-                rb_set_color(w, RB_RED);
-                node = rb_parent(node);
-                p = rb_parent(node);
-
-                if (p)
-                    y_is_left = (node == p->left);
-            } else {
-                if (rc == RB_BLACK) {
-                    rb_set_color(w->left, RB_BLACK);
-                    rb_set_color(w, RB_RED);
-                    w = map_rotate_right(obj, w);
-                    w = p->right;
-                }
-
-                rb_set_color(w, rb_color(p));
-                rb_set_color(p, RB_BLACK);
-
-                if (w->right)
-                    rb_set_color(w->right, RB_BLACK);
-
-                p = map_rotate_left(obj, p);
-                node = obj->head;
-                p = NULL;
-            }
-        } else {
-            /* Same except flipped "left" and "right" */
-            w = p->left;
-
-            if (rb_is_red(w)) {
-                rb_set_color(w, RB_BLACK);
-                rb_set_color(p, RB_RED);
-                p = map_rotate_right(obj, p)->right;
-                w = p->left;
-            }
-
-            lc = !w->left ? RB_BLACK : rb_color(w->left);
-            rc = !w->right ? RB_BLACK : rb_color(w->right);
-
-            if (lc == RB_BLACK && rc == RB_BLACK) {
-                rb_set_color(w, RB_RED);
-                node = rb_parent(node);
-                p = rb_parent(node);
-                if (p)
-                    y_is_left = (node == p->left);
-            } else {
-                if (lc == RB_BLACK) {
-                    rb_set_color(w->right, RB_BLACK);
-                    rb_set_color(w, RB_RED);
-                    w = map_rotate_left(obj, w);
-                    w = p->left;
-                }
-
-                rb_set_color(w, rb_color(p));
-                rb_set_color(p, RB_BLACK);
-
-                if (w->left)
-                    rb_set_color(w->left, RB_BLACK);
-
-                p = map_rotate_right(obj, p);
-                node = obj->head;
-                p = NULL;
-            }
-        }
-    }
-
-    rb_set_color(node, RB_BLACK);
-}
-
-/*
- * Recursive wrapper for deleting nodes in a graph at an accelerated pace.
- * Skips rotations. Just aggressively goes through all nodes and deletes.
- */
-static void map_clear_nested(map_t obj, map_node_t *node)
-{
-    /* Free children */
-    if (node->left)
-        map_clear_nested(obj, node->left);
-    if (node->right)
-        map_clear_nested(obj, node->right);
-
-    /* Free self */
-    map_delete_node(obj, node);
-}
-
-/*
- * Recalculate the positions of the "least" and "most" iterators in the
- * tree. This is so iterators know where the beginning and end of the tree
- * resides.
- */
-static void map_calibrate(map_t obj)
-{
-    if (!obj->head) {
-        obj->it_least.node = obj->it_most.node = NULL;
-        return;
-    }
-
-    /* Recompute it_least and it_most */
-    obj->it_least.node = obj->it_most.node = obj->head;
-
-    while (obj->it_least.node->left)
-        obj->it_least.node = obj->it_least.node->left;
-
-    while (obj->it_most.node->right)
-        obj->it_most.node = obj->it_most.node->right;
-}
-
-/*
- * Sets up a brand new, blank map for use. The size of the node elements
- * is determined by what types are thrown in. "s1" is the size of the key
- * elements in bytes, while "s2" is the size of the value elements in
- * bytes.
- *
- * Since this is also a tree data structure, a comparison function is also
- * required to be passed in. A destruct function is optional and must be
- * added in through another function.
- */
-map_t map_new(size_t s1, size_t s2, int (*cmp)(const void *, const void *))
-{
-    map_t obj = malloc(sizeof(struct map_internal));
-
-    /* Set all pointers to NULL */
-    obj->head = NULL;
-
-    /* Set up all default properties */
-    obj->key_size = s1;
-    obj->element_size = s2;
-    obj->size = 0;
-
-    /* Function pointers */
-    obj->comparator = cmp;
-
-    obj->it_end.prev = obj->it_end.node = NULL;
-    obj->it_least.prev = obj->it_least.node = NULL;
-    obj->it_most.prev = obj->it_most.node = NULL;
-    obj->it_most.node = NULL;
-
-    return obj;
-}
-
-/*
- * Insert a key/value pair into the map. The value can be blank. If so,
- * it is filled with 0's, as defined in "map_create_node".
- */
-bool map_insert(map_t obj, void *key, void *value)
-{
-    /* Copy the key and value into new node and prepare it to put into tree. */
-    map_node_t *new_node =
-        map_create_node(key, value, obj->key_size, obj->element_size);
-
-    obj->size++;
-
-    if (!obj->head) {
-        /* Just insert the node in as the new head. */
-        obj->head = new_node;
-        rb_set_color(obj->head, RB_BLACK);
-
-        /* Calibrate the tree to properly assign pointers. */
-        map_calibrate(obj);
-        return true;
-    }
-
-    /* Traverse the tree until we hit the end or find a side that is NULL */
-    map_node_t **indirect = &obj->head;
-    map_node_t *parent = obj->head;
-
-    while (*indirect) {
-        int res = obj->comparator(new_node->key, (*indirect)->key);
-        if (res == 0) { /* If the key matches something, don't insert */
-            map_delete_node(obj, new_node);
-            return false;
-        }
-        parent = *indirect;
-        indirect = res < 0 ? &(*indirect)->left : &(*indirect)->right;
-    }
-
-    *indirect = new_node;
-    rb_set_parent(new_node, parent);
-    map_fix_colors(obj, new_node);
-    map_calibrate(obj);
+    map_node *node = map_create_node(key, val, obj->key_size, obj->val_size);
+    internal_map_insert(obj, node);
     return true;
 }
 
-static void map_prev(map_t obj, map_iter_t *it)
-{
-    /* We have hit the end or null node. */
-    if (!it->node || it->node == obj->it_least.node) {
-        it->prev = it->node = NULL;
-        return;
-    }
-
-    if (it->node->left) { /* To the left, as far right as possible */
-        for (it->node = it->node->left; it->node->right;
-             it->node = it->node->right)
-            it->prev = it->node;
-        return;
-    }
-
-    /* If there is no left child, keep going up until there is a left child */
-    it->prev = it->node;
-    it->node = rb_parent(it->node);
-
-    while (rb_parent(it->node) && it->node->left &&
-           (it->node->left == it->prev)) {
-        it->prev = it->node;
-        it->node = rb_parent(it->node);
-    }
-}
-
+/* Get functions */
 void map_find(map_t obj, map_iter_t *it, void *key)
 {
-    if (!obj->head) { /* End the search instantly if nothing is found. */
-        it->node = it->prev = NULL;
-        return;
-    }
-
-    /* Basically a repeat of insert */
-    map_node_t **indirect = &obj->head;
-
-    /* binary search */
-    while (*indirect) {
-        int res = obj->comparator(key, (*indirect)->key);
-        if (res == 0)
-            break;
-        indirect = res < 0 ? &(*indirect)->left : &(*indirect)->right;
-    }
-
-    if (!*indirect) {
-        it->node = NULL;
-        return;
-    }
-    it->node = *indirect;
-
-    /* Generate a "prev" as well */
-    map_iter_t tmp = *it;
-    map_prev(obj, &tmp);
-    it->prev = tmp.node;
+    map_node *tmp_node = (map_node *) malloc(sizeof(map_node));
+    tmp_node->key = key;
+    it->node = internal_map_search(obj, tmp_node);
+    free(tmp_node);
 }
 
 bool map_empty(map_t obj)
 {
-    return (obj->size == 0);
+    return (NULL == obj->root);
 }
 
-/* Return true if at the the end of the map */
-bool map_at_end(map_t obj UNUSED, map_iter_t *it)
+/* Iteration */
+bool map_at_end(map_t UNUSED, map_iter_t *it)
 {
-    return (it->node == NULL);
+    return (NULL == it->node);
 }
 
-/*
- * Remove a node from the map. It performs a BST delete, and then reorders
- * the tree so that it remains balanced.
- */
+/* Remove functions */
 void map_erase(map_t obj, map_iter_t *it)
 {
-    map_node_t *x, *y;
-    map_node_t *node = it->node, *target, *double_blk, *x_parent;
-
-    /* If it is the head, and the size is 1, just delete it. */
-    if (obj->size == 1 && node == obj->head) {
-        map_delete_node(obj, node);
-        obj->head = NULL;
-        obj->size--;
+    if (NULL == it->node)
         return;
-    }
-
-    /* Determine what the target is */
-    uint8_t c = (!!node->left << 0x0) | (!!node->right << 0x1);
-
-    switch (c) {
-    case 0x0: /* Leaf node (this should be impossible) */
-        target = node;
-        break;
-
-    case 0x1: /* Has left child */
-        target = node->left;
-        break;
-
-    case 0x2: /* Has right child */
-        target = node->right;
-        break;
-
-    case 0x3: /* Has 2 children */
-        for (target = node->left; target->right; target = target->right)
-            ;
-        break;
-    }
-    assert(target);
-
-    /* Initially there is no Double Black */
-    double_blk = NULL;
-
-    if (!node->left || !node->right)
-        y = node;
-    else
-        y = target;
-
-    if (y->left)
-        x = y->left;
-    else
-        x = y->right;
-
-    if (x)
-        rb_set_parent(x, rb_parent(y));
-
-    x_parent = rb_parent(y);
-
-    bool y_is_left = false;
-    if (!rb_parent(y)) {
-        obj->head = x;
-    } else {
-        if (y == rb_parent(y)->left) {
-            rb_parent(y)->left = x;
-            y_is_left = true;
-        } else
-            rb_parent(y)->right = x;
-    }
-
-    if (y != node) {
-        free(node->key);
-        free(node->data);
-
-        node->key = y->key;
-        node->data = y->data;
-
-        y->key = y->data = NULL;
-    }
-
-    if (rb_color(y) == RB_BLACK) {
-        if (!x) { /* Make a blank node if null */
-            double_blk =
-                map_create_node(NULL, NULL, obj->key_size, obj->element_size);
-
-            x = double_blk;
-
-            if (!rb_parent(target)->left)
-                rb_parent(target)->left = x;
-            else
-                rb_parent(target)->right = x;
-
-            rb_set_parent_color(x, rb_parent(target), RB_BLACK);
-        }
-
-        /* fix the tree up */
-        map_delete_fixup(obj, x, x_parent, y_is_left, y);
-
-        /* Clean up Double Black */
-        if (double_blk) {
-            if (rb_parent(double_blk)) {
-                if (rb_parent(double_blk)->left == double_blk)
-                    rb_parent(double_blk)->left = NULL;
-                else
-                    rb_parent(double_blk)->right = NULL;
-            }
-
-            map_delete_node(obj, double_blk);
-        }
-    }
-
-    obj->size--;
-
-    map_delete_node(obj, y);
-    map_calibrate(obj);
+    internal_map_remove(obj, it->node);
+    map_delete_node(obj, it->node);
 }
 
-/*
- * Delete all nodes in the graph. This is done by calling erase on the head
- * node until the tree is empty.
- */
+/* Empty map */
 void map_clear(map_t obj)
 {
-    if (obj->head) /* Aggressively delete by recursion */
-        map_clear_nested(obj, obj->head);
-
-    obj->size = 0;
-    obj->head = NULL;
+    internal_map_destroy(obj, cb, NULL);
+    // FIXME: Not freeing all nodes
 }
 
-/* Free the map from memory and delete all nodes. */
+/* Destructor */
 void map_delete(map_t obj)
 {
-    /* Free all nodes */
     map_clear(obj);
-
-    /* Free the map itself */
     free(obj);
 }

--- a/src/map.h
+++ b/src/map.h
@@ -1,691 +1,73 @@
+/*
+ * rv32emu is freely redistributable under the MIT License. See the file
+ * "LICENSE" for information on usage and redistribution of this file.
+ */
+
+/*
+ * C Implementation for C++ std::map using red-black tree.
+ *
+ * Any data type can be stored in a map, just like std::map.
+ * A map instance requires the specification of two file types:
+ *   1. the key;
+ *   2. what data type the tree node will store;
+ *
+ * It will also require a comparison function to sort the tree.
+ */
+
 #pragma once
 
-#include <assert.h>
 #include <stdbool.h>
 #include <stddef.h>
-#include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 
-/* C macro implementation of left-leaning 2-3 red-black trees.  Parent
- * pointers are not used, and color bits are stored in the least significant
- * bit of right-child pointers, thus making node linkage as compact as is
- * possible for red-black trees.
- */
+typedef struct map_node map_node_t;
+struct map_node {
+    void *key;
+    void *val;
+    struct {
+        map_node_t *left, *right_red;
+    } link;
+};
 
-/* Each node in the RB tree consumes at least 1 byte of space (for the linkage
- * if nothing else, so there are a maximum of sizeof(void *) << 3 rb tree nodes
- * in any process (and thus, at most sizeof(void *) << 3 nodes in any rb tree).
- * The choice of algorithm bounds the depth of a tree to twice the binary log of
- * the number of elements in the tree; the following bound follows.
- */
-#define RB_MAX_DEPTH (sizeof(void *) << 4)
+typedef struct {
+    map_node_t *root;
+    int (*cmp)(const void *, const void *);
+    size_t key_size;
+    size_t val_size;
+} map_head_t;
 
-/* Node structure */
-#define rb_node(x_type)           \
-    struct {                      \
-        x_type *left, *right_red; \
-    }
+typedef map_head_t *map_t;
 
-/* Root structure */
-#define rb_tree(x_type)  \
-    struct {             \
-        x_type *root;    \
-        size_t key_size; \
-        size_t val_size; \
-    }
-
-/* Left accessors */
-#define rbtn_left_get(x_type, x_field, x_node) ((x_node)->x_field.left)
-#define rbtn_left_set(x_type, x_field, x_node, x_left) \
-    do {                                               \
-        (x_node)->x_field.left = x_left;               \
-    } while (0)
-
-/* Right accessors */
-#define rbtn_right_get(x_type, x_field, x_node) \
-    ((x_type *) (((intptr_t) (x_node)->x_field.right_red) & ~3))
-#define rbtn_right_set(x_type, x_field, x_node, x_right)                  \
-    do {                                                                  \
-        (x_node)->x_field.right_red =                                     \
-            (x_type *) (((uintptr_t) x_right) |                           \
-                        (((uintptr_t) (x_node)->x_field.right_red) & 1)); \
-    } while (0)
-
-/* Color accessors */
-#define rbtn_red_get(x_type, x_field, x_node) \
-    ((bool) (((uintptr_t) (x_node)->x_field.right_red) & 1))
-#define rbtn_color_set(x_type, x_field, x_node, x_red)                    \
-    do {                                                                  \
-        (x_node)->x_field.right_red =                                     \
-            (x_type *) ((((intptr_t) (x_node)->x_field.right_red) & ~3) | \
-                        ((ssize_t) x_red));                               \
-    } while (0)
-#define rbtn_red_set(x_type, x_field, x_node)                           \
-    do {                                                                \
-        (x_node)->x_field.right_red =                                   \
-            (x_type *) (((uintptr_t) (x_node)->x_field.right_red) | 1); \
-    } while (0)
-#define rbtn_black_set(x_type, x_field, x_node)                         \
-    do {                                                                \
-        (x_node)->x_field.right_red =                                   \
-            (x_type *) (((intptr_t) (x_node)->x_field.right_red) & ~3); \
-    } while (0)
-
-/* Node initializer */
-#define rbt_node_new(x_type, x_field, x_rbt, x_node)          \
-    do {                                                      \
-        /* Bookkeeping bit cannot be used by node pointer. */ \
-        assert(((uintptr_t) (x_node) & (0x1)) == 0);          \
-        rbtn_left_set(x_type, x_field, (x_node), NULL);       \
-        rbtn_right_set(x_type, x_field, (x_node), NULL);      \
-        rbtn_red_set(x_type, x_field, (x_node));              \
-    } while (0)
-
-/* Tree initializer. */
-#define rb_new(x_type, x_field, x_rbt) \
-    do {                               \
-        (x_rbt)->root = NULL;          \
-    } while (0)
-
-/* Internal utility macros */
-#define rbtn_rotate_left(x_type, x_field, x_node, r_node)         \
-    do {                                                          \
-        (r_node) = rbtn_right_get(x_type, x_field, (x_node));     \
-        rbtn_right_set(x_type, x_field, (x_node),                 \
-                       rbtn_left_get(x_type, x_field, (r_node))); \
-        rbtn_left_set(x_type, x_field, (r_node), (x_node));       \
-    } while (0)
-
-#define rbtn_rotate_right(x_type, x_field, x_node, r_node)        \
-    do {                                                          \
-        (r_node) = rbtn_left_get(x_type, x_field, (x_node));      \
-        rbtn_left_set(x_type, x_field, (x_node),                  \
-                      rbtn_right_get(x_type, x_field, (r_node))); \
-        rbtn_right_set(x_type, x_field, (r_node), (x_node));      \
-    } while (0)
-
-/* The rb_proto() macro generate function prototypes that correspond to the
- * functions generated by an equivalently parameterized call to rb_gen().
- */
-#define rb_proto(x_attr, x_prefix, x_rbt_type, x_type)                      \
-    x_attr void x_prefix##new (x_rbt_type * rbtree);                        \
-    x_attr x_type *x_prefix##search(x_rbt_type *rbtree, const x_type *key); \
-    x_attr void x_prefix##insert(x_rbt_type *rbtree, x_type *node);         \
-    x_attr void x_prefix##remove(x_rbt_type *rbtree, x_type *node);         \
-    x_attr void x_prefix##destroy(x_rbt_type *rbtree,                       \
-                                  void (*cb)(x_type *, void *), void *arg);
-
-/* The rb_gen() macro generates a type-specific red-black tree implementation,
- * based on the above C macros.
- * Arguments:
- *
- *   x_attr:
- *     Function attribute for generated functions (e.g., static).
- *   x_prefix:
- *     Prefix for generated functions (e.g., ex_).
- *   x_rb_type:
- *     Type for red-black tree data structure (e.g., ex_t).
- *   x_type:
- *     Type for red-black tree node data structure (e.g., ex_node_t).
- *   x_field:
- *     Name of red-black tree node linkage (e.g., ex_link).
- *   x_cmp:
- *     Node comparison function name, with the following prototype:
- *
- *     int x_cmp(x_type *x_node, x_type *x_other);
- *                        ^^^^^^
- *                        or x_key
- *     Interpretation of comparison function return values:
- *       -1 : x_node <  x_other
- *        0 : x_node == x_other
- *        1 : x_node >  x_other
- *     In all cases, the x_node or x_key macro argument is the first argument to
- *     the comparison function, which makes it possible to write comparison
- *     functions that treat the first argument specially.  x_cmp must be a total
- *     order on values inserted into the tree -- duplicates are not allowed.
- *
- * Assuming the following setup:
- *
- *   typedef struct ex_node_s ex_node_t;
- *   struct ex_node_s {
- *       rb_node(ex_node_t) ex_link;
- *   };
- *   typedef rb_tree(ex_node_t) ex_t;
- *   rb_gen(static, ex_, ex_t, ex_node_t, ex_link, ex_cmp)
- *
- * The following API is generated:
- *
- *   static void
- *   ex_new(ex_t *tree);
- *       Description: Initialize a red-black tree structure.
- *       Args:
- *         tree: Pointer to an uninitialized red-black tree object.
- *
- *   static ex_node_t *
- *   ex_search(ex_t *tree, const ex_node_t *key);
- *       Description: Search for node that matches key.
- *       Args:
- *         tree: Pointer to an initialized red-black tree object.
- *         key : Search key.
- *       Ret: Node in tree that matches key, or NULL if no match.
- *
- *   static void
- *   ex_insert(ex_t *tree, ex_node_t *node);
- *       Description: Insert node into tree.
- *       Args:
- *         tree: Pointer to an initialized red-black tree object.
- *         node: Node to be inserted into tree.
- *
- *   static void
- *   ex_remove(ex_t *tree, ex_node_t *node);
- *       Description: Remove node from tree.
- *       Args:
- *         tree: Pointer to an initialized red-black tree object.
- *         node: Node in tree to be removed.
- *
- *   static void
- *   ex_destroy(ex_t *tree, void (*cb)(ex_node_t *, void *), void *arg);
- *       Description: Iterate over the tree with post-order traversal, remove
- *                    each node, and run the callback if non-null.  This is
- *                    used for destroying a tree without paying the cost to
- *                    rebalance it.  The tree must not be otherwise altered
- *                    during traversal.
- *       Args:
- *         tree: Pointer to an initialized red-black tree object.
- *         cb  : Callback function, which, if non-null, is called for each node
- *               during iteration.  There is no way to stop iteration once it
- *               has begun.
- *         arg : Opaque pointer passed to cb().
- */
-#define rb_gen(x_attr, x_prefix, x_rbt_type, x_type, x_field, x_cmp)           \
-    typedef struct {                                                           \
-        x_type *node;                                                          \
-        int cmp;                                                               \
-    } x_prefix##path_entry_t;                                                  \
-    x_attr void x_prefix##new (x_rbt_type * rbtree)                            \
-    {                                                                          \
-        rb_new(x_type, x_field, rbtree);                                       \
-    }                                                                          \
-    x_attr x_type *x_prefix##search(x_rbt_type *rbtree, const x_type *key)     \
-    {                                                                          \
-        int cmp;                                                               \
-        x_type *ret = rbtree->root;                                            \
-        while (ret && (cmp = (x_cmp) (key, ret)) != 0) {                       \
-            if (cmp < 0) {                                                     \
-                ret = rbtn_left_get(x_type, x_field, ret);                     \
-            } else {                                                           \
-                ret = rbtn_right_get(x_type, x_field, ret);                    \
-            }                                                                  \
-        }                                                                      \
-        return ret;                                                            \
-    }                                                                          \
-    x_attr void x_prefix##insert(x_rbt_type *rbtree, x_type *node)             \
-    {                                                                          \
-        x_prefix##path_entry_t path[RB_MAX_DEPTH];                             \
-        x_prefix##path_entry_t *pathp;                                         \
-        rbt_node_new(x_type, x_field, rbtree, node);                           \
-        /* Wind. */                                                            \
-        path->node = rbtree->root;                                             \
-        for (pathp = path; pathp->node; pathp++) {                             \
-            int cmp = pathp->cmp = x_cmp(node, pathp->node);                   \
-            if (cmp == 0) {                                                    \
-                /* assert(cmp != 0); */                                        \
-                break; /* If the key matches something, don't insert */        \
-            }                                                                  \
-            if (cmp < 0) {                                                     \
-                pathp[1].node = rbtn_left_get(x_type, x_field, pathp->node);   \
-            } else {                                                           \
-                pathp[1].node = rbtn_right_get(x_type, x_field, pathp->node);  \
-            }                                                                  \
-        }                                                                      \
-        pathp->node = node;                                                    \
-        /* A loop invariant we maintain is that all nodes with            */   \
-        /* out-of-date summaries live in path[0], path[1], ..., *pathp.   */   \
-        /* To maintain this, we have to summarize node, since we          */   \
-        /* decrement pathp before the first iteration.                    */   \
-        assert(!rbtn_left_get(x_type, x_field, node));                         \
-        assert(!rbtn_right_get(x_type, x_field, node));                        \
-        /* Unwind. */                                                          \
-        for (pathp--; (uintptr_t) pathp >= (uintptr_t) path; pathp--) {        \
-            x_type *cnode = pathp->node;                                       \
-            if (pathp->cmp < 0) {                                              \
-                x_type *left = pathp[1].node;                                  \
-                rbtn_left_set(x_type, x_field, cnode, left);                   \
-                if (!rbtn_red_get(x_type, x_field, left))                      \
-                    return;                                                    \
-                x_type *leftleft = rbtn_left_get(x_type, x_field, left);       \
-                if (leftleft && rbtn_red_get(x_type, x_field, leftleft)) {     \
-                    /* Fix up 4-node. */                                       \
-                    x_type *tnode;                                             \
-                    rbtn_black_set(x_type, x_field, leftleft);                 \
-                    rbtn_rotate_right(x_type, x_field, cnode, tnode);          \
-                    cnode = tnode;                                             \
-                }                                                              \
-            } else {                                                           \
-                x_type *right = pathp[1].node;                                 \
-                rbtn_right_set(x_type, x_field, cnode, right);                 \
-                if (!rbtn_red_get(x_type, x_field, right))                     \
-                    return;                                                    \
-                x_type *left = rbtn_left_get(x_type, x_field, cnode);          \
-                if (left && rbtn_red_get(x_type, x_field, left)) {             \
-                    /* Split 4-node. */                                        \
-                    rbtn_black_set(x_type, x_field, left);                     \
-                    rbtn_black_set(x_type, x_field, right);                    \
-                    rbtn_red_set(x_type, x_field, cnode);                      \
-                } else {                                                       \
-                    /* Lean left. */                                           \
-                    x_type *tnode;                                             \
-                    bool tred = rbtn_red_get(x_type, x_field, cnode);          \
-                    rbtn_rotate_left(x_type, x_field, cnode, tnode);           \
-                    rbtn_color_set(x_type, x_field, tnode, tred);              \
-                    rbtn_red_set(x_type, x_field, cnode);                      \
-                    cnode = tnode;                                             \
-                }                                                              \
-            }                                                                  \
-            pathp->node = cnode;                                               \
-        }                                                                      \
-        /* Set root, and make it black. */                                     \
-        rbtree->root = path->node;                                             \
-        rbtn_black_set(x_type, x_field, rbtree->root);                         \
-    }                                                                          \
-    x_attr void x_prefix##remove(x_rbt_type *rbtree, x_type *node)             \
-    {                                                                          \
-        x_prefix##path_entry_t path[RB_MAX_DEPTH];                             \
-        x_prefix##path_entry_t *pathp;                                         \
-        x_prefix##path_entry_t *nodep;                                         \
-        /* This is just to silence a compiler warning. */                      \
-        nodep = NULL;                                                          \
-        /* Wind. */                                                            \
-        path->node = rbtree->root;                                             \
-        for (pathp = path; pathp->node; pathp++) {                             \
-            int cmp = pathp->cmp = x_cmp(node, pathp->node);                   \
-            if (cmp < 0) {                                                     \
-                pathp[1].node = rbtn_left_get(x_type, x_field, pathp->node);   \
-            } else {                                                           \
-                pathp[1].node = rbtn_right_get(x_type, x_field, pathp->node);  \
-                if (cmp == 0) {                                                \
-                    /* Find node's successor, in preparation for swap. */      \
-                    pathp->cmp = 1;                                            \
-                    nodep = pathp;                                             \
-                    for (pathp++; pathp->node; pathp++) {                      \
-                        pathp->cmp = -1;                                       \
-                        pathp[1].node =                                        \
-                            rbtn_left_get(x_type, x_field, pathp->node);       \
-                    }                                                          \
-                    break;                                                     \
-                }                                                              \
-            }                                                                  \
-        }                                                                      \
-        assert(nodep->node == node);                                           \
-        pathp--;                                                               \
-        if (pathp->node != node) {                                             \
-            /* Swap node with its successor. */                                \
-            bool tred = rbtn_red_get(x_type, x_field, pathp->node);            \
-            rbtn_color_set(x_type, x_field, pathp->node,                       \
-                           rbtn_red_get(x_type, x_field, node));               \
-            rbtn_left_set(x_type, x_field, pathp->node,                        \
-                          rbtn_left_get(x_type, x_field, node));               \
-            /* If node's successor is its right child, the following code */   \
-            /* will do the wrong thing for the right child pointer.       */   \
-            /* However, it doesn't matter, because the pointer will be    */   \
-            /* properly set when the successor is pruned.                 */   \
-            rbtn_right_set(x_type, x_field, pathp->node,                       \
-                           rbtn_right_get(x_type, x_field, node));             \
-            rbtn_color_set(x_type, x_field, node, tred);                       \
-            /* The pruned leaf node's child pointers are never accessed   */   \
-            /* again, so don't bother setting them to nil.                */   \
-            nodep->node = pathp->node;                                         \
-            pathp->node = node;                                                \
-            if (nodep == path) {                                               \
-                rbtree->root = nodep->node;                                    \
-            } else {                                                           \
-                if (nodep[-1].cmp < 0) {                                       \
-                    rbtn_left_set(x_type, x_field, nodep[-1].node,             \
-                                  nodep->node);                                \
-                } else {                                                       \
-                    rbtn_right_set(x_type, x_field, nodep[-1].node,            \
-                                   nodep->node);                               \
-                }                                                              \
-            }                                                                  \
-        } else {                                                               \
-            x_type *left = rbtn_left_get(x_type, x_field, node);               \
-            if (left) {                                                        \
-                /* node has no successor, but it has a left child.        */   \
-                /* Splice node out, without losing the left child.        */   \
-                assert(!rbtn_red_get(x_type, x_field, node));                  \
-                assert(rbtn_red_get(x_type, x_field, left));                   \
-                rbtn_black_set(x_type, x_field, left);                         \
-                if (pathp == path) {                                           \
-                    rbtree->root = left;                                       \
-                    /* Nothing to summarize -- the subtree rooted at the  */   \
-                    /* node's left child hasn't changed, and it's now the */   \
-                    /* root.                                              */   \
-                } else {                                                       \
-                    if (pathp[-1].cmp < 0) {                                   \
-                        rbtn_left_set(x_type, x_field, pathp[-1].node, left);  \
-                    } else {                                                   \
-                        rbtn_right_set(x_type, x_field, pathp[-1].node, left); \
-                    }                                                          \
-                }                                                              \
-                return;                                                        \
-            } else if (pathp == path) {                                        \
-                /* The tree only contained one node. */                        \
-                rbtree->root = NULL;                                           \
-                return;                                                        \
-            }                                                                  \
-        }                                                                      \
-        /* We've now established the invariant that the node has no right */   \
-        /* child (well, morally; we didn't bother nulling it out if we    */   \
-        /* swapped it with its successor), and that the only nodes with   */   \
-        /* out-of-date summaries live in path[0], path[1], ..., pathp[-1].*/   \
-        if (rbtn_red_get(x_type, x_field, pathp->node)) {                      \
-            /* Prune red node, which requires no fixup. */                     \
-            assert(pathp[-1].cmp < 0);                                         \
-            rbtn_left_set(x_type, x_field, pathp[-1].node, NULL);              \
-            return;                                                            \
-        }                                                                      \
-        /* The node to be pruned is black, so unwind until balance is     */   \
-        /* restored.                                                      */   \
-        pathp->node = NULL;                                                    \
-        for (pathp--; (uintptr_t) pathp >= (uintptr_t) path; pathp--) {        \
-            assert(pathp->cmp != 0);                                           \
-            if (pathp->cmp < 0) {                                              \
-                rbtn_left_set(x_type, x_field, pathp->node, pathp[1].node);    \
-                if (rbtn_red_get(x_type, x_field, pathp->node)) {              \
-                    x_type *right =                                            \
-                        rbtn_right_get(x_type, x_field, pathp->node);          \
-                    x_type *rightleft = rbtn_left_get(x_type, x_field, right); \
-                    x_type *tnode;                                             \
-                    if (rightleft &&                                           \
-                        rbtn_red_get(x_type, x_field, rightleft)) {            \
-                        /* In the following diagrams, ||, //, and \\      */   \
-                        /* indicate the path to the removed node.         */   \
-                        /*                                                */   \
-                        /*      ||                                        */   \
-                        /*    pathp(r)                                    */   \
-                        /*  //        \                                   */   \
-                        /* (b)        (b)                                 */   \
-                        /*           /                                    */   \
-                        /*          (r)                                   */   \
-                        /*                                                */   \
-                        rbtn_black_set(x_type, x_field, pathp->node);          \
-                        rbtn_rotate_right(x_type, x_field, right, tnode);      \
-                        rbtn_right_set(x_type, x_field, pathp->node, tnode);   \
-                        rbtn_rotate_left(x_type, x_field, pathp->node, tnode); \
-                    } else {                                                   \
-                        /*      ||                                        */   \
-                        /*    pathp(r)                                    */   \
-                        /*  //        \                                   */   \
-                        /* (b)        (b)                                 */   \
-                        /*           /                                    */   \
-                        /*          (b)                                   */   \
-                        /*                                                */   \
-                        rbtn_rotate_left(x_type, x_field, pathp->node, tnode); \
-                    }                                                          \
-                    /* Balance restored, but rotation modified subtree    */   \
-                    /* root.                                              */   \
-                    assert((uintptr_t) pathp > (uintptr_t) path);              \
-                    if (pathp[-1].cmp < 0) {                                   \
-                        rbtn_left_set(x_type, x_field, pathp[-1].node, tnode); \
-                    } else {                                                   \
-                        rbtn_right_set(x_type, x_field, pathp[-1].node,        \
-                                       tnode);                                 \
-                    }                                                          \
-                    return;                                                    \
-                } else {                                                       \
-                    x_type *right =                                            \
-                        rbtn_right_get(x_type, x_field, pathp->node);          \
-                    x_type *rightleft = rbtn_left_get(x_type, x_field, right); \
-                    if (rightleft &&                                           \
-                        rbtn_red_get(x_type, x_field, rightleft)) {            \
-                        /*      ||                                        */   \
-                        /*    pathp(b)                                    */   \
-                        /*  //        \                                   */   \
-                        /* (b)        (b)                                 */   \
-                        /*           /                                    */   \
-                        /*          (r)                                   */   \
-                        x_type *tnode;                                         \
-                        rbtn_black_set(x_type, x_field, rightleft);            \
-                        rbtn_rotate_right(x_type, x_field, right, tnode);      \
-                        rbtn_right_set(x_type, x_field, pathp->node, tnode);   \
-                        rbtn_rotate_left(x_type, x_field, pathp->node, tnode); \
-                        /* Balance restored, but rotation modified        */   \
-                        /* subtree root, which may actually be the tree   */   \
-                        /* root.                                          */   \
-                        if (pathp == path) {                                   \
-                            /* Set root. */                                    \
-                            rbtree->root = tnode;                              \
-                        } else {                                               \
-                            if (pathp[-1].cmp < 0) {                           \
-                                rbtn_left_set(x_type, x_field, pathp[-1].node, \
-                                              tnode);                          \
-                            } else {                                           \
-                                rbtn_right_set(x_type, x_field,                \
-                                               pathp[-1].node, tnode);         \
-                            }                                                  \
-                        }                                                      \
-                        return;                                                \
-                    } else {                                                   \
-                        /*      ||                                        */   \
-                        /*    pathp(b)                                    */   \
-                        /*  //        \                                   */   \
-                        /* (b)        (b)                                 */   \
-                        /*           /                                    */   \
-                        /*          (b)                                   */   \
-                        x_type *tnode;                                         \
-                        rbtn_red_set(x_type, x_field, pathp->node);            \
-                        rbtn_rotate_left(x_type, x_field, pathp->node, tnode); \
-                        pathp->node = tnode;                                   \
-                    }                                                          \
-                }                                                              \
-            } else {                                                           \
-                x_type *left;                                                  \
-                rbtn_right_set(x_type, x_field, pathp->node, pathp[1].node);   \
-                left = rbtn_left_get(x_type, x_field, pathp->node);            \
-                if (rbtn_red_get(x_type, x_field, left)) {                     \
-                    x_type *tnode;                                             \
-                    x_type *leftright = rbtn_right_get(x_type, x_field, left); \
-                    x_type *leftrightleft =                                    \
-                        rbtn_left_get(x_type, x_field, leftright);             \
-                    if (leftrightleft &&                                       \
-                        rbtn_red_get(x_type, x_field, leftrightleft)) {        \
-                        /*      ||                                        */   \
-                        /*    pathp(b)                                    */   \
-                        /*   /        \\                                  */   \
-                        /* (r)        (b)                                 */   \
-                        /*   \                                            */   \
-                        /*   (b)                                          */   \
-                        /*   /                                            */   \
-                        /* (r)                                            */   \
-                        x_type *unode;                                         \
-                        rbtn_black_set(x_type, x_field, leftrightleft);        \
-                        rbtn_rotate_right(x_type, x_field, pathp->node,        \
-                                          unode);                              \
-                        rbtn_rotate_right(x_type, x_field, pathp->node,        \
-                                          tnode);                              \
-                        rbtn_right_set(x_type, x_field, unode, tnode);         \
-                        rbtn_rotate_left(x_type, x_field, unode, tnode);       \
-                    } else {                                                   \
-                        /*      ||                                        */   \
-                        /*    pathp(b)                                    */   \
-                        /*   /        \\                                  */   \
-                        /* (r)        (b)                                 */   \
-                        /*   \                                            */   \
-                        /*   (b)                                          */   \
-                        /*   /                                            */   \
-                        /* (b)                                            */   \
-                        assert(leftright);                                     \
-                        rbtn_red_set(x_type, x_field, leftright);              \
-                        rbtn_rotate_right(x_type, x_field, pathp->node,        \
-                                          tnode);                              \
-                        rbtn_black_set(x_type, x_field, tnode);                \
-                    }                                                          \
-                    /* Balance restored, but rotation modified subtree    */   \
-                    /* root, which may actually be the tree root.         */   \
-                    if (pathp == path) {                                       \
-                        /* Set root. */                                        \
-                        rbtree->root = tnode;                                  \
-                    } else {                                                   \
-                        if (pathp[-1].cmp < 0) {                               \
-                            rbtn_left_set(x_type, x_field, pathp[-1].node,     \
-                                          tnode);                              \
-                        } else {                                               \
-                            rbtn_right_set(x_type, x_field, pathp[-1].node,    \
-                                           tnode);                             \
-                        }                                                      \
-                    }                                                          \
-                    return;                                                    \
-                } else if (rbtn_red_get(x_type, x_field, pathp->node)) {       \
-                    x_type *leftleft = rbtn_left_get(x_type, x_field, left);   \
-                    if (leftleft && rbtn_red_get(x_type, x_field, leftleft)) { \
-                        /*        ||                                      */   \
-                        /*      pathp(r)                                  */   \
-                        /*     /        \\                                */   \
-                        /*   (b)        (b)                               */   \
-                        /*   /                                            */   \
-                        /* (r)                                            */   \
-                        x_type *tnode;                                         \
-                        rbtn_black_set(x_type, x_field, pathp->node);          \
-                        rbtn_red_set(x_type, x_field, left);                   \
-                        rbtn_black_set(x_type, x_field, leftleft);             \
-                        rbtn_rotate_right(x_type, x_field, pathp->node,        \
-                                          tnode);                              \
-                        /* Balance restored, but rotation modified        */   \
-                        /* subtree root.                                  */   \
-                        assert((uintptr_t) pathp > (uintptr_t) path);          \
-                        if (pathp[-1].cmp < 0) {                               \
-                            rbtn_left_set(x_type, x_field, pathp[-1].node,     \
-                                          tnode);                              \
-                        } else {                                               \
-                            rbtn_right_set(x_type, x_field, pathp[-1].node,    \
-                                           tnode);                             \
-                        }                                                      \
-                        return;                                                \
-                    } else {                                                   \
-                        /*        ||                                      */   \
-                        /*      pathp(r)                                  */   \
-                        /*     /        \\                                */   \
-                        /*   (b)        (b)                               */   \
-                        /*   /                                            */   \
-                        /* (b)                                            */   \
-                        rbtn_red_set(x_type, x_field, left);                   \
-                        rbtn_black_set(x_type, x_field, pathp->node);          \
-                        /* Balance restored. */                                \
-                        return;                                                \
-                    }                                                          \
-                } else {                                                       \
-                    x_type *leftleft = rbtn_left_get(x_type, x_field, left);   \
-                    if (leftleft && rbtn_red_get(x_type, x_field, leftleft)) { \
-                        /*               ||                               */   \
-                        /*             pathp(b)                           */   \
-                        /*            /        \\                         */   \
-                        /*          (b)        (b)                        */   \
-                        /*          /                                     */   \
-                        /*        (r)                                     */   \
-                        x_type *tnode;                                         \
-                        rbtn_black_set(x_type, x_field, leftleft);             \
-                        rbtn_rotate_right(x_type, x_field, pathp->node,        \
-                                          tnode);                              \
-                        /* Balance restored, but rotation modified        */   \
-                        /* subtree root, which may actually be the tree   */   \
-                        /* root.                                          */   \
-                        if (pathp == path) {                                   \
-                            /* Set root. */                                    \
-                            rbtree->root = tnode;                              \
-                        } else {                                               \
-                            if (pathp[-1].cmp < 0) {                           \
-                                rbtn_left_set(x_type, x_field, pathp[-1].node, \
-                                              tnode);                          \
-                            } else {                                           \
-                                rbtn_right_set(x_type, x_field,                \
-                                               pathp[-1].node, tnode);         \
-                            }                                                  \
-                        }                                                      \
-                        return;                                                \
-                    } else {                                                   \
-                        /*               ||                               */   \
-                        /*             pathp(b)                           */   \
-                        /*            /        \\                         */   \
-                        /*          (b)        (b)                        */   \
-                        /*          /                                     */   \
-                        /*        (b)                                     */   \
-                        rbtn_red_set(x_type, x_field, left);                   \
-                    }                                                          \
-                }                                                              \
-            }                                                                  \
-        }                                                                      \
-        /* Set root. */                                                        \
-        rbtree->root = path->node;                                             \
-        assert(!rbtn_red_get(x_type, x_field, rbtree->root));                  \
-    }                                                                          \
-    x_attr void x_prefix##destroy_recurse(x_rbt_type *rbtree, x_type *node,    \
-                                          void (*cb)(x_type *, void *),        \
-                                          void *arg)                           \
-    {                                                                          \
-        if (!node)                                                             \
-            return;                                                            \
-        x_prefix##destroy_recurse(                                             \
-            rbtree, rbtn_left_get(x_type, x_field, node), cb, arg);            \
-        rbtn_left_set(x_type, x_field, (node), NULL);                          \
-        x_prefix##destroy_recurse(                                             \
-            rbtree, rbtn_right_get(x_type, x_field, node), cb, arg);           \
-        rbtn_right_set(x_type, x_field, (node), NULL);                         \
-        if (cb) {                                                              \
-            cb(node, arg);                                                     \
-        }                                                                      \
-    }                                                                          \
-    x_attr void x_prefix##destroy(x_rbt_type *rbtree,                          \
-                                  void (*cb)(x_type *, void *), void *arg)     \
-    {                                                                          \
-        x_prefix##destroy_recurse(rbtree, rbtree->root, cb, arg);              \
-        rbtree->root = NULL;                                                   \
-    }
-
-#define map_init(key_type, element_type, __func) \
-    map_new(sizeof(key_type), sizeof(element_type), __func)
+typedef struct {
+    map_node_t *prev, *node;
+    size_t count;
+} map_iter_t;
 
 #define map_iter_value(it, type) (*(type *) (it)->node->val)
 
-typedef struct node_ map_node;
-struct node_ {
-    void *key;
-    void *val;
-    rb_node(map_node) link;
-};
-
 enum { _CMP_LESS = -1, _CMP_EQUAL = 0, _CMP_GREATER = 1 };
 
+typedef enum { RB_BLACK = 0, RB_RED } map_color_t;
+
 /* Integer comparison */
-static inline int map_cmp_int(const map_node *arg0, const map_node *arg1)
+static inline int map_cmp_int(const void *arg0, const void *arg1)
 {
-    int *a = (int *) arg0->key, *b = (int *) arg1->key;
+    int *a = (int *) arg0;
+    int *b = (int *) arg1;
     return (*a < *b) ? _CMP_LESS : (*a > *b) ? _CMP_GREATER : _CMP_EQUAL;
 }
 
 /* Unsigned integer comparison */
-static inline int map_cmp_uint(const map_node *arg0, const map_node *arg1)
+static inline int map_cmp_uint(const void *arg0, const void *arg1)
 {
-    unsigned int *a = (unsigned int *) arg0->key,
-                 *b = (unsigned int *) arg1->key;
+    unsigned int *a = (unsigned int *) arg0;
+    unsigned int *b = (unsigned int *) arg1;
     return (*a < *b) ? _CMP_LESS : (*a > *b) ? _CMP_GREATER : _CMP_EQUAL;
 }
 
-static inline void cb(map_node *node, void *UNUSED)
-{
-    free(node);
-}
-
-typedef rb_tree(map_node) map_internal_t;
-typedef map_internal_t *map_t;
-rb_gen(static, internal_map_, map_internal_t, map_node, link, map_cmp_uint);
-
-typedef struct {
-    map_node *prev, *node;
-    size_t count;
-} map_iter_t;
-
 /* Constructor */
-map_t map_new(size_t, size_t, int (*)(const map_node *, const map_node *));
+map_t map_new(size_t, size_t, int (*)(const void *, const void *));
 
 /* Add function */
 bool map_insert(map_t, void *, void *);
@@ -703,3 +85,6 @@ void map_clear(map_t);
 
 /* Destructor */
 void map_delete(map_t);
+
+#define map_init(key_type, element_type, __func) \
+    map_new(sizeof(key_type), sizeof(element_type), __func)

--- a/src/map.h
+++ b/src/map.h
@@ -1,72 +1,691 @@
-/*
- * rv32emu is freely redistributable under the MIT License. See the file
- * "LICENSE" for information on usage and redistribution of this file.
- */
-
-/*
- * C Implementation for C++ std::map using red-black tree.
- *
- * Any data type can be stored in a map, just like std::map.
- * A map instance requires the specification of two file types:
- *   1. the key;
- *   2. what data type the tree node will store;
- *
- * It will also require a comparison function to sort the tree.
- */
-
 #pragma once
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* C macro implementation of left-leaning 2-3 red-black trees.  Parent
+ * pointers are not used, and color bits are stored in the least significant
+ * bit of right-child pointers, thus making node linkage as compact as is
+ * possible for red-black trees.
+ */
+
+/* Each node in the RB tree consumes at least 1 byte of space (for the linkage
+ * if nothing else, so there are a maximum of sizeof(void *) << 3 rb tree nodes
+ * in any process (and thus, at most sizeof(void *) << 3 nodes in any rb tree).
+ * The choice of algorithm bounds the depth of a tree to twice the binary log of
+ * the number of elements in the tree; the following bound follows.
+ */
+#define RB_MAX_DEPTH (sizeof(void *) << 4)
+
+/* Node structure */
+#define rb_node(x_type)           \
+    struct {                      \
+        x_type *left, *right_red; \
+    }
+
+/* Root structure */
+#define rb_tree(x_type)  \
+    struct {             \
+        x_type *root;    \
+        size_t key_size; \
+        size_t val_size; \
+    }
+
+/* Left accessors */
+#define rbtn_left_get(x_type, x_field, x_node) ((x_node)->x_field.left)
+#define rbtn_left_set(x_type, x_field, x_node, x_left) \
+    do {                                               \
+        (x_node)->x_field.left = x_left;               \
+    } while (0)
+
+/* Right accessors */
+#define rbtn_right_get(x_type, x_field, x_node) \
+    ((x_type *) (((intptr_t) (x_node)->x_field.right_red) & ~3))
+#define rbtn_right_set(x_type, x_field, x_node, x_right)                  \
+    do {                                                                  \
+        (x_node)->x_field.right_red =                                     \
+            (x_type *) (((uintptr_t) x_right) |                           \
+                        (((uintptr_t) (x_node)->x_field.right_red) & 1)); \
+    } while (0)
+
+/* Color accessors */
+#define rbtn_red_get(x_type, x_field, x_node) \
+    ((bool) (((uintptr_t) (x_node)->x_field.right_red) & 1))
+#define rbtn_color_set(x_type, x_field, x_node, x_red)                    \
+    do {                                                                  \
+        (x_node)->x_field.right_red =                                     \
+            (x_type *) ((((intptr_t) (x_node)->x_field.right_red) & ~3) | \
+                        ((ssize_t) x_red));                               \
+    } while (0)
+#define rbtn_red_set(x_type, x_field, x_node)                           \
+    do {                                                                \
+        (x_node)->x_field.right_red =                                   \
+            (x_type *) (((uintptr_t) (x_node)->x_field.right_red) | 1); \
+    } while (0)
+#define rbtn_black_set(x_type, x_field, x_node)                         \
+    do {                                                                \
+        (x_node)->x_field.right_red =                                   \
+            (x_type *) (((intptr_t) (x_node)->x_field.right_red) & ~3); \
+    } while (0)
+
+/* Node initializer */
+#define rbt_node_new(x_type, x_field, x_rbt, x_node)          \
+    do {                                                      \
+        /* Bookkeeping bit cannot be used by node pointer. */ \
+        assert(((uintptr_t) (x_node) & (0x1)) == 0);          \
+        rbtn_left_set(x_type, x_field, (x_node), NULL);       \
+        rbtn_right_set(x_type, x_field, (x_node), NULL);      \
+        rbtn_red_set(x_type, x_field, (x_node));              \
+    } while (0)
+
+/* Tree initializer. */
+#define rb_new(x_type, x_field, x_rbt) \
+    do {                               \
+        (x_rbt)->root = NULL;          \
+    } while (0)
+
+/* Internal utility macros */
+#define rbtn_rotate_left(x_type, x_field, x_node, r_node)         \
+    do {                                                          \
+        (r_node) = rbtn_right_get(x_type, x_field, (x_node));     \
+        rbtn_right_set(x_type, x_field, (x_node),                 \
+                       rbtn_left_get(x_type, x_field, (r_node))); \
+        rbtn_left_set(x_type, x_field, (r_node), (x_node));       \
+    } while (0)
+
+#define rbtn_rotate_right(x_type, x_field, x_node, r_node)        \
+    do {                                                          \
+        (r_node) = rbtn_left_get(x_type, x_field, (x_node));      \
+        rbtn_left_set(x_type, x_field, (x_node),                  \
+                      rbtn_right_get(x_type, x_field, (r_node))); \
+        rbtn_right_set(x_type, x_field, (r_node), (x_node));      \
+    } while (0)
+
+/* The rb_proto() macro generate function prototypes that correspond to the
+ * functions generated by an equivalently parameterized call to rb_gen().
+ */
+#define rb_proto(x_attr, x_prefix, x_rbt_type, x_type)                      \
+    x_attr void x_prefix##new (x_rbt_type * rbtree);                        \
+    x_attr x_type *x_prefix##search(x_rbt_type *rbtree, const x_type *key); \
+    x_attr void x_prefix##insert(x_rbt_type *rbtree, x_type *node);         \
+    x_attr void x_prefix##remove(x_rbt_type *rbtree, x_type *node);         \
+    x_attr void x_prefix##destroy(x_rbt_type *rbtree,                       \
+                                  void (*cb)(x_type *, void *), void *arg);
+
+/* The rb_gen() macro generates a type-specific red-black tree implementation,
+ * based on the above C macros.
+ * Arguments:
+ *
+ *   x_attr:
+ *     Function attribute for generated functions (e.g., static).
+ *   x_prefix:
+ *     Prefix for generated functions (e.g., ex_).
+ *   x_rb_type:
+ *     Type for red-black tree data structure (e.g., ex_t).
+ *   x_type:
+ *     Type for red-black tree node data structure (e.g., ex_node_t).
+ *   x_field:
+ *     Name of red-black tree node linkage (e.g., ex_link).
+ *   x_cmp:
+ *     Node comparison function name, with the following prototype:
+ *
+ *     int x_cmp(x_type *x_node, x_type *x_other);
+ *                        ^^^^^^
+ *                        or x_key
+ *     Interpretation of comparison function return values:
+ *       -1 : x_node <  x_other
+ *        0 : x_node == x_other
+ *        1 : x_node >  x_other
+ *     In all cases, the x_node or x_key macro argument is the first argument to
+ *     the comparison function, which makes it possible to write comparison
+ *     functions that treat the first argument specially.  x_cmp must be a total
+ *     order on values inserted into the tree -- duplicates are not allowed.
+ *
+ * Assuming the following setup:
+ *
+ *   typedef struct ex_node_s ex_node_t;
+ *   struct ex_node_s {
+ *       rb_node(ex_node_t) ex_link;
+ *   };
+ *   typedef rb_tree(ex_node_t) ex_t;
+ *   rb_gen(static, ex_, ex_t, ex_node_t, ex_link, ex_cmp)
+ *
+ * The following API is generated:
+ *
+ *   static void
+ *   ex_new(ex_t *tree);
+ *       Description: Initialize a red-black tree structure.
+ *       Args:
+ *         tree: Pointer to an uninitialized red-black tree object.
+ *
+ *   static ex_node_t *
+ *   ex_search(ex_t *tree, const ex_node_t *key);
+ *       Description: Search for node that matches key.
+ *       Args:
+ *         tree: Pointer to an initialized red-black tree object.
+ *         key : Search key.
+ *       Ret: Node in tree that matches key, or NULL if no match.
+ *
+ *   static void
+ *   ex_insert(ex_t *tree, ex_node_t *node);
+ *       Description: Insert node into tree.
+ *       Args:
+ *         tree: Pointer to an initialized red-black tree object.
+ *         node: Node to be inserted into tree.
+ *
+ *   static void
+ *   ex_remove(ex_t *tree, ex_node_t *node);
+ *       Description: Remove node from tree.
+ *       Args:
+ *         tree: Pointer to an initialized red-black tree object.
+ *         node: Node in tree to be removed.
+ *
+ *   static void
+ *   ex_destroy(ex_t *tree, void (*cb)(ex_node_t *, void *), void *arg);
+ *       Description: Iterate over the tree with post-order traversal, remove
+ *                    each node, and run the callback if non-null.  This is
+ *                    used for destroying a tree without paying the cost to
+ *                    rebalance it.  The tree must not be otherwise altered
+ *                    during traversal.
+ *       Args:
+ *         tree: Pointer to an initialized red-black tree object.
+ *         cb  : Callback function, which, if non-null, is called for each node
+ *               during iteration.  There is no way to stop iteration once it
+ *               has begun.
+ *         arg : Opaque pointer passed to cb().
+ */
+#define rb_gen(x_attr, x_prefix, x_rbt_type, x_type, x_field, x_cmp)           \
+    typedef struct {                                                           \
+        x_type *node;                                                          \
+        int cmp;                                                               \
+    } x_prefix##path_entry_t;                                                  \
+    x_attr void x_prefix##new (x_rbt_type * rbtree)                            \
+    {                                                                          \
+        rb_new(x_type, x_field, rbtree);                                       \
+    }                                                                          \
+    x_attr x_type *x_prefix##search(x_rbt_type *rbtree, const x_type *key)     \
+    {                                                                          \
+        int cmp;                                                               \
+        x_type *ret = rbtree->root;                                            \
+        while (ret && (cmp = (x_cmp) (key, ret)) != 0) {                       \
+            if (cmp < 0) {                                                     \
+                ret = rbtn_left_get(x_type, x_field, ret);                     \
+            } else {                                                           \
+                ret = rbtn_right_get(x_type, x_field, ret);                    \
+            }                                                                  \
+        }                                                                      \
+        return ret;                                                            \
+    }                                                                          \
+    x_attr void x_prefix##insert(x_rbt_type *rbtree, x_type *node)             \
+    {                                                                          \
+        x_prefix##path_entry_t path[RB_MAX_DEPTH];                             \
+        x_prefix##path_entry_t *pathp;                                         \
+        rbt_node_new(x_type, x_field, rbtree, node);                           \
+        /* Wind. */                                                            \
+        path->node = rbtree->root;                                             \
+        for (pathp = path; pathp->node; pathp++) {                             \
+            int cmp = pathp->cmp = x_cmp(node, pathp->node);                   \
+            if (cmp == 0) {                                                    \
+                /* assert(cmp != 0); */                                        \
+                break; /* If the key matches something, don't insert */        \
+            }                                                                  \
+            if (cmp < 0) {                                                     \
+                pathp[1].node = rbtn_left_get(x_type, x_field, pathp->node);   \
+            } else {                                                           \
+                pathp[1].node = rbtn_right_get(x_type, x_field, pathp->node);  \
+            }                                                                  \
+        }                                                                      \
+        pathp->node = node;                                                    \
+        /* A loop invariant we maintain is that all nodes with            */   \
+        /* out-of-date summaries live in path[0], path[1], ..., *pathp.   */   \
+        /* To maintain this, we have to summarize node, since we          */   \
+        /* decrement pathp before the first iteration.                    */   \
+        assert(!rbtn_left_get(x_type, x_field, node));                         \
+        assert(!rbtn_right_get(x_type, x_field, node));                        \
+        /* Unwind. */                                                          \
+        for (pathp--; (uintptr_t) pathp >= (uintptr_t) path; pathp--) {        \
+            x_type *cnode = pathp->node;                                       \
+            if (pathp->cmp < 0) {                                              \
+                x_type *left = pathp[1].node;                                  \
+                rbtn_left_set(x_type, x_field, cnode, left);                   \
+                if (!rbtn_red_get(x_type, x_field, left))                      \
+                    return;                                                    \
+                x_type *leftleft = rbtn_left_get(x_type, x_field, left);       \
+                if (leftleft && rbtn_red_get(x_type, x_field, leftleft)) {     \
+                    /* Fix up 4-node. */                                       \
+                    x_type *tnode;                                             \
+                    rbtn_black_set(x_type, x_field, leftleft);                 \
+                    rbtn_rotate_right(x_type, x_field, cnode, tnode);          \
+                    cnode = tnode;                                             \
+                }                                                              \
+            } else {                                                           \
+                x_type *right = pathp[1].node;                                 \
+                rbtn_right_set(x_type, x_field, cnode, right);                 \
+                if (!rbtn_red_get(x_type, x_field, right))                     \
+                    return;                                                    \
+                x_type *left = rbtn_left_get(x_type, x_field, cnode);          \
+                if (left && rbtn_red_get(x_type, x_field, left)) {             \
+                    /* Split 4-node. */                                        \
+                    rbtn_black_set(x_type, x_field, left);                     \
+                    rbtn_black_set(x_type, x_field, right);                    \
+                    rbtn_red_set(x_type, x_field, cnode);                      \
+                } else {                                                       \
+                    /* Lean left. */                                           \
+                    x_type *tnode;                                             \
+                    bool tred = rbtn_red_get(x_type, x_field, cnode);          \
+                    rbtn_rotate_left(x_type, x_field, cnode, tnode);           \
+                    rbtn_color_set(x_type, x_field, tnode, tred);              \
+                    rbtn_red_set(x_type, x_field, cnode);                      \
+                    cnode = tnode;                                             \
+                }                                                              \
+            }                                                                  \
+            pathp->node = cnode;                                               \
+        }                                                                      \
+        /* Set root, and make it black. */                                     \
+        rbtree->root = path->node;                                             \
+        rbtn_black_set(x_type, x_field, rbtree->root);                         \
+    }                                                                          \
+    x_attr void x_prefix##remove(x_rbt_type *rbtree, x_type *node)             \
+    {                                                                          \
+        x_prefix##path_entry_t path[RB_MAX_DEPTH];                             \
+        x_prefix##path_entry_t *pathp;                                         \
+        x_prefix##path_entry_t *nodep;                                         \
+        /* This is just to silence a compiler warning. */                      \
+        nodep = NULL;                                                          \
+        /* Wind. */                                                            \
+        path->node = rbtree->root;                                             \
+        for (pathp = path; pathp->node; pathp++) {                             \
+            int cmp = pathp->cmp = x_cmp(node, pathp->node);                   \
+            if (cmp < 0) {                                                     \
+                pathp[1].node = rbtn_left_get(x_type, x_field, pathp->node);   \
+            } else {                                                           \
+                pathp[1].node = rbtn_right_get(x_type, x_field, pathp->node);  \
+                if (cmp == 0) {                                                \
+                    /* Find node's successor, in preparation for swap. */      \
+                    pathp->cmp = 1;                                            \
+                    nodep = pathp;                                             \
+                    for (pathp++; pathp->node; pathp++) {                      \
+                        pathp->cmp = -1;                                       \
+                        pathp[1].node =                                        \
+                            rbtn_left_get(x_type, x_field, pathp->node);       \
+                    }                                                          \
+                    break;                                                     \
+                }                                                              \
+            }                                                                  \
+        }                                                                      \
+        assert(nodep->node == node);                                           \
+        pathp--;                                                               \
+        if (pathp->node != node) {                                             \
+            /* Swap node with its successor. */                                \
+            bool tred = rbtn_red_get(x_type, x_field, pathp->node);            \
+            rbtn_color_set(x_type, x_field, pathp->node,                       \
+                           rbtn_red_get(x_type, x_field, node));               \
+            rbtn_left_set(x_type, x_field, pathp->node,                        \
+                          rbtn_left_get(x_type, x_field, node));               \
+            /* If node's successor is its right child, the following code */   \
+            /* will do the wrong thing for the right child pointer.       */   \
+            /* However, it doesn't matter, because the pointer will be    */   \
+            /* properly set when the successor is pruned.                 */   \
+            rbtn_right_set(x_type, x_field, pathp->node,                       \
+                           rbtn_right_get(x_type, x_field, node));             \
+            rbtn_color_set(x_type, x_field, node, tred);                       \
+            /* The pruned leaf node's child pointers are never accessed   */   \
+            /* again, so don't bother setting them to nil.                */   \
+            nodep->node = pathp->node;                                         \
+            pathp->node = node;                                                \
+            if (nodep == path) {                                               \
+                rbtree->root = nodep->node;                                    \
+            } else {                                                           \
+                if (nodep[-1].cmp < 0) {                                       \
+                    rbtn_left_set(x_type, x_field, nodep[-1].node,             \
+                                  nodep->node);                                \
+                } else {                                                       \
+                    rbtn_right_set(x_type, x_field, nodep[-1].node,            \
+                                   nodep->node);                               \
+                }                                                              \
+            }                                                                  \
+        } else {                                                               \
+            x_type *left = rbtn_left_get(x_type, x_field, node);               \
+            if (left) {                                                        \
+                /* node has no successor, but it has a left child.        */   \
+                /* Splice node out, without losing the left child.        */   \
+                assert(!rbtn_red_get(x_type, x_field, node));                  \
+                assert(rbtn_red_get(x_type, x_field, left));                   \
+                rbtn_black_set(x_type, x_field, left);                         \
+                if (pathp == path) {                                           \
+                    rbtree->root = left;                                       \
+                    /* Nothing to summarize -- the subtree rooted at the  */   \
+                    /* node's left child hasn't changed, and it's now the */   \
+                    /* root.                                              */   \
+                } else {                                                       \
+                    if (pathp[-1].cmp < 0) {                                   \
+                        rbtn_left_set(x_type, x_field, pathp[-1].node, left);  \
+                    } else {                                                   \
+                        rbtn_right_set(x_type, x_field, pathp[-1].node, left); \
+                    }                                                          \
+                }                                                              \
+                return;                                                        \
+            } else if (pathp == path) {                                        \
+                /* The tree only contained one node. */                        \
+                rbtree->root = NULL;                                           \
+                return;                                                        \
+            }                                                                  \
+        }                                                                      \
+        /* We've now established the invariant that the node has no right */   \
+        /* child (well, morally; we didn't bother nulling it out if we    */   \
+        /* swapped it with its successor), and that the only nodes with   */   \
+        /* out-of-date summaries live in path[0], path[1], ..., pathp[-1].*/   \
+        if (rbtn_red_get(x_type, x_field, pathp->node)) {                      \
+            /* Prune red node, which requires no fixup. */                     \
+            assert(pathp[-1].cmp < 0);                                         \
+            rbtn_left_set(x_type, x_field, pathp[-1].node, NULL);              \
+            return;                                                            \
+        }                                                                      \
+        /* The node to be pruned is black, so unwind until balance is     */   \
+        /* restored.                                                      */   \
+        pathp->node = NULL;                                                    \
+        for (pathp--; (uintptr_t) pathp >= (uintptr_t) path; pathp--) {        \
+            assert(pathp->cmp != 0);                                           \
+            if (pathp->cmp < 0) {                                              \
+                rbtn_left_set(x_type, x_field, pathp->node, pathp[1].node);    \
+                if (rbtn_red_get(x_type, x_field, pathp->node)) {              \
+                    x_type *right =                                            \
+                        rbtn_right_get(x_type, x_field, pathp->node);          \
+                    x_type *rightleft = rbtn_left_get(x_type, x_field, right); \
+                    x_type *tnode;                                             \
+                    if (rightleft &&                                           \
+                        rbtn_red_get(x_type, x_field, rightleft)) {            \
+                        /* In the following diagrams, ||, //, and \\      */   \
+                        /* indicate the path to the removed node.         */   \
+                        /*                                                */   \
+                        /*      ||                                        */   \
+                        /*    pathp(r)                                    */   \
+                        /*  //        \                                   */   \
+                        /* (b)        (b)                                 */   \
+                        /*           /                                    */   \
+                        /*          (r)                                   */   \
+                        /*                                                */   \
+                        rbtn_black_set(x_type, x_field, pathp->node);          \
+                        rbtn_rotate_right(x_type, x_field, right, tnode);      \
+                        rbtn_right_set(x_type, x_field, pathp->node, tnode);   \
+                        rbtn_rotate_left(x_type, x_field, pathp->node, tnode); \
+                    } else {                                                   \
+                        /*      ||                                        */   \
+                        /*    pathp(r)                                    */   \
+                        /*  //        \                                   */   \
+                        /* (b)        (b)                                 */   \
+                        /*           /                                    */   \
+                        /*          (b)                                   */   \
+                        /*                                                */   \
+                        rbtn_rotate_left(x_type, x_field, pathp->node, tnode); \
+                    }                                                          \
+                    /* Balance restored, but rotation modified subtree    */   \
+                    /* root.                                              */   \
+                    assert((uintptr_t) pathp > (uintptr_t) path);              \
+                    if (pathp[-1].cmp < 0) {                                   \
+                        rbtn_left_set(x_type, x_field, pathp[-1].node, tnode); \
+                    } else {                                                   \
+                        rbtn_right_set(x_type, x_field, pathp[-1].node,        \
+                                       tnode);                                 \
+                    }                                                          \
+                    return;                                                    \
+                } else {                                                       \
+                    x_type *right =                                            \
+                        rbtn_right_get(x_type, x_field, pathp->node);          \
+                    x_type *rightleft = rbtn_left_get(x_type, x_field, right); \
+                    if (rightleft &&                                           \
+                        rbtn_red_get(x_type, x_field, rightleft)) {            \
+                        /*      ||                                        */   \
+                        /*    pathp(b)                                    */   \
+                        /*  //        \                                   */   \
+                        /* (b)        (b)                                 */   \
+                        /*           /                                    */   \
+                        /*          (r)                                   */   \
+                        x_type *tnode;                                         \
+                        rbtn_black_set(x_type, x_field, rightleft);            \
+                        rbtn_rotate_right(x_type, x_field, right, tnode);      \
+                        rbtn_right_set(x_type, x_field, pathp->node, tnode);   \
+                        rbtn_rotate_left(x_type, x_field, pathp->node, tnode); \
+                        /* Balance restored, but rotation modified        */   \
+                        /* subtree root, which may actually be the tree   */   \
+                        /* root.                                          */   \
+                        if (pathp == path) {                                   \
+                            /* Set root. */                                    \
+                            rbtree->root = tnode;                              \
+                        } else {                                               \
+                            if (pathp[-1].cmp < 0) {                           \
+                                rbtn_left_set(x_type, x_field, pathp[-1].node, \
+                                              tnode);                          \
+                            } else {                                           \
+                                rbtn_right_set(x_type, x_field,                \
+                                               pathp[-1].node, tnode);         \
+                            }                                                  \
+                        }                                                      \
+                        return;                                                \
+                    } else {                                                   \
+                        /*      ||                                        */   \
+                        /*    pathp(b)                                    */   \
+                        /*  //        \                                   */   \
+                        /* (b)        (b)                                 */   \
+                        /*           /                                    */   \
+                        /*          (b)                                   */   \
+                        x_type *tnode;                                         \
+                        rbtn_red_set(x_type, x_field, pathp->node);            \
+                        rbtn_rotate_left(x_type, x_field, pathp->node, tnode); \
+                        pathp->node = tnode;                                   \
+                    }                                                          \
+                }                                                              \
+            } else {                                                           \
+                x_type *left;                                                  \
+                rbtn_right_set(x_type, x_field, pathp->node, pathp[1].node);   \
+                left = rbtn_left_get(x_type, x_field, pathp->node);            \
+                if (rbtn_red_get(x_type, x_field, left)) {                     \
+                    x_type *tnode;                                             \
+                    x_type *leftright = rbtn_right_get(x_type, x_field, left); \
+                    x_type *leftrightleft =                                    \
+                        rbtn_left_get(x_type, x_field, leftright);             \
+                    if (leftrightleft &&                                       \
+                        rbtn_red_get(x_type, x_field, leftrightleft)) {        \
+                        /*      ||                                        */   \
+                        /*    pathp(b)                                    */   \
+                        /*   /        \\                                  */   \
+                        /* (r)        (b)                                 */   \
+                        /*   \                                            */   \
+                        /*   (b)                                          */   \
+                        /*   /                                            */   \
+                        /* (r)                                            */   \
+                        x_type *unode;                                         \
+                        rbtn_black_set(x_type, x_field, leftrightleft);        \
+                        rbtn_rotate_right(x_type, x_field, pathp->node,        \
+                                          unode);                              \
+                        rbtn_rotate_right(x_type, x_field, pathp->node,        \
+                                          tnode);                              \
+                        rbtn_right_set(x_type, x_field, unode, tnode);         \
+                        rbtn_rotate_left(x_type, x_field, unode, tnode);       \
+                    } else {                                                   \
+                        /*      ||                                        */   \
+                        /*    pathp(b)                                    */   \
+                        /*   /        \\                                  */   \
+                        /* (r)        (b)                                 */   \
+                        /*   \                                            */   \
+                        /*   (b)                                          */   \
+                        /*   /                                            */   \
+                        /* (b)                                            */   \
+                        assert(leftright);                                     \
+                        rbtn_red_set(x_type, x_field, leftright);              \
+                        rbtn_rotate_right(x_type, x_field, pathp->node,        \
+                                          tnode);                              \
+                        rbtn_black_set(x_type, x_field, tnode);                \
+                    }                                                          \
+                    /* Balance restored, but rotation modified subtree    */   \
+                    /* root, which may actually be the tree root.         */   \
+                    if (pathp == path) {                                       \
+                        /* Set root. */                                        \
+                        rbtree->root = tnode;                                  \
+                    } else {                                                   \
+                        if (pathp[-1].cmp < 0) {                               \
+                            rbtn_left_set(x_type, x_field, pathp[-1].node,     \
+                                          tnode);                              \
+                        } else {                                               \
+                            rbtn_right_set(x_type, x_field, pathp[-1].node,    \
+                                           tnode);                             \
+                        }                                                      \
+                    }                                                          \
+                    return;                                                    \
+                } else if (rbtn_red_get(x_type, x_field, pathp->node)) {       \
+                    x_type *leftleft = rbtn_left_get(x_type, x_field, left);   \
+                    if (leftleft && rbtn_red_get(x_type, x_field, leftleft)) { \
+                        /*        ||                                      */   \
+                        /*      pathp(r)                                  */   \
+                        /*     /        \\                                */   \
+                        /*   (b)        (b)                               */   \
+                        /*   /                                            */   \
+                        /* (r)                                            */   \
+                        x_type *tnode;                                         \
+                        rbtn_black_set(x_type, x_field, pathp->node);          \
+                        rbtn_red_set(x_type, x_field, left);                   \
+                        rbtn_black_set(x_type, x_field, leftleft);             \
+                        rbtn_rotate_right(x_type, x_field, pathp->node,        \
+                                          tnode);                              \
+                        /* Balance restored, but rotation modified        */   \
+                        /* subtree root.                                  */   \
+                        assert((uintptr_t) pathp > (uintptr_t) path);          \
+                        if (pathp[-1].cmp < 0) {                               \
+                            rbtn_left_set(x_type, x_field, pathp[-1].node,     \
+                                          tnode);                              \
+                        } else {                                               \
+                            rbtn_right_set(x_type, x_field, pathp[-1].node,    \
+                                           tnode);                             \
+                        }                                                      \
+                        return;                                                \
+                    } else {                                                   \
+                        /*        ||                                      */   \
+                        /*      pathp(r)                                  */   \
+                        /*     /        \\                                */   \
+                        /*   (b)        (b)                               */   \
+                        /*   /                                            */   \
+                        /* (b)                                            */   \
+                        rbtn_red_set(x_type, x_field, left);                   \
+                        rbtn_black_set(x_type, x_field, pathp->node);          \
+                        /* Balance restored. */                                \
+                        return;                                                \
+                    }                                                          \
+                } else {                                                       \
+                    x_type *leftleft = rbtn_left_get(x_type, x_field, left);   \
+                    if (leftleft && rbtn_red_get(x_type, x_field, leftleft)) { \
+                        /*               ||                               */   \
+                        /*             pathp(b)                           */   \
+                        /*            /        \\                         */   \
+                        /*          (b)        (b)                        */   \
+                        /*          /                                     */   \
+                        /*        (r)                                     */   \
+                        x_type *tnode;                                         \
+                        rbtn_black_set(x_type, x_field, leftleft);             \
+                        rbtn_rotate_right(x_type, x_field, pathp->node,        \
+                                          tnode);                              \
+                        /* Balance restored, but rotation modified        */   \
+                        /* subtree root, which may actually be the tree   */   \
+                        /* root.                                          */   \
+                        if (pathp == path) {                                   \
+                            /* Set root. */                                    \
+                            rbtree->root = tnode;                              \
+                        } else {                                               \
+                            if (pathp[-1].cmp < 0) {                           \
+                                rbtn_left_set(x_type, x_field, pathp[-1].node, \
+                                              tnode);                          \
+                            } else {                                           \
+                                rbtn_right_set(x_type, x_field,                \
+                                               pathp[-1].node, tnode);         \
+                            }                                                  \
+                        }                                                      \
+                        return;                                                \
+                    } else {                                                   \
+                        /*               ||                               */   \
+                        /*             pathp(b)                           */   \
+                        /*            /        \\                         */   \
+                        /*          (b)        (b)                        */   \
+                        /*          /                                     */   \
+                        /*        (b)                                     */   \
+                        rbtn_red_set(x_type, x_field, left);                   \
+                    }                                                          \
+                }                                                              \
+            }                                                                  \
+        }                                                                      \
+        /* Set root. */                                                        \
+        rbtree->root = path->node;                                             \
+        assert(!rbtn_red_get(x_type, x_field, rbtree->root));                  \
+    }                                                                          \
+    x_attr void x_prefix##destroy_recurse(x_rbt_type *rbtree, x_type *node,    \
+                                          void (*cb)(x_type *, void *),        \
+                                          void *arg)                           \
+    {                                                                          \
+        if (!node)                                                             \
+            return;                                                            \
+        x_prefix##destroy_recurse(                                             \
+            rbtree, rbtn_left_get(x_type, x_field, node), cb, arg);            \
+        rbtn_left_set(x_type, x_field, (node), NULL);                          \
+        x_prefix##destroy_recurse(                                             \
+            rbtree, rbtn_right_get(x_type, x_field, node), cb, arg);           \
+        rbtn_right_set(x_type, x_field, (node), NULL);                         \
+        if (cb) {                                                              \
+            cb(node, arg);                                                     \
+        }                                                                      \
+    }                                                                          \
+    x_attr void x_prefix##destroy(x_rbt_type *rbtree,                          \
+                                  void (*cb)(x_type *, void *), void *arg)     \
+    {                                                                          \
+        x_prefix##destroy_recurse(rbtree, rbtree->root, cb, arg);              \
+        rbtree->root = NULL;                                                   \
+    }
+
+#define map_init(key_type, element_type, __func) \
+    map_new(sizeof(key_type), sizeof(element_type), __func)
+
+#define map_iter_value(it, type) (*(type *) (it)->node->val)
+
+typedef struct node_ map_node;
+struct node_ {
+    void *key;
+    void *val;
+    rb_node(map_node) link;
+};
 
 enum { _CMP_LESS = -1, _CMP_EQUAL = 0, _CMP_GREATER = 1 };
 
 /* Integer comparison */
-static inline int map_cmp_int(const void *arg0, const void *arg1)
+static inline int map_cmp_int(const map_node *arg0, const map_node *arg1)
 {
-    int *a = (int *) arg0, *b = (int *) arg1;
+    int *a = (int *) arg0->key, *b = (int *) arg1->key;
     return (*a < *b) ? _CMP_LESS : (*a > *b) ? _CMP_GREATER : _CMP_EQUAL;
 }
 
 /* Unsigned integer comparison */
-static inline int map_cmp_uint(const void *arg0, const void *arg1)
+static inline int map_cmp_uint(const map_node *arg0, const map_node *arg1)
 {
-    unsigned int *a = (unsigned int *) arg0, *b = (unsigned int *) arg1;
+    unsigned int *a = (unsigned int *) arg0->key,
+                 *b = (unsigned int *) arg1->key;
     return (*a < *b) ? _CMP_LESS : (*a > *b) ? _CMP_GREATER : _CMP_EQUAL;
 }
 
-/*
- * Store the key, data, and values of each element in the tree.
- * This is the main basis of the entire tree aside from the root struct.
- *
- * @parent_color: combination of @parent and @color (lowest bit)
- * @left: pointer to the left child in the tree
- * @right: pointer to the right child in the tree
- *
- * The red-black tree consists of a root and nodes attached to this root.
- */
-typedef struct map_node {
-    void *key, *data;
+static inline void cb(map_node *node, void *UNUSED)
+{
+    free(node);
+}
 
-    /* red-black tree */
-    unsigned long parent_color;
-    struct map_node *left, *right;
-} __ALIGNED(sizeof(unsigned long)) map_node_t;
+typedef rb_tree(map_node) map_internal_t;
+typedef map_internal_t *map_t;
+rb_gen(static, internal_map_, map_internal_t, map_node, link, map_cmp_uint);
 
 typedef struct {
-    struct map_node *prev, *node;
+    map_node *prev, *node;
     size_t count;
 } map_iter_t;
 
-/*
- * Store access to the head node, as well as the first and last nodes.
- * Keep track of all aspects of the tree. All map functions require a pointer
- * to this struct.
- */
-typedef struct map_internal *map_t;
-
 /* Constructor */
-map_t map_new(size_t, size_t, int (*)(const void *, const void *));
+map_t map_new(size_t, size_t, int (*)(const map_node *, const map_node *));
 
 /* Add function */
 bool map_insert(map_t, void *, void *);
@@ -84,8 +703,3 @@ void map_clear(map_t);
 
 /* Destructor */
 void map_delete(map_t);
-
-#define map_init(key_type, element_type, __func) \
-    map_new(sizeof(key_type), sizeof(element_type), __func)
-
-#define map_iter_value(it, type) (*(type *) (it)->node->data)


### PR DESCRIPTION
`map.[ch]` is the C Implementation for C++ std::map using red-black tree. It works well, but there is room for improvements.

Close https://github.com/sysprog21/rv32emu/issues/29