### PR TITLE
Introduce baseline JIT compiler

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,10 @@ jobs:
     - name: gdbstub test
       run: |
             make gdbstub-test
+    - name: JIT test
+      run: |
+            make ENABLE_JIT=1 clean all
+            make check
 
   coding_style:
     runs-on: ubuntu-22.04

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "mini-gdbstub"]
 	path = src/mini-gdbstub
 	url = https://github.com/RinHizakura/mini-gdbstub
+[submodule "src/mir"]
+	path = src/mir
+	url = https://github.com/vnmakarov/mir

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,27 @@ gdbstub-test: $(BIN)
 	$(Q).ci/gdbstub-test.sh && $(call notice, [OK])
 endif
 
+ENABLE_JIT ?= 0
+$(call set-feature, JIT)
+ifeq ($(call has, JIT), 1)
+CFLAGS += -I./src/mir
+LDFLAGS += src/mir/libmir.a -lpthread
+OBJS_EXT += compile.o
+
+src/jit_template.c:
+	$(Q)tools/gen-jit-template.py $(CFLAGS) > $@
+	
+src/mir/GNUmakefile:
+	git submodule update --init $(dir $@)
+	
+src/mir/libmir.a: src/mir/GNUmakefile
+	$(MAKE) --quiet -C src/mir
+
+$(OUT)/compile.o: src/compile.c src/mir/libmir.a src/jit_template.c
+	$(VECHO) "  CC\t$@\n"
+	$(Q)$(CC) -o $@ $(CFLAGS) -c -MMD -MF $@.d $<
+endif
+
 # For tail-call elimination, we need a specific set of build flags applied.
 # FIXME: On macOS + Apple Silicon, -fno-stack-protector might have a negative impact.
 $(OUT)/emulate.o: CFLAGS += -fomit-frame-pointer -fno-stack-check -fno-stack-protector
@@ -104,6 +125,9 @@ OBJS := \
 
 OBJS := $(addprefix $(OUT)/, $(OBJS))
 deps := $(OBJS:%.o=%.o.d)
+ifeq ($(call has, JIT), 1)
+OBJS += src/mir/libmir.a
+endif
 
 $(OUT)/%.o: src/%.c
 	$(VECHO) "  CC\t$@\n"
@@ -159,7 +183,7 @@ endif
 endif
 
 clean:
-	$(RM) $(BIN) $(OBJS) $(deps) $(CACHE_OUT)
+	$(RM) $(BIN) $(OBJS) $(deps) $(CACHE_OUT) src/jit_template.c
 distclean: clean
 	-$(RM) $(DOOM_DATA) $(QUAKE_DATA)
 	$(RM) -r $(OUT)/id1

--- a/src/cache.h
+++ b/src/cache.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <stdint.h>
 
 struct cache;
@@ -38,3 +39,15 @@ void *cache_put(struct cache *cache, uint32_t key, void *value);
  * @callback: a function for freeing cache entry completely
  */
 void cache_free(struct cache *cache, void (*callback)(void *));
+
+#if RV32_HAS(JIT)
+bool cache_hot(struct cache *cache, uint32_t key);
+
+uint8_t *code_cache_lookup(struct cache *cache, uint32_t key);
+
+uint8_t *code_cache_add(struct cache *cache,
+                        uint64_t key,
+                        uint8_t *code,
+                        size_t sz,
+                        uint64_t align);
+#endif

--- a/src/compile.c
+++ b/src/compile.c
@@ -1,0 +1,407 @@
+/*
+ * rv32emu is freely redistributable under the MIT License. See the file
+ * "LICENSE" for information on usage and redistribution of this file.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "c2mir/c2mir.h"
+#include "cache.h"
+#include "compile.h"
+#include "decode.h"
+#include "mir-gen.h"
+#include "mir.h"
+#include "riscv_private.h"
+#include "utils.h"
+
+typedef struct {
+    char *code;
+    size_t code_size;
+    size_t curr;
+} jit_item_t;
+
+typedef struct {
+    MIR_context_t ctx;
+    struct c2mir_options *options;
+    uint8_t debug_level;
+    uint8_t optimize_level;
+} riscv_jit_t;
+
+typedef struct {
+    char *name;
+    void *func;
+} func_obj_t;
+
+#define SET_SIZE_BITS 10
+#define SET_SIZE 1 << SET_SIZE_BITS
+#define HASH(val) \
+    (((val) * (GOLDEN_RATIO_32)) >> (32 - SET_SIZE_BITS)) & ((SET_SIZE) -1)
+
+typedef struct {
+    uint32_t table[SET_SIZE][32];
+} set_t;
+
+static inline void set_reset(set_t *set)
+{
+    memset(set, 0, sizeof(set_t));
+}
+
+static bool set_add(set_t *set, uint32_t key)
+{
+    uint32_t index = HASH(key);
+    uint8_t count = 0;
+    while (set->table[index][count]) {
+        if (set->table[index][count++] == key)
+            return false;
+    }
+
+    set->table[index][count] = key;
+    return true;
+}
+
+static bool set_has(set_t *set, uint32_t key)
+{
+    uint32_t index = HASH(key);
+    uint8_t count = 0;
+    while (set->table[index][count]) {
+        if (set->table[index][count++] == key)
+            return true;
+    }
+    return false;
+}
+
+static bool insn_is_branch(uint8_t opcode)
+{
+    switch (opcode) {
+#define _(inst, can_branch) IIF(can_branch)(case rv_insn_##inst:, )
+        RISCV_INSN_LIST
+#undef _
+        return true;
+    }
+    return false;
+}
+
+typedef void (*gen_func_t)(riscv_t *, const rv_insn_t *, char *, uint32_t);
+static gen_func_t dispatch_table[N_RV_INSN];
+static char funcbuf[128] = {0};
+#define GEN(...)                   \
+    sprintf(funcbuf, __VA_ARGS__); \
+    strcat(gencode, funcbuf);
+#define UPDATE_PC(inc) GEN("  rv->PC += %d;\n", inc)
+#define NEXT_INSN(target) GEN("  goto insn_%x;\n", target)
+#define RVOP(inst, code)                                            \
+    static void gen_##inst(riscv_t *rv UNUSED, const rv_insn_t *ir, \
+                           char *gencode, uint32_t pc)              \
+    {                                                               \
+        GEN("insn_%x:\n"                                            \
+            "  rv->X[0] = 0;\n"                                     \
+            "  rv->csr_cycle++;\n",                                 \
+            (pc));                                                  \
+        code;                                                       \
+        if (!insn_is_branch(ir->opcode)) {                          \
+            GEN("  rv->PC += ir->insn_len;\n");                     \
+            GEN("  ir = ir + 1;\n");                                \
+            NEXT_INSN(pc + ir->insn_len);                           \
+        }                                                           \
+    }
+
+#include "jit_template.c"
+/*
+ * In the decoding and emulation stage, specific information is stored in the
+ * IR, such as register numbers and immediates. We can leverage this information
+ * to generate more efficient code instead of relying on the original source
+ * code.
+ */
+RVOP(jal, {
+    GEN("  pc = rv->PC;\n");
+    UPDATE_PC(ir->imm);
+    if (ir->rd) {
+        GEN("  rv->X[%u] = pc + %u;\n", ir->rd, ir->insn_len);
+    }
+    GEN("  ir = ir->branch_taken;\n");
+    NEXT_INSN(pc + ir->imm);
+})
+
+#define BRNACH_FUNC(type, comp)                                               \
+    GEN("  if ((%s) rv->X[%u] %s (%s) rv->X[%u]) {\n", #type, ir->rs1, #comp, \
+        #type, ir->rs2);                                                      \
+    UPDATE_PC(ir->imm);                                                       \
+    if (ir->branch_taken) {                                                   \
+        GEN("    ir = ir->branch_taken;\n");                                  \
+        NEXT_INSN(pc + ir->imm);                                              \
+    } else                                                                    \
+        GEN("    return true;\n");                                            \
+    GEN("  }\n");                                                             \
+    UPDATE_PC(ir->insn_len);                                                  \
+    if (ir->branch_untaken) {                                                 \
+        GEN("  ir = ir->branch_untaken;\n");                                  \
+        NEXT_INSN(pc + ir->insn_len);                                         \
+    } else                                                                    \
+        GEN("  return true;\n");
+
+RVOP(beq, { BRNACH_FUNC(uint32_t, ==); })
+
+RVOP(bne, { BRNACH_FUNC(uint32_t, !=); })
+
+RVOP(blt, { BRNACH_FUNC(int32_t, <); })
+
+RVOP(bge, { BRNACH_FUNC(int32_t, >=); })
+
+RVOP(bltu, { BRNACH_FUNC(uint32_t, <); })
+
+RVOP(bgeu, { BRNACH_FUNC(uint32_t, >=); })
+
+RVOP(lb, {
+    GEN("  addr = rv->X[%u] + %u;\n", ir->rs1, ir->imm);
+    GEN("  c = m->chunks[addr >> 16];\n");
+    GEN("  rv->X[%u] = sign_extend_b(* (const uint32_t *) (c->data + "
+        "(addr & 0xffff)));\n",
+        ir->rd);
+})
+
+RVOP(lh, {
+    GEN("  addr = rv->X[%u] + %u;\n", ir->rs1, ir->imm);
+    GEN("  c = m->chunks[addr >> 16];\n");
+    GEN("  rv->X[%u] = sign_extend_h(* (const uint32_t *) (c->data + "
+        "(addr & 0xffff)));\n",
+        ir->rd);
+})
+
+#define MEMORY_FUNC(type, IO)                                                \
+    GEN("  addr = rv->X[%u] + %u;\n", ir->rs1, ir->imm);                     \
+    GEN("  c = m->chunks[addr >> 16];\n");                                   \
+    IIF(IO)                                                                  \
+    (GEN("  rv->X[%u] = * (const %s *) (c->data + (addr & 0xffff));\n",      \
+         ir->rd, #type),                                                     \
+     GEN("  *(%s *) (c->data + (addr & 0xffff)) = (%s) rv->X[%u];\n", #type, \
+         #type, ir->rs2));
+
+RVOP(lw, {MEMORY_FUNC(uint32_t, 1)})
+
+RVOP(lbu, {MEMORY_FUNC(uint8_t, 1)})
+
+RVOP(lhu, {MEMORY_FUNC(uint16_t, 1)})
+
+RVOP(sb, {MEMORY_FUNC(uint8_t, 0)})
+
+RVOP(sh, {MEMORY_FUNC(uint16_t, 0)})
+
+RVOP(sw, {MEMORY_FUNC(uint32_t, 0)})
+
+#if RV32_HAS(EXT_C)
+RVOP(clw, {
+    GEN("  addr = rv->X[%u] + %u;\n", ir->rs1, ir->imm);
+    GEN("  c = m->chunks[addr >> 16];\n");
+    GEN("  rv->X[%u] = * (const uint32_t *) (c->data + (addr & "
+        "0xffff));\n",
+        ir->rd);
+})
+
+RVOP(csw, {
+    GEN("  addr = rv->X[%u] + %u;\n", ir->rs1, ir->imm);
+    GEN("  c = m->chunks[addr >> 16];\n");
+    GEN("  *(uint32_t *) (c->data + (addr & 0xffff)) = rv->X[%u];\n", ir->rs2);
+})
+
+RVOP(cjal, {
+    GEN("  rv->X[1] = rv->PC += %u;\n", ir->insn_len);
+    UPDATE_PC(ir->imm);
+    GEN("  ir = ir->branch_taken;\n");
+    NEXT_INSN(pc + ir->imm);
+})
+
+RVOP(cj, {
+    UPDATE_PC(ir->imm);
+    GEN("  ir = ir->branch_taken;\n");
+    NEXT_INSN(pc + ir->imm);
+})
+
+RVOP(cbeqz, {
+    GEN("  if (!rv->X[%u]){\n", ir->rs1);
+    UPDATE_PC(ir->imm);
+    if (ir->branch_taken) {
+        GEN("    ir = ir->branch_taken;\n");
+        NEXT_INSN(pc + ir->imm);
+    } else
+        GEN("    return true;\n");
+    GEN("  }\n");
+    UPDATE_PC(ir->insn_len);
+    if (ir->branch_untaken) {
+        GEN("  ir = ir->branch_untaken;\n");
+        NEXT_INSN(pc + ir->insn_len);
+    } else
+        GEN("  return true;\n");
+})
+
+RVOP(cbnez, {
+    GEN("  if (rv->X[%u]){\n", ir->rs1);
+    UPDATE_PC(ir->imm);
+    if (ir->branch_taken) {
+        GEN("    ir = ir->branch_taken;\n");
+        NEXT_INSN(pc + ir->imm);
+    } else
+        GEN("    return true;\n");
+    GEN("  }\n");
+    UPDATE_PC(ir->insn_len);
+    if (ir->branch_untaken) {
+        GEN("  ir = ir->branch_untaken;\n");
+        NEXT_INSN(pc + ir->insn_len);
+    } else
+        GEN("  return true;\n");
+})
+#endif
+
+RVOP(fuse3, {
+    opcode_fuse_t *fuse = ir->fuse;
+    for (int i = 0; i < ir->imm2; i++) {
+        GEN("  addr = rv->X[%u] + %u;\n", fuse[i].rs1, fuse[i].imm);
+        GEN("  c = m->chunks[addr >> 16];\n");
+        GEN("  *(uint32_t *) (c->data + (addr & 0xffff)) = rv->X[%u];\n",
+            fuse[i].rs2);
+    }
+})
+
+RVOP(fuse4, {
+    opcode_fuse_t *fuse = ir->fuse;
+    for (int i = 0; i < ir->imm2; i++) {
+        GEN("  addr = rv->X[%u] + %u;\n", fuse[i].rs1, fuse[i].imm);
+        GEN("  c = m->chunks[addr >> 16];\n");
+        GEN("  rv->X[%u] = * (const uint32_t *) (c->data + (addr & "
+            "0xffff));\n",
+            fuse[i].rd);
+    }
+})
+#undef RVOP
+
+static void trace_ebb(riscv_t *rv, char *gencode, rv_insn_t *ir, set_t *set)
+{
+    while (1) {
+        if (set_add(set, ir->pc))
+            dispatch_table[ir->opcode](rv, ir, gencode, ir->pc);
+
+        if (ir->tailcall)
+            break;
+        ir++;
+    }
+    if (ir->branch_untaken && !set_has(set, ir->branch_untaken->pc))
+        trace_ebb(rv, gencode, ir->branch_untaken, set);
+    if (ir->branch_taken && !set_has(set, ir->branch_taken->pc))
+        trace_ebb(rv, gencode, ir->branch_taken, set);
+}
+
+#define EPILOGUE "}"
+
+static void trace_and_gencode(riscv_t *rv, char *gencode)
+{
+#define _(inst, can_branch) dispatch_table[rv_insn_##inst] = &gen_##inst;
+    RISCV_INSN_LIST
+#undef _
+    set_t set;
+    strcat(gencode, PROLOGUE);
+    set_reset(&set);
+    block_t *block = cache_get(rv->cache, rv->PC);
+    trace_ebb(rv, gencode, block->ir, &set);
+    strcat(gencode, EPILOGUE);
+}
+
+static int get_func(void *data)
+{
+    jit_item_t *item = data;
+    return item->curr >= item->code_size ? EOF : item->code[item->curr++];
+}
+
+#define DLIST_ITEM_FOREACH(modules, item)                     \
+    for (item = DLIST_HEAD(MIR_item_t, modules->items); item; \
+         item = DLIST_NEXT(MIR_item_t, item))
+
+static void *import_resolver(const char *name)
+{
+    func_obj_t func_list[] = {
+        {"sign_extend_b", sign_extend_b},
+        {"sign_extend_h", sign_extend_h},
+#if RV32_HAS(Zicsr)
+        {"csr_csrrw", csr_csrrw},
+        {"csr_csrrs", csr_csrrs},
+        {"csr_csrrc", csr_csrrc},
+#endif
+#if RV32_HAS(EXT_F)
+        {"isnanf", isnanf},
+        {"isinff", isinff},
+        {"sqrtf", sqrtf},
+        {"calc_fclass", calc_fclass},
+        {"is_nan", is_nan},
+        {"is_snan", is_snan},
+#endif
+        {NULL, NULL},
+    };
+    for (int i = 0; func_list[i].name; i++) {
+        if (!strcmp(name, func_list[i].name))
+            return func_list[i].func;
+    }
+    return NULL;
+}
+
+static riscv_jit_t *jit = NULL;
+static jit_item_t *jit_ptr = NULL;
+
+/* TODO: fix error when running on ARM architecture */
+static uint8_t *compile(riscv_t *rv)
+{
+    char func_name[25];
+    snprintf(func_name, 25, "jit_func_%d", rv->PC);
+    c2mir_init(jit->ctx);
+    size_t gen_num = 0;
+    MIR_gen_init(jit->ctx, gen_num);
+    MIR_gen_set_optimize_level(jit->ctx, gen_num, jit->optimize_level);
+    if (!c2mir_compile(jit->ctx, jit->options, get_func, jit_ptr, func_name,
+                       NULL)) {
+        perror("Compile failure");
+        exit(EXIT_FAILURE);
+    }
+    MIR_module_t module =
+        DLIST_TAIL(MIR_module_t, *MIR_get_module_list(jit->ctx));
+    MIR_load_module(jit->ctx, module);
+    MIR_link(jit->ctx, MIR_set_gen_interface, import_resolver);
+    MIR_item_t func = DLIST_HEAD(MIR_item_t, module->items);
+    size_t code_len = 0;
+    size_t func_len = DLIST_LENGTH(MIR_item_t, module->items);
+    for (size_t i = 0; i < func_len; i++, func = DLIST_NEXT(MIR_item_t, func)) {
+        if (func->item_type == MIR_func_item) {
+            uint32_t *tmp = (uint32_t *) func->addr;
+            while (*tmp) {
+                code_len += 4;
+                tmp += 1;
+            }
+            break;
+        }
+    }
+
+    MIR_gen_finish(jit->ctx);
+    c2mir_finish(jit->ctx);
+    return code_cache_add(rv->cache, rv->PC, func->addr, code_len, 4);
+}
+
+uint8_t *block_compile(riscv_t *rv)
+{
+    if (!jit) {
+        jit = calloc(1, sizeof(riscv_jit_t));
+        jit->options = calloc(1, sizeof(struct c2mir_options));
+        jit->ctx = MIR_init();
+        jit->optimize_level = 1;
+    }
+
+    if (!jit_ptr) {
+        jit_ptr = malloc(sizeof(jit_item_t));
+        jit_ptr->curr = 0;
+        jit_ptr->code = calloc(1, 1024 * 1024);
+    } else {
+        jit_ptr->curr = 0;
+        memset(jit_ptr->code, 0, 1024 * 1024);
+    }
+    trace_and_gencode(rv, jit_ptr->code);
+    jit_ptr->code_size = strlen(jit_ptr->code);
+    return compile(rv);
+}

--- a/src/compile.h
+++ b/src/compile.h
@@ -1,0 +1,11 @@
+/*
+ * rv32emu is freely redistributable under the MIT License. See the file
+ * "LICENSE" for information on usage and redistribution of this file.
+ */
+
+#pragma once
+#include <stdint.h>
+
+#include "riscv.h"
+
+uint8_t *block_compile(riscv_t *rv);

--- a/src/decode.h
+++ b/src/decode.h
@@ -171,6 +171,7 @@ enum {
 #define _(inst, can_branch) rv_insn_##inst,
     RISCV_INSN_LIST
 #undef _
+        N_RV_INSN,
 };
 
 /* clang-format off */
@@ -283,6 +284,9 @@ typedef struct rv_insn {
      * specific IR array without the need for additional copying.
      */
     struct rv_insn *branch_taken, *branch_untaken;
+#if RV32_HAS(JIT)
+    uint32_t pc;
+#endif
 } rv_insn_t;
 
 /* decode the RISC-V instruction */

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -12,17 +12,6 @@
 #if RV32_HAS(EXT_F)
 #include <math.h>
 #include "softfloat.h"
-
-#if defined(__APPLE__)
-static inline int isinff(float x)
-{
-    return __builtin_fabsf(x) == __builtin_inff();
-}
-static inline int isnanf(float x)
-{
-    return x != x;
-}
-#endif
 #endif /* RV32_HAS(EXT_F) */
 
 #if RV32_HAS(GDBSTUB)
@@ -34,6 +23,10 @@ extern struct target_ops gdbstub_ops;
 #include "riscv_private.h"
 #include "state.h"
 #include "utils.h"
+#if RV32_HAS(JIT)
+#include "cache.h"
+#include "compile.h"
+#endif
 
 /* RISC-V exception code list */
 #define RV_EXCEPTION_LIST                                       \
@@ -107,139 +100,6 @@ RV_EXCEPTION_LIST
         rv_except_##type##_misaligned(rv, IIF(IO)(addr, mask_or_pc)); \
         return false;                                                 \
     }
-
-/* get current time in microsecnds and update csr_time register */
-static inline void update_time(riscv_t *rv)
-{
-    struct timeval tv;
-    rv_gettimeofday(&tv);
-
-    uint64_t t = (uint64_t) tv.tv_sec * 1e6 + (uint32_t) tv.tv_usec;
-    rv->csr_time[0] = t & 0xFFFFFFFF;
-    rv->csr_time[1] = t >> 32;
-}
-
-#if RV32_HAS(Zicsr)
-/* get a pointer to a CSR */
-static uint32_t *csr_get_ptr(riscv_t *rv, uint32_t csr)
-{
-    /* csr & 0xFFF prevent sign-extension in decode stage */
-    switch (csr & 0xFFF) {
-    case CSR_MSTATUS: /* Machine Status */
-        return (uint32_t *) (&rv->csr_mstatus);
-    case CSR_MTVEC: /* Machine Trap Handler */
-        return (uint32_t *) (&rv->csr_mtvec);
-    case CSR_MISA: /* Machine ISA and Extensions */
-        return (uint32_t *) (&rv->csr_misa);
-
-    /* Machine Trap Handling */
-    case CSR_MSCRATCH: /* Machine Scratch Register */
-        return (uint32_t *) (&rv->csr_mscratch);
-    case CSR_MEPC: /* Machine Exception Program Counter */
-        return (uint32_t *) (&rv->csr_mepc);
-    case CSR_MCAUSE: /* Machine Exception Cause */
-        return (uint32_t *) (&rv->csr_mcause);
-    case CSR_MTVAL: /* Machine Trap Value */
-        return (uint32_t *) (&rv->csr_mtval);
-    case CSR_MIP: /* Machine Interrupt Pending */
-        return (uint32_t *) (&rv->csr_mip);
-
-    /* Machine Counter/Timers */
-    case CSR_CYCLE: /* Cycle counter for RDCYCLE instruction */
-        return (uint32_t *) &rv->csr_cycle;
-    case CSR_CYCLEH: /* Upper 32 bits of cycle */
-        return &((uint32_t *) &rv->csr_cycle)[1];
-
-    /* TIME/TIMEH - very roughly about 1 ms per tick */
-    case CSR_TIME: { /* Timer for RDTIME instruction */
-        update_time(rv);
-        return &rv->csr_time[0];
-    }
-    case CSR_TIMEH: { /* Upper 32 bits of time */
-        update_time(rv);
-        return &rv->csr_time[1];
-    }
-    case CSR_INSTRET: /* Number of Instructions Retired Counter */
-        /* Number of Instructions Retired Counter, just use cycle */
-        return (uint32_t *) (&rv->csr_cycle);
-#if RV32_HAS(EXT_F)
-    case CSR_FFLAGS:
-        return (uint32_t *) (&rv->csr_fcsr);
-    case CSR_FCSR:
-        return (uint32_t *) (&rv->csr_fcsr);
-#endif
-    default:
-        return NULL;
-    }
-}
-
-static inline bool csr_is_writable(uint32_t csr)
-{
-    return csr < 0xc00;
-}
-
-/* CSRRW (Atomic Read/Write CSR) instruction atomically swaps values in the
- * CSRs and integer registers. CSRRW reads the old value of the CSR,
- * zero-extends the value to XLEN bits, and then writes it to register rd.
- * The initial value in rs1 is written to the CSR.
- * If rd == x0, then the instruction shall not read the CSR and shall not cause
- * any of the side effects that might occur on a CSR read.
- */
-static uint32_t csr_csrrw(riscv_t *rv, uint32_t csr, uint32_t val)
-{
-    uint32_t *c = csr_get_ptr(rv, csr);
-    if (!c)
-        return 0;
-
-    uint32_t out = *c;
-#if RV32_HAS(EXT_F)
-    if (csr == CSR_FFLAGS)
-        out &= FFLAG_MASK;
-#endif
-    if (csr_is_writable(csr))
-        *c = val;
-
-    return out;
-}
-
-/* perform csrrs (atomic read and set) */
-static uint32_t csr_csrrs(riscv_t *rv, uint32_t csr, uint32_t val)
-{
-    uint32_t *c = csr_get_ptr(rv, csr);
-    if (!c)
-        return 0;
-
-    uint32_t out = *c;
-#if RV32_HAS(EXT_F)
-    if (csr == CSR_FFLAGS)
-        out &= FFLAG_MASK;
-#endif
-    if (csr_is_writable(csr))
-        *c |= val;
-
-    return out;
-}
-
-/* perform csrrc (atomic read and clear)
- * Read old value of CSR, zero-extend to XLEN bits, write to rd.
- * Read value from rs1, use as bit mask to clear bits in CSR.
- */
-static uint32_t csr_csrrc(riscv_t *rv, uint32_t csr, uint32_t val)
-{
-    uint32_t *c = csr_get_ptr(rv, csr);
-    if (!c)
-        return 0;
-
-    uint32_t out = *c;
-#if RV32_HAS(EXT_F)
-    if (csr == CSR_FFLAGS)
-        out &= FFLAG_MASK;
-#endif
-    if (csr_is_writable(csr))
-        *c &= ~val;
-    return out;
-}
-#endif
 
 #if RV32_HAS(GDBSTUB)
 void rv_debug(riscv_t *rv)
@@ -353,6 +213,7 @@ static inline bool insn_is_unconditional_branch(uint8_t opcode)
     return false;
 }
 
+#if !RV32_HAS(JIT)
 /* hash function is used when mapping address into the block map */
 static inline uint32_t hash(size_t k)
 {
@@ -364,6 +225,7 @@ static inline uint32_t hash(size_t k)
 #endif
     return k;
 }
+#endif
 
 /* allocate a basic block */
 static block_t *block_alloc(const uint8_t bits)
@@ -373,9 +235,13 @@ static block_t *block_alloc(const uint8_t bits)
     block->n_insn = 0;
     block->predict = NULL;
     block->ir = malloc(block->insn_capacity * sizeof(rv_insn_t));
+#if RV32_HAS(JIT)
+    block->hot = false;
+#endif
     return block;
 }
 
+#if !RV32_HAS(JIT)
 /* insert a block into block map */
 static void block_insert(block_map_t *map, const block_t *block)
 {
@@ -411,6 +277,7 @@ static block_t *block_find(const block_map_t *map, const uint32_t addr)
     }
     return NULL;
 }
+#endif
 
 static void block_translate(riscv_t *rv, block_t *block)
 {
@@ -431,6 +298,9 @@ static void block_translate(riscv_t *rv, block_t *block)
             break;
         }
         ir->impl = dispatch_table[ir->opcode];
+#if RV32_HAS(JIT)
+        ir->pc = block->pc_end;
+#endif
         /* compute the end of pc */
         block->pc_end += ir->insn_len;
         block->n_insn++;
@@ -534,16 +404,23 @@ static void match_pattern(block_t *block)
 static block_t *prev = NULL;
 static block_t *block_find_or_translate(riscv_t *rv)
 {
+#if !RV32_HAS(JIT)
     block_map_t *map = &rv->block_map;
+
     /* lookup the next block in the block map */
     block_t *next = block_find(map, rv->PC);
+#else
+    /* lookup the next block in the block cache */
+    block_t *next = (block_t *) cache_get(rv->cache, rv->PC);
+#endif
 
     if (!next) {
+#if !RV32_HAS(JIT)
         if (map->size * 1.25 > map->block_capacity) {
             block_map_clear(map);
             prev = NULL;
         }
-
+#endif
         /* allocate a new block */
         next = block_alloc(10);
 
@@ -555,10 +432,17 @@ static block_t *block_find_or_translate(riscv_t *rv)
             /* macro operation fusion */
             match_pattern(next);
 
-
+#if !RV32_HAS(JIT)
         /* insert the block into block map */
         block_insert(&rv->block_map, next);
-
+#else
+        /* insert the block into block cache */
+        block_t *delete_target = cache_put(rv->cache, rv->PC, &(*next));
+        if (delete_target) {
+            free(delete_target->ir);
+            free(delete_target);
+        }
+#endif
         /* update the block prediction.
          * When translating a new block, the block predictor may benefit,
          * but updating it after finding a particular block may penalize
@@ -570,6 +454,10 @@ static block_t *block_find_or_translate(riscv_t *rv)
 
     return next;
 }
+
+#if RV32_HAS(JIT)
+typedef bool (*exec_block_func_t)(riscv_t *rv, rv_insn_t *ir);
+#endif
 
 void rv_step(riscv_t *rv, int32_t cycles)
 {
@@ -602,7 +490,11 @@ void rv_step(riscv_t *rv, int32_t cycles)
         if (prev) {
             /* updtae previous block */
             if (prev->pc_start != last_pc)
+#if !RV32_HAS(JIT)
                 prev = block_find(&rv->block_map, last_pc);
+#else
+                prev = cache_get(rv->cache, last_pc);
+#endif
 
             rv_insn_t *last_ir = prev->ir + prev->n_insn - 1;
             /* chain block */
@@ -615,7 +507,26 @@ void rv_step(riscv_t *rv, int32_t cycles)
         }
         last_pc = rv->PC;
 
-        /* execute the block */
+#if RV32_HAS(JIT)
+        /* execute the block by JIT compiler */
+        exec_block_func_t code = NULL;
+        if (block->hot)
+            code = (exec_block_func_t) code_cache_lookup(rv->cache,
+                                                         block->pc_start);
+        if (!code) {
+            /* check if using frequency of block exceed threshold */
+            if ((block->hot = cache_hot(rv->cache, block->pc_start)))
+                code = (exec_block_func_t) block_compile(rv);
+        }
+        if (block->hot) {
+            /* execute machine code */
+            if (unlikely(!code(rv, block->ir)))
+                break;
+            prev = block;
+            continue;
+        }
+#endif
+        /* execute the block by interpreter */
         const rv_insn_t *ir = block->ir;
         if (unlikely(!ir->impl(rv, ir)))
             break;

--- a/src/feature.h
+++ b/src/feature.h
@@ -53,6 +53,11 @@
 #define RV32_FEATURE_ARC 0
 #endif
 
+/* Cache */
+#ifndef RV32_FEATURE_JIT
+#define RV32_FEATURE_JIT 0
+#endif
+
 /* Feature test macro */
 #define RV32_HAS(x) RV32_FEATURE_##x
 

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -8,7 +8,9 @@
 #include <string.h>
 
 #include "riscv_private.h"
+#include "utils.h"
 
+#if !RV32_HAS(JIT)
 /* initialize the block map */
 static void block_map_init(block_map_t *map, const uint8_t bits)
 {
@@ -33,6 +35,7 @@ void block_map_clear(block_map_t *map)
     }
     map->size = 0;
 }
+#endif
 
 riscv_user_t rv_userdata(riscv_t *rv)
 {
@@ -92,8 +95,12 @@ riscv_t *rv_create(const riscv_io_t *io,
 
     rv->output_exit_code = output_exit_code;
 
+#if !RV32_HAS(JIT)
     /* initialize the block map */
     block_map_init(&rv->block_map, 10);
+#else
+    rv->cache = cache_create(10);
+#endif
 
     /* reset */
     rv_reset(rv, 0U);
@@ -116,11 +123,23 @@ bool rv_enables_to_output_exit_code(riscv_t *rv)
     return rv->output_exit_code;
 }
 
+#if RV32_HAS(JIT)
+static void release_block(void *block)
+{
+    free(((block_t *) block)->ir);
+    free(block);
+}
+#endif
+
 void rv_delete(riscv_t *rv)
 {
     assert(rv);
+#if !RV32_HAS(JIT)
     block_map_clear(&rv->block_map);
     free(rv->block_map.map);
+#else
+    cache_free(rv->cache, release_block);
+#endif
     free(rv);
 }
 
@@ -148,3 +167,124 @@ void rv_reset(riscv_t *rv, riscv_word_t pc)
 
     rv->halt = false;
 }
+
+/* get current time in microsecnds and update csr_time register */
+static inline void update_time(riscv_t *rv)
+{
+    struct timeval tv;
+    rv_gettimeofday(&tv);
+
+    uint64_t t = (uint64_t) tv.tv_sec * 1e6 + (uint32_t) tv.tv_usec;
+    rv->csr_time[0] = t & 0xFFFFFFFF;
+    rv->csr_time[1] = t >> 32;
+}
+
+#if RV32_HAS(Zicsr)
+/* get a pointer to a CSR */
+static uint32_t *csr_get_ptr(riscv_t *rv, uint32_t csr)
+{
+    /* csr & 0xFFF prevent sign-extension in decode stage */
+    switch (csr & 0xFFF) {
+    case CSR_MSTATUS: /* Machine Status */
+        return (uint32_t *) (&rv->csr_mstatus);
+    case CSR_MTVEC: /* Machine Trap Handler */
+        return (uint32_t *) (&rv->csr_mtvec);
+    case CSR_MISA: /* Machine ISA and Extensions */
+        return (uint32_t *) (&rv->csr_misa);
+
+    /* Machine Trap Handling */
+    case CSR_MSCRATCH: /* Machine Scratch Register */
+        return (uint32_t *) (&rv->csr_mscratch);
+    case CSR_MEPC: /* Machine Exception Program Counter */
+        return (uint32_t *) (&rv->csr_mepc);
+    case CSR_MCAUSE: /* Machine Exception Cause */
+        return (uint32_t *) (&rv->csr_mcause);
+    case CSR_MTVAL: /* Machine Trap Value */
+        return (uint32_t *) (&rv->csr_mtval);
+    case CSR_MIP: /* Machine Interrupt Pending */
+        return (uint32_t *) (&rv->csr_mip);
+
+    /* Machine Counter/Timers */
+    case CSR_CYCLE: /* Cycle counter for RDCYCLE instruction */
+        return &((uint32_t *) &rv->csr_cycle)[0];
+    case CSR_CYCLEH: /* Upper 32 bits of cycle */
+        return &((uint32_t *) &rv->csr_cycle)[1];
+
+    /* TIME/TIMEH - very roughly about 1 ms per tick */
+    case CSR_TIME: { /* Timer for RDTIME instruction */
+        update_time(rv);
+        return &rv->csr_time[0];
+    }
+    case CSR_TIMEH: { /* Upper 32 bits of time */
+        update_time(rv);
+        return &rv->csr_time[1];
+    }
+    case CSR_INSTRET: /* Number of Instructions Retired Counter */
+        /* Number of Instructions Retired Counter, just use cycle */
+        return (uint32_t *) (&rv->csr_cycle);
+#if RV32_HAS(EXT_F)
+    case CSR_FFLAGS:
+        return (uint32_t *) (&rv->csr_fcsr);
+    case CSR_FCSR:
+        return (uint32_t *) (&rv->csr_fcsr);
+#endif
+    default:
+        return NULL;
+    }
+}
+
+static inline bool csr_is_writable(uint32_t csr)
+{
+    return csr < 0xc00;
+}
+
+uint32_t csr_csrrw(riscv_t *rv, uint32_t csr, uint32_t val)
+{
+    uint32_t *c = csr_get_ptr(rv, csr);
+    if (!c)
+        return 0;
+
+    uint32_t out = *c;
+#if RV32_HAS(EXT_F)
+    if (csr == CSR_FFLAGS)
+        out &= FFLAG_MASK;
+#endif
+    if (csr_is_writable(csr))
+        *c = val;
+
+    return out;
+}
+
+uint32_t csr_csrrs(riscv_t *rv, uint32_t csr, uint32_t val)
+{
+    uint32_t *c = csr_get_ptr(rv, csr);
+    if (!c)
+        return 0;
+
+    uint32_t out = *c;
+#if RV32_HAS(EXT_F)
+    if (csr == CSR_FFLAGS)
+        out &= FFLAG_MASK;
+#endif
+    if (csr_is_writable(csr))
+        *c |= val;
+
+    return out;
+}
+
+uint32_t csr_csrrc(riscv_t *rv, uint32_t csr, uint32_t val)
+{
+    uint32_t *c = csr_get_ptr(rv, csr);
+    if (!c)
+        return 0;
+
+    uint32_t out = *c;
+#if RV32_HAS(EXT_F)
+    if (csr == CSR_FFLAGS)
+        out &= FFLAG_MASK;
+#endif
+    if (csr_is_writable(csr))
+        *c &= ~val;
+    return out;
+}
+#endif

--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -3,17 +3,8 @@
  * "LICENSE" for information on usage and redistribution of this file.
  */
 
-/* RV32I Base Instruction Set */
-
 /* Internal */
-static bool do_nop(riscv_t *rv, const rv_insn_t *ir)
-{
-    rv->X[rv_reg_zero] = 0;
-    rv->csr_cycle++;
-    rv->PC += ir->insn_len;
-    const rv_insn_t *next = ir + 1;
-    MUST_TAIL return next->impl(rv, next);
-}
+RVOP(nop, {/* no operation */})
 
 /* LUI is used to build 32-bit constants and uses the U-type format. LUI
  * places the U-immediate value in the top 20 bits of the destination
@@ -334,16 +325,16 @@ RVOP(mul,
 
 /* MULH: Multiply High Signed Signed */
 RVOP(mulh, {
-    const int64_t a = (int32_t) rv->X[ir->rs1];
-    const int64_t b = (int32_t) rv->X[ir->rs2];
-    rv->X[ir->rd] = ((uint64_t) (a * b)) >> 32;
+    const int64_t multiplicand = (int32_t) rv->X[ir->rs1];
+    const int64_t multiplier = (int32_t) rv->X[ir->rs2];
+    rv->X[ir->rd] = ((uint64_t) (multiplicand * multiplier)) >> 32;
 })
 
 /* MULHSU: Multiply High Signed Unsigned */
 RVOP(mulhsu, {
-    const int64_t a = (int32_t) rv->X[ir->rs1];
-    const uint64_t b = rv->X[ir->rs2];
-    rv->X[ir->rd] = ((uint64_t) (a * b)) >> 32;
+    const int64_t multiplicand = (int32_t) rv->X[ir->rs1];
+    const uint64_t umultiplier = rv->X[ir->rs2];
+    rv->X[ir->rd] = ((uint64_t) (multiplicand * umultiplier)) >> 32;
 })
 
 /* MULHU: Multiply High Unsigned Unsigned */
@@ -377,9 +368,9 @@ RVOP(div, {
  * +------------------------+-----------+----------+----------+
  */
 RVOP(divu, {
-    const uint32_t dividend = rv->X[ir->rs1];
-    const uint32_t divisor = rv->X[ir->rs2];
-    rv->X[ir->rd] = !divisor ? ~0U : dividend / divisor;
+    const uint32_t udividend = rv->X[ir->rs1];
+    const uint32_t udivisor = rv->X[ir->rs2];
+    rv->X[ir->rd] = !udivisor ? ~0U : udividend / udivisor;
 })
 
 /* REM: Remainder Signed */
@@ -407,9 +398,9 @@ RVOP(rem, {
  * +------------------------+-----------+----------+----------+
  */
 RVOP(remu, {
-    const uint32_t dividend = rv->X[ir->rs1];
-    const uint32_t divisor = rv->X[ir->rs2];
-    rv->X[ir->rd] = !divisor ? dividend : dividend % divisor;
+    const uint32_t udividend = rv->X[ir->rs1];
+    const uint32_t udivisor = rv->X[ir->rs2];
+    rv->X[ir->rd] = !udivisor ? udividend : udividend % udivisor;
 })
 #endif
 
@@ -473,37 +464,33 @@ RVOP(amoorw, {
 /* AMOMIN.W: Atomic MIN */
 RVOP(amominw, {
     rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
-    const int32_t a = rv->X[ir->rd];
-    const int32_t b = rv->X[ir->rs2];
-    const int32_t res = a < b ? a : b;
+    const int32_t res =
+        rv->X[ir->rd] < rv->X[ir->rs2] ? rv->X[ir->rd] : rv->X[ir->rs2];
     rv->io.mem_write_s(rv, ir->rs1, res);
 })
 
 /* AMOMAX.W: Atomic MAX */
 RVOP(amomaxw, {
     rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
-    const int32_t a = rv->X[ir->rd];
-    const int32_t b = rv->X[ir->rs2];
-    const int32_t res = a > b ? a : b;
+    const int32_t res =
+        rv->X[ir->rd] > rv->X[ir->rs2] ? rv->X[ir->rd] : rv->X[ir->rs2];
     rv->io.mem_write_s(rv, ir->rs1, res);
 })
 
 /* AMOMINU.W */
 RVOP(amominuw, {
     rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
-    const uint32_t a = rv->X[ir->rd];
-    const uint32_t b = rv->X[ir->rs2];
-    const uint32_t res = a < b ? a : b;
-    rv->io.mem_write_s(rv, ir->rs1, res);
+    const uint32_t ures =
+        rv->X[ir->rd] < rv->X[ir->rs2] ? rv->X[ir->rd] : rv->X[ir->rs2];
+    rv->io.mem_write_s(rv, ir->rs1, ures);
 })
 
 /* AMOMAXU.W */
 RVOP(amomaxuw, {
     rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
-    const uint32_t a = rv->X[ir->rd];
-    const uint32_t b = rv->X[ir->rs2];
-    const uint32_t res = a > b ? a : b;
-    rv->io.mem_write_s(rv, ir->rs1, res);
+    const uint32_t ures =
+        rv->X[ir->rd] > rv->X[ir->rs2] ? rv->X[ir->rd] : rv->X[ir->rs2];
+    rv->io.mem_write_s(rv, ir->rs1, ures);
 })
 #endif /* RV32_HAS(EXT_A) */
 
@@ -574,29 +561,23 @@ RVOP(fsqrts, { rv->F[ir->rd] = sqrtf(rv->F[ir->rs1]); })
 
 /* FSGNJ.S */
 RVOP(fsgnjs, {
-    uint32_t f1 = rv->F_int[ir->rs1];
-    uint32_t f2 = rv->F_int[ir->rs2];
-    uint32_t res;
-    res = (f1 & ~FMASK_SIGN) | (f2 & FMASK_SIGN);
-    rv->F_int[ir->rd] = res;
+    const uint32_t ures = (((uint32_t) rv->F_int[ir->rs1]) & ~FMASK_SIGN) |
+                          (((uint32_t) rv->F_int[ir->rs2]) & FMASK_SIGN);
+    rv->F_int[ir->rd] = ures;
 })
 
 /* FSGNJN.S */
 RVOP(fsgnjns, {
-    uint32_t f1 = rv->F_int[ir->rs1];
-    uint32_t f2 = rv->F_int[ir->rs2];
-    uint32_t res;
-    res = (f1 & ~FMASK_SIGN) | (~f2 & FMASK_SIGN);
-    rv->F_int[ir->rd] = res;
+    const uint32_t ures = (((uint32_t) rv->F_int[ir->rs1]) & ~FMASK_SIGN) |
+                          (~((uint32_t) rv->F_int[ir->rs2]) & FMASK_SIGN);
+    rv->F_int[ir->rd] = ures;
 })
 
 /* FSGNJX.S */
 RVOP(fsgnjxs, {
-    uint32_t f1 = rv->F_int[ir->rs1];
-    uint32_t f2 = rv->F_int[ir->rs2];
-    uint32_t res;
-    res = f1 ^ (f2 & FMASK_SIGN);
-    rv->F_int[ir->rd] = res;
+    const uint32_t ures = ((uint32_t) rv->F_int[ir->rs1]) ^
+                          (((uint32_t) rv->F_int[ir->rs2]) & FMASK_SIGN);
+    rv->F_int[ir->rd] = ures;
 })
 
 /* FMIN.S
@@ -620,10 +601,8 @@ RVOP(fmins, {
             rv->F_int[ir->rd] = RV_NAN;
         }
     } else {
-        uint32_t a_sign;
-        uint32_t b_sign;
-        a_sign = a & FMASK_SIGN;
-        b_sign = b & FMASK_SIGN;
+        uint32_t a_sign = a & FMASK_SIGN;
+        uint32_t b_sign = b & FMASK_SIGN;
         if (a_sign != b_sign) {
             rv->F[ir->rd] = a_sign ? rv->F[ir->rs1] : rv->F[ir->rs2];
         } else {
@@ -648,10 +627,8 @@ RVOP(fmaxs, {
             rv->F_int[ir->rd] = RV_NAN;
         }
     } else {
-        uint32_t a_sign;
-        uint32_t b_sign;
-        a_sign = a & FMASK_SIGN;
-        b_sign = b & FMASK_SIGN;
+        uint32_t a_sign = a & FMASK_SIGN;
+        uint32_t b_sign = b & FMASK_SIGN;
         if (a_sign != b_sign) {
             rv->F[ir->rd] = a_sign ? rv->F[ir->rs2] : rv->F[ir->rs1];
         } else {
@@ -932,7 +909,7 @@ RVOP(fuse2, {
 
 /* multiple sw */
 RVOP(fuse3, {
-    opcode_fuse_t *fuse = ir->fuse;
+    const opcode_fuse_t *fuse = ir->fuse;
     uint32_t addr = rv->X[fuse[0].rs1] + fuse[0].imm;
     /* the memory addresses of the sw instructions are contiguous, so we only
      * need to check the first sw instruction to determine if its memory address
@@ -948,7 +925,7 @@ RVOP(fuse3, {
 
 /* multiple lw */
 RVOP(fuse4, {
-    opcode_fuse_t *fuse = ir->fuse;
+    const opcode_fuse_t *fuse = ir->fuse;
     uint32_t addr = rv->X[fuse[0].rs1] + fuse[0].imm;
     /* the memory addresses of the lw instructions are contiguous, so we only
      * need to check the first lw instruction to determine if its memory address

--- a/src/utils.h
+++ b/src/utils.h
@@ -3,6 +3,8 @@
 #include <sys/time.h>
 #include <time.h>
 
+#define GOLDEN_RATIO_32 0x61C88647
+
 /* Obtain the system 's notion of the current Greenwich time.
  * TODO: manipulate current time zone.
  */

--- a/tools/gen-jit-template.py
+++ b/tools/gen-jit-template.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+
+'''
+This script serves as a code generator for creating JIT code templates 
+based on existing code files in the 'src' directory, eliminating the need 
+for writing duplicated code.
+'''
+
+import re
+import sys
+
+INSN = {
+    "Zifencei": ["fencei"],
+    "Zicsr": [
+        "csrrw",
+        "csrrs",
+        "csrrc",
+        "csrrw",
+        "csrrsi",
+        "csrrci"],
+    "EXT_M": [
+        "mul",
+        "mulh",
+        "mulhsu",
+        "mulhu",
+        "div",
+        "divu",
+        "rem",
+        "remu"],
+    "EXT_A": [
+        "lrw",
+        "scw",
+        "amoswapw",
+        "amoaddw",
+        "amoxorw",
+        "amoandw",
+        "amoorw",
+        "amominw",
+        "amomaxw",
+        "amominuw",
+        "amomaxuw"],
+    "EXT_F": [
+        "flw",
+        "fsw",
+        "fmadds",
+        "fmsubs",
+        "fnmsubs",
+        "fnmadds",
+        "fadds",
+        "fsubs",
+        "fmuls",
+        "fdivs",
+        "fsqrts",
+        "fsgnjs",
+        "fsgnjns",
+        "fsgnjxs",
+        "fmins",
+        "fmaxs",
+        "fcvtws",
+        "fcvtwus",
+        "fmvxw",
+        "feqs",
+        "flts",
+        "fles",
+        "fclasss",
+        "fcvtsw",
+        "fcvtswu",
+        "fmvwx"],
+    "EXT_C": [
+        "caddi4spn",
+        "clw",
+        "csw",
+        "cnop",
+        "caddi",
+        "cjal",
+        "cli",
+        "caddi16sp",
+        "clui",
+        "csrli",
+        "csrai",
+        "candi",
+        "csub",
+        "cxor",
+        "cor",
+        "cand",
+        "cj",
+        "cbeqz",
+        "cbnez",
+        "cslli",
+        "clwsp",
+        "cjr",
+        "cmv",
+        "cebreak",
+        "cjalr",
+        "cadd",
+        "cswsp",
+    ],
+}
+EXT_LIST = ["Zifencei", "Zicsr", "EXT_M", "EXT_A", "EXT_F", "EXT_C"]
+SKIPLIST = [
+    "jal",
+    "beq",
+    "bne",
+    "blt",
+    "bge",
+    "bltu",
+    "bgeu",
+    "lb",
+    "lh",
+    "lw",
+    "lbu",
+    "lhu",
+    "sb",
+    "sh",
+    "sw",
+    "clw",
+    "csw",
+    "cjal",
+    "cj",
+    "cbeqz",
+    "cbnez",
+    "fuse3",
+    "fuse4"]
+# check enabled extension in Makefile
+
+def parse_argv(EXT_LIST, SKIPLIST):
+    for argv in sys.argv:
+        if argv.find("RV32_FEATURE_") != -1:
+            ext = argv[argv.find("RV32_FEATURE_") + 13:-2]
+            if argv[-1:] == "1" and EXT_LIST.count(ext):
+                EXT_LIST.remove(ext)
+    for ext in EXT_LIST:
+        SKIPLIST += INSN[ext]
+
+
+def remove_comment(str):
+    return re.sub(r'/\*[\s|\S]+?\*/\n', "", str)
+
+parse_argv(EXT_LIST, SKIPLIST)
+# prepare PROLOGUE
+output = "#define PROLOGUE\\\n  \"#include <stdint.h>\\n\"\\\n \"#include <stdbool.h>\\n\"\\\n"
+f = open('src/riscv.h', 'r')
+lines = f.read()
+lines = remove_comment(lines)
+output = output + "\"" + \
+    re.sub("\n", "\"\\\n\"", re.findall(
+        r'enum[\S|\s]+?riscv_io_t;', lines)[0]) + "\"\\\n"
+f = open('src/riscv_private.h', 'r')
+lines = f.read()
+lines = remove_comment(lines)
+lines = re.sub(r'#if RV32_HAS\(GDBSTUB\)[\s|\S]+?#endif\n', "", lines)
+lines = re.sub(r'#if !RV32_HAS\(JIT\)[\s|\S]+?#endif\n', "", lines)
+lines = re.sub(r"#if RV32_HAS\(EXT_F\)", "", lines)
+lines = re.sub('#endif\n', "", lines)
+output = output + "\"" + \
+    re.sub("\n", "\"\\\n\"", re.findall(
+        r'struct riscv_internal[\S|\s]+?bool output_exit_code;\n};', lines)[0]) + "\"\\\n"
+f = open('src/io.h', 'r')
+lines = f.read()
+lines = remove_comment(lines)
+output = output + "\"" + \
+    re.sub("\n", "\"\\\n\"", re.findall(
+        r'typedef[\S|\s]+?memory_t;', lines)[0]) + "\"\\\n"
+f = open('src/state.h', 'r')
+lines = f.read()
+lines = remove_comment(lines)
+lines = re.sub('map_t fd_map;', "", lines)
+output = output + "\"" + \
+    re.sub("\n", "\"\\\n\"", re.findall(
+        r'typedef[\S|\s]+?state_t;', lines)[0]) + "\"\\\n"
+f = open('src/decode.h', 'r')
+lines = f.read()
+lines = remove_comment(lines)
+lines = re.sub(r'#if[\s|\S]+?\)\n', "", lines)
+lines = re.sub('#endif\n', "", lines)
+output = output + "\"" + \
+    re.sub("\n", "\"\\\n\"", re.findall(
+        r'typedef[\S|\s]+?rv_insn_t;', lines)[0]) + "\"\\\n"
+output += "\"bool start(volatile riscv_t *rv, rv_insn_t *ir) {\"\\\n"
+output += "\" uint32_t pc, addr, udividend, udivisor, tmp, data, mask, ures, \"\\\n"
+output += "\"a, b, jump_to;\"\\\n"
+output += "\"  int32_t dividend, divisor, res;\"\\\n"
+output += "\"  int64_t multiplicand, multiplier;\"\\\n"
+output += "\"  uint64_t umultiplier;\"\\\n"
+output += "\"  memory_t *m = ((state_t *)rv->userdata)->mem;\"\\\n"
+output += "\"  chunk_t *c;\"\n"
+
+f = open('src/rv32_template.c', 'r')
+lines = f.read()
+# remove exception handler
+lines = re.sub(r'RV_EXC[\S]+?\([\S|\s]+?\);\s', "", lines)
+# replace variable
+lines = re.sub(r'const [u]*int[32|64]+_t', "", lines)
+lines = re.sub("uint32_t tmp", "tmp", lines)
+lines = re.sub("uint32_t a", "a", lines)
+lines = re.sub("uint32_t b", "b", lines)
+lines = re.sub("uint32_t a_sign", "a_sign", lines)
+lines = re.sub("uint32_t b_sign", "b_sign", lines)
+lines = re.sub("uint32_t data", "data", lines)
+lines = re.sub("uint32_t bits", "bits", lines)
+str2 = re.findall(r'RVOP\([\s|\S]+?}\)', lines)
+op = []
+impl = []
+for i in range(len(str2)):
+    tmp = remove_comment(str2[i])
+    op.append(tmp[5:tmp.find(',')])
+    impl.append(tmp[tmp.find('{') + 1:-2])
+
+f.close()
+# generate jit template
+for i in range(len(str2)):
+    if (not SKIPLIST.count(op[i])):
+        output = output + "RVOP(" + op[i] + ", { strcat(gencode, "
+        substr = impl[i].split("\n")
+        for str in substr:
+            if (str != ""):
+                output = output + '\"' + str + '\\n\"'
+        output = output + ");})\n"
+sys.stdout.write(output)


### PR DESCRIPTION
The baseline JIT compiler design involves tracing an EBB when its usage frequency exceeds a predetermined threshold. We then utilize a code generator to convert the instruction sequence into C code. The C code is subsequently compiled using mir, and the resulting target machine code is stored in the code cache for future utilization.

The primary objective of introducing the baseline JIT compiler is to enhance the execution speed of RISC-V instructions with minimal modification. This implementation requires three additional components: a code generator, mir compiler, and code cache, while maintaining the original design of the interpreter. Furthermore, this baseline JIT compiler serves as the foundational target for future improvements.

|Metric|  master| baseline JIT|Speedup|
|--------| -------- | -------- | -------- | 
| CoreMark | 1352.843 (Iterations/Sec)|1740.881 (Iterations/Sec) |+28.6％|
| dhrystone  |1146 DMIPS |2368.33DMIPS |+106%|