### PR TITLE
Fix incorrect performance counter

### DIFF
--- a/src/emulate.c
+++ b/src/emulate.c
@@ -123,7 +123,8 @@ static inline void update_time(riscv_t *rv)
 /* get a pointer to a CSR */
 static uint32_t *csr_get_ptr(riscv_t *rv, uint32_t csr)
 {
-    switch (csr) {
+    /* csr & 0xFFF prevent sign-extension in decode stage */
+    switch (csr & 0xFFF) {
     case CSR_MSTATUS: /* Machine Status */
         return (uint32_t *) (&rv->csr_mstatus);
     case CSR_MTVEC: /* Machine Trap Handler */


### PR DESCRIPTION
The issue occurs when the variable csr undergoes sign-extension. Specifically, the values of CSR_CYCLE and CSR_CYCLEH are assigned as 0xC00 and 0xC80 respectively. During the decoding immediate stage, these values are unintentionally sign-extended to 0xFFFFFC00 and 0xFFFFFC80. To mitigate this problem, a solution is only the last 12 bits of csr are considered, disregarding the sign extension.

Solve: #139