### PR TITLE
Introduce preliminary macro operation fusion

### DIFF
--- a/src/decode.h
+++ b/src/decode.h
@@ -156,7 +156,14 @@
         _(cjalr, 1)                        \
         _(cadd, 0)                         \
         _(cswsp, 0)                        \
-    )
+    )                                      \
+    /* macro operation fusion: convert specific RISC-V instruction patterns 
+     * into faster and equivalent code 
+     */                                    \
+    _(fuse1, 0)                            \
+    _(fuse2, 0)                            \
+    _(fuse3, 0)                            \
+    _(fuse4, 0)
 /* clang-format on */
 
 /* IR list */
@@ -228,6 +235,11 @@ enum {
     INSN_32 = 4,
 };
 
+typedef struct {
+    int32_t imm;
+    uint8_t rd, rs1, rs2;
+} opcode_fuse_t;
+
 typedef struct rv_insn {
     union {
         int32_t imm;
@@ -240,6 +252,9 @@ typedef struct rv_insn {
 #if RV32_HAS(EXT_C)
     uint8_t shamt;
 #endif
+    /* fuse operation */
+    int16_t imm2;
+    opcode_fuse_t *fuse;
 
     /* instruction length */
     uint8_t insn_len;

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -25,6 +25,8 @@ void block_map_clear(block_map_t *map)
         block_t *block = map->map[i];
         if (!block)
             continue;
+        for (uint32_t i = 0; i < block->n_insn; i++)
+            free(block->ir[i].fuse);
         free(block->ir);
         free(block);
         map->map[i] = NULL;


### PR DESCRIPTION
Through our observations, we have identified certain patterns in instruction sequences. By converting these specific RISC-V instruction patterns into faster and equivalent code, we can significantly improve execution efficiency.

In our current analysis, we focus on a commonly used benchmark and have found the following frequently occurring instruction patterns: auipc + addi, auipc + add, multiple sw, and multiple lw.

|Metric| commit fba5802 | macro fuse operation |Speedup|
|--------| -------- | -------- | -------- | 
| CoreMark | 1351.065 (Iterations/Sec)| 1352.843 (Iterations/Sec) |+0.13％|
| dhrystone  |1073 DMIPS |1146 DMIPS |+6.8%|
| nqueens |8295 msec    | 7824  msec   |+6.0%| 
