### PR TITLE
Refactor code cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,10 @@ jobs:
     - name: gdbstub test
       run: |
             make gdbstub-test
+    - name: JIT test
+      run: |
+            make ENABLE_JIT=1 clean all
+            make check
 
   coding_style:
     runs-on: ubuntu-22.04

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "mini-gdbstub"]
 	path = src/mini-gdbstub
 	url = https://github.com/RinHizakura/mini-gdbstub
+[submodule "src/mir"]
+	path = src/mir
+	url = https://github.com/vnmakarov/mir

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Visit our [Issues page on GitHub](https://github.com/sysprog21/rv32emu/issues) t
 
 ## Coding Convention
 
-We welcome all contributions from corporate, acaddemic and individual developers. However, there are a number of fundamental ground rules that you must adhere to in order to participate. These rules are outlined as follows:
+We welcome all contributions from corporate, academic and individual developers. However, there are a number of fundamental ground rules that you must adhere to in order to participate. These rules are outlined as follows:
 * All code must adhere to the existing C coding style (see below). While we are somewhat flexible in basic style, you will adhere to what is currently in place. Uncommented, complicated algorithmic constructs will be rejected.
 * All external pull requests must contain sufficient documentation in the pull request comments in order to be accepted.
 

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,27 @@ gdbstub-test: $(BIN)
 	$(Q).ci/gdbstub-test.sh && $(call notice, [OK])
 endif
 
+ENABLE_JIT ?= 0
+$(call set-feature, JIT)
+ifeq ($(call has, JIT), 1)
+CFLAGS += -I./src/mir
+LDFLAGS += src/mir/libmir.a -lpthread
+OBJS_EXT += compile.o
+
+src/jit_template.c:
+	$(Q)tools/gen-jit-template.py $(CFLAGS) > $@
+	
+src/mir/GNUmakefile:
+	git submodule update --init $(dir $@)
+	
+src/mir/libmir.a: src/mir/GNUmakefile
+	$(MAKE) --quiet -C src/mir
+
+$(OUT)/compile.o: src/compile.c src/mir/libmir.a src/jit_template.c
+	$(VECHO) "  CC\t$@\n"
+	$(Q)$(CC) -o $@ $(CFLAGS) -c -MMD -MF $@.d $<
+endif
+
 # For tail-call elimination, we need a specific set of build flags applied.
 # FIXME: On macOS + Apple Silicon, -fno-stack-protector might have a negative impact.
 $(OUT)/emulate.o: CFLAGS += -fomit-frame-pointer -fno-stack-check -fno-stack-protector
@@ -104,6 +125,9 @@ OBJS := \
 
 OBJS := $(addprefix $(OUT)/, $(OBJS))
 deps := $(OBJS:%.o=%.o.d)
+ifeq ($(call has, JIT), 1)
+OBJS += src/mir/libmir.a
+endif
 
 $(OUT)/%.o: src/%.c
 	$(VECHO) "  CC\t$@\n"
@@ -159,7 +183,7 @@ endif
 endif
 
 clean:
-	$(RM) $(BIN) $(OBJS) $(deps) $(CACHE_OUT)
+	$(RM) $(BIN) $(OBJS) $(deps) $(CACHE_OUT) src/jit_template.c
 distclean: clean
 	-$(RM) $(DOOM_DATA) $(QUAKE_DATA)
 	$(RM) -r $(OUT)/id1

--- a/src/cache.h
+++ b/src/cache.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <stdint.h>
 
 struct cache;
@@ -38,3 +39,7 @@ void *cache_put(struct cache *cache, uint32_t key, void *value);
  * @callback: a function for freeing cache entry completely
  */
 void cache_free(struct cache *cache, void (*callback)(void *));
+
+#if RV32_HAS(JIT)
+bool cache_hot(struct cache *cache, uint32_t key);
+#endif

--- a/src/compile.c
+++ b/src/compile.c
@@ -1,0 +1,411 @@
+/*
+ * rv32emu is freely redistributable under the MIT License. See the file
+ * "LICENSE" for information on usage and redistribution of this file.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "c2mir/c2mir.h"
+#include "cache.h"
+#include "compile.h"
+#include "decode.h"
+#include "mir-gen.h"
+#include "mir.h"
+#include "riscv_private.h"
+#include "utils.h"
+
+typedef struct {
+    char *code;
+    size_t code_size;
+    size_t curr;
+} jit_item_t;
+
+typedef struct {
+    MIR_context_t ctx;
+    struct c2mir_options *options;
+    uint8_t debug_level;
+    uint8_t optimize_level;
+} riscv_jit_t;
+
+typedef struct {
+    char *name;
+    void *func;
+} func_obj_t;
+
+#define SET_SIZE_BITS 10
+#define SET_SIZE 1 << SET_SIZE_BITS
+#define HASH(val) \
+    (((val) * (GOLDEN_RATIO_32)) >> (32 - SET_SIZE_BITS)) & ((SET_SIZE) -1)
+#define sys_icache_invalidate(addr, size) \
+    __builtin___clear_cache((char *) (addr), (char *) (addr) + (size));
+
+typedef struct {
+    uint32_t table[SET_SIZE][32];
+} set_t;
+
+static inline void set_reset(set_t *set)
+{
+    memset(set, 0, sizeof(set_t));
+}
+
+static bool set_add(set_t *set, uint32_t key)
+{
+    uint32_t index = HASH(key);
+    uint8_t count = 0;
+    while (set->table[index][count]) {
+        if (set->table[index][count++] == key)
+            return false;
+    }
+
+    set->table[index][count] = key;
+    return true;
+}
+
+static bool set_has(set_t *set, uint32_t key)
+{
+    uint32_t index = HASH(key);
+    uint8_t count = 0;
+    while (set->table[index][count]) {
+        if (set->table[index][count++] == key)
+            return true;
+    }
+    return false;
+}
+
+static bool insn_is_branch(uint8_t opcode)
+{
+    switch (opcode) {
+#define _(inst, can_branch) IIF(can_branch)(case rv_insn_##inst:, )
+        RISCV_INSN_LIST
+#undef _
+        return true;
+    }
+    return false;
+}
+
+typedef void (*gen_func_t)(riscv_t *, const rv_insn_t *, char *, uint32_t);
+static gen_func_t dispatch_table[N_RV_INSN];
+static char funcbuf[128] = {0};
+#define GEN(...)                   \
+    sprintf(funcbuf, __VA_ARGS__); \
+    strcat(gencode, funcbuf);
+#define UPDATE_PC(inc) GEN("  rv->PC += %d;\n", inc)
+#define NEXT_INSN(target) GEN("  goto insn_%x;\n", target)
+#define RVOP(inst, code)                                            \
+    static void gen_##inst(riscv_t *rv UNUSED, const rv_insn_t *ir, \
+                           char *gencode, uint32_t pc)              \
+    {                                                               \
+        GEN("insn_%x:\n"                                            \
+            "  rv->X[0] = 0;\n"                                     \
+            "  rv->csr_cycle++;\n",                                 \
+            (pc));                                                  \
+        code;                                                       \
+        if (!insn_is_branch(ir->opcode)) {                          \
+            GEN("  rv->PC += ir->insn_len;\n");                     \
+            GEN("  ir = ir + 1;\n");                                \
+            NEXT_INSN(pc + ir->insn_len);                           \
+        }                                                           \
+    }
+
+#include "jit_template.c"
+/*
+ * In the decoding and emulation stage, specific information is stored in the
+ * IR, such as register numbers and immediates. We can leverage this information
+ * to generate more efficient code instead of relying on the original source
+ * code.
+ */
+RVOP(jal, {
+    GEN("  pc = rv->PC;\n");
+    UPDATE_PC(ir->imm);
+    if (ir->rd) {
+        GEN("  rv->X[%u] = pc + %u;\n", ir->rd, ir->insn_len);
+    }
+    GEN("  ir = ir->branch_taken;\n");
+    NEXT_INSN(pc + ir->imm);
+})
+
+#define BRNACH_FUNC(type, comp)                                               \
+    GEN("  if ((%s) rv->X[%u] %s (%s) rv->X[%u]) {\n", #type, ir->rs1, #comp, \
+        #type, ir->rs2);                                                      \
+    UPDATE_PC(ir->imm);                                                       \
+    if (ir->branch_taken) {                                                   \
+        GEN("    ir = ir->branch_taken;\n");                                  \
+        NEXT_INSN(pc + ir->imm);                                              \
+    } else                                                                    \
+        GEN("    return true;\n");                                            \
+    GEN("  }\n");                                                             \
+    UPDATE_PC(ir->insn_len);                                                  \
+    if (ir->branch_untaken) {                                                 \
+        GEN("  ir = ir->branch_untaken;\n");                                  \
+        NEXT_INSN(pc + ir->insn_len);                                         \
+    } else                                                                    \
+        GEN("  return true;\n");
+
+RVOP(beq, { BRNACH_FUNC(uint32_t, ==); })
+
+RVOP(bne, { BRNACH_FUNC(uint32_t, !=); })
+
+RVOP(blt, { BRNACH_FUNC(int32_t, <); })
+
+RVOP(bge, { BRNACH_FUNC(int32_t, >=); })
+
+RVOP(bltu, { BRNACH_FUNC(uint32_t, <); })
+
+RVOP(bgeu, { BRNACH_FUNC(uint32_t, >=); })
+
+RVOP(lb, {
+    GEN("  addr = rv->X[%u] + %u;\n", ir->rs1, ir->imm);
+    GEN("  c = m->chunks[addr >> 16];\n");
+    GEN("  rv->X[%u] = sign_extend_b(* (const uint32_t *) (c->data + "
+        "(addr & 0xffff)));\n",
+        ir->rd);
+})
+
+RVOP(lh, {
+    GEN("  addr = rv->X[%u] + %u;\n", ir->rs1, ir->imm);
+    GEN("  c = m->chunks[addr >> 16];\n");
+    GEN("  rv->X[%u] = sign_extend_h(* (const uint32_t *) (c->data + "
+        "(addr & 0xffff)));\n",
+        ir->rd);
+})
+
+#define MEMORY_FUNC(type, IO)                                                \
+    GEN("  addr = rv->X[%u] + %u;\n", ir->rs1, ir->imm);                     \
+    GEN("  c = m->chunks[addr >> 16];\n");                                   \
+    IIF(IO)                                                                  \
+    (GEN("  rv->X[%u] = * (const %s *) (c->data + (addr & 0xffff));\n",      \
+         ir->rd, #type),                                                     \
+     GEN("  *(%s *) (c->data + (addr & 0xffff)) = (%s) rv->X[%u];\n", #type, \
+         #type, ir->rs2));
+
+RVOP(lw, {MEMORY_FUNC(uint32_t, 1)})
+
+RVOP(lbu, {MEMORY_FUNC(uint8_t, 1)})
+
+RVOP(lhu, {MEMORY_FUNC(uint16_t, 1)})
+
+RVOP(sb, {MEMORY_FUNC(uint8_t, 0)})
+
+RVOP(sh, {MEMORY_FUNC(uint16_t, 0)})
+
+RVOP(sw, {MEMORY_FUNC(uint32_t, 0)})
+
+#if RV32_HAS(EXT_C)
+RVOP(clw, {
+    GEN("  addr = rv->X[%u] + %u;\n", ir->rs1, ir->imm);
+    GEN("  c = m->chunks[addr >> 16];\n");
+    GEN("  rv->X[%u] = * (const uint32_t *) (c->data + (addr & "
+        "0xffff));\n",
+        ir->rd);
+})
+
+RVOP(csw, {
+    GEN("  addr = rv->X[%u] + %u;\n", ir->rs1, ir->imm);
+    GEN("  c = m->chunks[addr >> 16];\n");
+    GEN("  *(uint32_t *) (c->data + (addr & 0xffff)) = rv->X[%u];\n", ir->rs2);
+})
+
+RVOP(cjal, {
+    GEN("  rv->X[1] = rv->PC += %u;\n", ir->insn_len);
+    UPDATE_PC(ir->imm);
+    GEN("  ir = ir->branch_taken;\n");
+    NEXT_INSN(pc + ir->imm);
+})
+
+RVOP(cj, {
+    UPDATE_PC(ir->imm);
+    GEN("  ir = ir->branch_taken;\n");
+    NEXT_INSN(pc + ir->imm);
+})
+
+RVOP(cbeqz, {
+    GEN("  if (!rv->X[%u]){\n", ir->rs1);
+    UPDATE_PC(ir->imm);
+    if (ir->branch_taken) {
+        GEN("    ir = ir->branch_taken;\n");
+        NEXT_INSN(pc + ir->imm);
+    } else
+        GEN("    return true;\n");
+    GEN("  }\n");
+    UPDATE_PC(ir->insn_len);
+    if (ir->branch_untaken) {
+        GEN("  ir = ir->branch_untaken;\n");
+        NEXT_INSN(pc + ir->insn_len);
+    } else
+        GEN("  return true;\n");
+})
+
+RVOP(cbnez, {
+    GEN("  if (rv->X[%u]){\n", ir->rs1);
+    UPDATE_PC(ir->imm);
+    if (ir->branch_taken) {
+        GEN("    ir = ir->branch_taken;\n");
+        NEXT_INSN(pc + ir->imm);
+    } else
+        GEN("    return true;\n");
+    GEN("  }\n");
+    UPDATE_PC(ir->insn_len);
+    if (ir->branch_untaken) {
+        GEN("  ir = ir->branch_untaken;\n");
+        NEXT_INSN(pc + ir->insn_len);
+    } else
+        GEN("  return true;\n");
+})
+#endif
+
+RVOP(fuse3, {
+    opcode_fuse_t *fuse = ir->fuse;
+    for (int i = 0; i < ir->imm2; i++) {
+        GEN("  addr = rv->X[%u] + %u;\n", fuse[i].rs1, fuse[i].imm);
+        GEN("  c = m->chunks[addr >> 16];\n");
+        GEN("  *(uint32_t *) (c->data + (addr & 0xffff)) = rv->X[%u];\n",
+            fuse[i].rs2);
+    }
+})
+
+RVOP(fuse4, {
+    opcode_fuse_t *fuse = ir->fuse;
+    for (int i = 0; i < ir->imm2; i++) {
+        GEN("  addr = rv->X[%u] + %u;\n", fuse[i].rs1, fuse[i].imm);
+        GEN("  c = m->chunks[addr >> 16];\n");
+        GEN("  rv->X[%u] = * (const uint32_t *) (c->data + (addr & "
+            "0xffff));\n",
+            fuse[i].rd);
+    }
+})
+#undef RVOP
+
+static void trace_ebb(riscv_t *rv, char *gencode, rv_insn_t *ir, set_t *set)
+{
+    while (1) {
+        if (set_add(set, ir->pc))
+            dispatch_table[ir->opcode](rv, ir, gencode, ir->pc);
+
+        if (ir->tailcall)
+            break;
+        ir++;
+    }
+    if (ir->branch_untaken && !set_has(set, ir->branch_untaken->pc))
+        trace_ebb(rv, gencode, ir->branch_untaken, set);
+    if (ir->branch_taken && !set_has(set, ir->branch_taken->pc))
+        trace_ebb(rv, gencode, ir->branch_taken, set);
+}
+
+#define EPILOGUE "}"
+
+static void trace_and_gencode(riscv_t *rv, char *gencode)
+{
+#define _(inst, can_branch) dispatch_table[rv_insn_##inst] = &gen_##inst;
+    RISCV_INSN_LIST
+#undef _
+    set_t set;
+    strcat(gencode, PROLOGUE);
+    set_reset(&set);
+    block_t *block = cache_get(rv->cache, rv->PC);
+    trace_ebb(rv, gencode, block->ir, &set);
+    strcat(gencode, EPILOGUE);
+}
+
+static int get_func(void *data)
+{
+    jit_item_t *item = data;
+    return item->curr >= item->code_size ? EOF : item->code[item->curr++];
+}
+
+#define DLIST_ITEM_FOREACH(modules, item)                     \
+    for (item = DLIST_HEAD(MIR_item_t, modules->items); item; \
+         item = DLIST_NEXT(MIR_item_t, item))
+
+static void *import_resolver(const char *name)
+{
+    func_obj_t func_list[] = {
+        {"sign_extend_b", sign_extend_b},
+        {"sign_extend_h", sign_extend_h},
+#if RV32_HAS(Zicsr)
+        {"csr_csrrw", csr_csrrw},
+        {"csr_csrrs", csr_csrrs},
+        {"csr_csrrc", csr_csrrc},
+#endif
+#if RV32_HAS(EXT_F)
+        {"isnanf", isnanf},
+        {"isinff", isinff},
+        {"sqrtf", sqrtf},
+        {"calc_fclass", calc_fclass},
+        {"is_nan", is_nan},
+        {"is_snan", is_snan},
+#endif
+        {NULL, NULL},
+    };
+    for (int i = 0; func_list[i].name; i++) {
+        if (!strcmp(name, func_list[i].name))
+            return func_list[i].func;
+    }
+    return NULL;
+}
+
+static riscv_jit_t *jit = NULL;
+static jit_item_t *jit_ptr = NULL;
+
+/* TODO: fix error when running on ARM architecture */
+static uint8_t *compile(riscv_t *rv)
+{
+    char func_name[25];
+    snprintf(func_name, 25, "jit_func_%d", rv->PC);
+    c2mir_init(jit->ctx);
+    size_t gen_num = 0;
+    MIR_gen_init(jit->ctx, gen_num);
+    MIR_gen_set_optimize_level(jit->ctx, gen_num, jit->optimize_level);
+    if (!c2mir_compile(jit->ctx, jit->options, get_func, jit_ptr, func_name,
+                       NULL)) {
+        perror("Compile failure");
+        exit(EXIT_FAILURE);
+    }
+    MIR_module_t module =
+        DLIST_TAIL(MIR_module_t, *MIR_get_module_list(jit->ctx));
+    MIR_load_module(jit->ctx, module);
+    MIR_link(jit->ctx, MIR_set_gen_interface, import_resolver);
+    MIR_item_t func = DLIST_HEAD(MIR_item_t, module->items);
+    uint8_t *code = NULL;
+    size_t func_len = DLIST_LENGTH(MIR_item_t, module->items);
+    for (size_t i = 0; i < func_len; i++, func = DLIST_NEXT(MIR_item_t, func)) {
+        if (func->item_type == MIR_func_item) {
+            uint32_t code_len = 0;
+            uint32_t *tmp = (uint32_t *) func->addr;
+            while (*tmp) {
+                code_len += 4;
+                tmp += 1;
+            }
+            code = func->addr;
+            sys_icache_invalidate(func->addr, code_len)
+        }
+    }
+
+    MIR_gen_finish(jit->ctx);
+    c2mir_finish(jit->ctx);
+    return code;
+}
+
+uint8_t *block_compile(riscv_t *rv)
+{
+    if (!jit) {
+        jit = calloc(1, sizeof(riscv_jit_t));
+        jit->options = calloc(1, sizeof(struct c2mir_options));
+        jit->ctx = MIR_init();
+        jit->optimize_level = 1;
+    }
+
+    if (!jit_ptr) {
+        jit_ptr = malloc(sizeof(jit_item_t));
+        jit_ptr->curr = 0;
+        jit_ptr->code = calloc(1, 1024 * 1024);
+    } else {
+        jit_ptr->curr = 0;
+        memset(jit_ptr->code, 0, 1024 * 1024);
+    }
+    trace_and_gencode(rv, jit_ptr->code);
+    jit_ptr->code_size = strlen(jit_ptr->code);
+    return compile(rv);
+}

--- a/src/compile.h
+++ b/src/compile.h
@@ -1,0 +1,11 @@
+/*
+ * rv32emu is freely redistributable under the MIT License. See the file
+ * "LICENSE" for information on usage and redistribution of this file.
+ */
+
+#pragma once
+#include <stdint.h>
+
+#include "riscv.h"
+
+uint8_t *block_compile(riscv_t *rv);

--- a/src/decode.h
+++ b/src/decode.h
@@ -171,6 +171,7 @@ enum {
 #define _(inst, can_branch) rv_insn_##inst,
     RISCV_INSN_LIST
 #undef _
+        N_RV_INSN,
 };
 
 /* clang-format off */
@@ -283,6 +284,9 @@ typedef struct rv_insn {
      * specific IR array without the need for additional copying.
      */
     struct rv_insn *branch_taken, *branch_untaken;
+#if RV32_HAS(JIT)
+    uint32_t pc;
+#endif
 } rv_insn_t;
 
 /* decode the RISC-V instruction */

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -1149,12 +1149,15 @@ RVOP(cbeqz, {
         if (!ir->branch_untaken)
             goto nextop;
         rv->PC += ir->insn_len;
+        last_pc = rv->PC;
         return ir->branch_untaken->impl(rv, ir->branch_untaken);
     }
     branch_taken = true;
     rv->PC += (uint32_t) ir->imm;
-    if (ir->branch_taken)
+    if (ir->branch_taken) {
+        last_pc = rv->PC;
         return ir->branch_taken->impl(rv, ir->branch_taken);
+    }
     return true;
 })
 
@@ -1165,12 +1168,15 @@ RVOP(cbnez, {
         if (!ir->branch_untaken)
             goto nextop;
         rv->PC += ir->insn_len;
+        last_pc = rv->PC;
         return ir->branch_untaken->impl(rv, ir->branch_untaken);
     }
     branch_taken = true;
     rv->PC += (uint32_t) ir->imm;
-    if (ir->branch_taken)
+    if (ir->branch_taken) {
+        last_pc = rv->PC;
         return ir->branch_taken->impl(rv, ir->branch_taken);
+    }
     return true;
 })
 

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -12,17 +12,6 @@
 #if RV32_HAS(EXT_F)
 #include <math.h>
 #include "softfloat.h"
-
-#if defined(__APPLE__)
-static inline int isinff(float x)
-{
-    return __builtin_fabsf(x) == __builtin_inff();
-}
-static inline int isnanf(float x)
-{
-    return x != x;
-}
-#endif
 #endif /* RV32_HAS(EXT_F) */
 
 #if RV32_HAS(GDBSTUB)
@@ -34,6 +23,10 @@ extern struct target_ops gdbstub_ops;
 #include "riscv_private.h"
 #include "state.h"
 #include "utils.h"
+#if RV32_HAS(JIT)
+#include "cache.h"
+#include "compile.h"
+#endif
 
 /* RISC-V exception code list */
 #define RV_EXCEPTION_LIST                                       \
@@ -108,139 +101,6 @@ RV_EXCEPTION_LIST
         return false;                                                 \
     }
 
-/* get current time in microsecnds and update csr_time register */
-static inline void update_time(riscv_t *rv)
-{
-    struct timeval tv;
-    rv_gettimeofday(&tv);
-
-    uint64_t t = (uint64_t) tv.tv_sec * 1e6 + (uint32_t) tv.tv_usec;
-    rv->csr_time[0] = t & 0xFFFFFFFF;
-    rv->csr_time[1] = t >> 32;
-}
-
-#if RV32_HAS(Zicsr)
-/* get a pointer to a CSR */
-static uint32_t *csr_get_ptr(riscv_t *rv, uint32_t csr)
-{
-    /* csr & 0xFFF prevent sign-extension in decode stage */
-    switch (csr & 0xFFF) {
-    case CSR_MSTATUS: /* Machine Status */
-        return (uint32_t *) (&rv->csr_mstatus);
-    case CSR_MTVEC: /* Machine Trap Handler */
-        return (uint32_t *) (&rv->csr_mtvec);
-    case CSR_MISA: /* Machine ISA and Extensions */
-        return (uint32_t *) (&rv->csr_misa);
-
-    /* Machine Trap Handling */
-    case CSR_MSCRATCH: /* Machine Scratch Register */
-        return (uint32_t *) (&rv->csr_mscratch);
-    case CSR_MEPC: /* Machine Exception Program Counter */
-        return (uint32_t *) (&rv->csr_mepc);
-    case CSR_MCAUSE: /* Machine Exception Cause */
-        return (uint32_t *) (&rv->csr_mcause);
-    case CSR_MTVAL: /* Machine Trap Value */
-        return (uint32_t *) (&rv->csr_mtval);
-    case CSR_MIP: /* Machine Interrupt Pending */
-        return (uint32_t *) (&rv->csr_mip);
-
-    /* Machine Counter/Timers */
-    case CSR_CYCLE: /* Cycle counter for RDCYCLE instruction */
-        return (uint32_t *) &rv->csr_cycle;
-    case CSR_CYCLEH: /* Upper 32 bits of cycle */
-        return &((uint32_t *) &rv->csr_cycle)[1];
-
-    /* TIME/TIMEH - very roughly about 1 ms per tick */
-    case CSR_TIME: { /* Timer for RDTIME instruction */
-        update_time(rv);
-        return &rv->csr_time[0];
-    }
-    case CSR_TIMEH: { /* Upper 32 bits of time */
-        update_time(rv);
-        return &rv->csr_time[1];
-    }
-    case CSR_INSTRET: /* Number of Instructions Retired Counter */
-        /* Number of Instructions Retired Counter, just use cycle */
-        return (uint32_t *) (&rv->csr_cycle);
-#if RV32_HAS(EXT_F)
-    case CSR_FFLAGS:
-        return (uint32_t *) (&rv->csr_fcsr);
-    case CSR_FCSR:
-        return (uint32_t *) (&rv->csr_fcsr);
-#endif
-    default:
-        return NULL;
-    }
-}
-
-static inline bool csr_is_writable(uint32_t csr)
-{
-    return csr < 0xc00;
-}
-
-/* CSRRW (Atomic Read/Write CSR) instruction atomically swaps values in the
- * CSRs and integer registers. CSRRW reads the old value of the CSR,
- * zero-extends the value to XLEN bits, and then writes it to register rd.
- * The initial value in rs1 is written to the CSR.
- * If rd == x0, then the instruction shall not read the CSR and shall not cause
- * any of the side effects that might occur on a CSR read.
- */
-static uint32_t csr_csrrw(riscv_t *rv, uint32_t csr, uint32_t val)
-{
-    uint32_t *c = csr_get_ptr(rv, csr);
-    if (!c)
-        return 0;
-
-    uint32_t out = *c;
-#if RV32_HAS(EXT_F)
-    if (csr == CSR_FFLAGS)
-        out &= FFLAG_MASK;
-#endif
-    if (csr_is_writable(csr))
-        *c = val;
-
-    return out;
-}
-
-/* perform csrrs (atomic read and set) */
-static uint32_t csr_csrrs(riscv_t *rv, uint32_t csr, uint32_t val)
-{
-    uint32_t *c = csr_get_ptr(rv, csr);
-    if (!c)
-        return 0;
-
-    uint32_t out = *c;
-#if RV32_HAS(EXT_F)
-    if (csr == CSR_FFLAGS)
-        out &= FFLAG_MASK;
-#endif
-    if (csr_is_writable(csr))
-        *c |= val;
-
-    return out;
-}
-
-/* perform csrrc (atomic read and clear)
- * Read old value of CSR, zero-extend to XLEN bits, write to rd.
- * Read value from rs1, use as bit mask to clear bits in CSR.
- */
-static uint32_t csr_csrrc(riscv_t *rv, uint32_t csr, uint32_t val)
-{
-    uint32_t *c = csr_get_ptr(rv, csr);
-    if (!c)
-        return 0;
-
-    uint32_t out = *c;
-#if RV32_HAS(EXT_F)
-    if (csr == CSR_FFLAGS)
-        out &= FFLAG_MASK;
-#endif
-    if (csr_is_writable(csr))
-        *c &= ~val;
-    return out;
-}
-#endif
-
 #if RV32_HAS(GDBSTUB)
 void rv_debug(riscv_t *rv)
 {
@@ -296,6 +156,7 @@ static bool branch_taken = false;
 /* record the program counter of the previous block */
 static uint32_t last_pc = 0;
 
+/* Interpreter-based execution path */
 #define RVOP(inst, code)                                    \
     static bool do_##inst(riscv_t *rv, const rv_insn_t *ir) \
     {                                                       \
@@ -310,971 +171,10 @@ static uint32_t last_pc = 0;
         MUST_TAIL return next->impl(rv, next);              \
     }
 
-/* RV32I Base Instruction Set */
+#include "rv32_template.c"
+#undef RVOP
 
-/* Internal */
-static bool do_nop(riscv_t *rv, const rv_insn_t *ir)
-{
-    rv->X[rv_reg_zero] = 0;
-    rv->csr_cycle++;
-    rv->PC += ir->insn_len;
-    const rv_insn_t *next = ir + 1;
-    MUST_TAIL return next->impl(rv, next);
-}
-
-
-/* LUI is used to build 32-bit constants and uses the U-type format. LUI
- * places the U-immediate value in the top 20 bits of the destination
- * register rd, filling in the lowest 12 bits with zeros. The 32-bit
- * result is sign-extended to 64 bits.
- */
-RVOP(lui, { rv->X[ir->rd] = ir->imm; })
-
-/* AUIPC is used to build pc-relative addresses and uses the U-type format.
- * AUIPC forms a 32-bit offset from the 20-bit U-immediate, filling in the
- * lowest 12 bits with zeros, adds this offset to the address of the AUIPC
- * instruction, then places the result in register rd.
- */
-RVOP(auipc, { rv->X[ir->rd] = ir->imm + rv->PC; })
-
-/* JAL: Jump and Link
- * store successor instruction address into rd.
- * add next J imm (offset) to pc.
- */
-RVOP(jal, {
-    const uint32_t pc = rv->PC;
-    /* Jump */
-    rv->PC += ir->imm;
-    /* link with return address */
-    if (ir->rd)
-        rv->X[ir->rd] = pc + ir->insn_len;
-    /* check instruction misaligned */
-    RV_EXC_MISALIGN_HANDLER(pc, insn, false, 0);
-    return ir->branch_taken->impl(rv, ir->branch_taken);
-})
-
-/* The indirect jump instruction JALR uses the I-type encoding. The target
- * address is obtained by adding the sign-extended 12-bit I-immediate to the
- * register rs1, then setting the least-significant bit of the result to zero.
- * The address of the instruction following the jump (pc+4) is written to
- * register rd. Register x0 can be used as the destination if the result is
- * not required.
- */
-RVOP(jalr, {
-    const uint32_t pc = rv->PC;
-    /* jump */
-    rv->PC = (rv->X[ir->rs1] + ir->imm) & ~1U;
-    /* link */
-    if (ir->rd)
-        rv->X[ir->rd] = pc + ir->insn_len;
-    /* check instruction misaligned */
-    RV_EXC_MISALIGN_HANDLER(pc, insn, false, 0);
-    return true;
-})
-
-/* clang-format off */
-#define BRANCH_FUNC(type, cond)                                  \
-    const uint32_t pc = rv->PC;                                  \
-    if ((type) rv->X[ir->rs1] cond (type) rv->X[ir->rs2]) {      \
-        branch_taken = false;                                    \
-        if (!ir->branch_untaken)                                 \
-            goto nextop;                                         \
-        rv->PC += ir->insn_len;                                  \
-        last_pc = rv->PC;                                        \
-        return ir->branch_untaken->impl(rv, ir->branch_untaken); \
-    }                                                            \
-    branch_taken = true;                                         \
-    rv->PC += ir->imm;                                           \
-    /* check instruction misaligned */                           \
-    RV_EXC_MISALIGN_HANDLER(pc, insn, false, 0);                 \
-    if (ir->branch_taken) {                                      \
-        last_pc = rv->PC;                                        \
-        return ir->branch_taken->impl(rv, ir->branch_taken);     \
-    }                                                            \
-    return true;
-/* clang-format on */
-
-/* BEQ: Branch if Equal */
-RVOP(beq, { BRANCH_FUNC(uint32_t, !=); })
-
-/* BNE: Branch if Not Equal */
-RVOP(bne, { BRANCH_FUNC(uint32_t, ==); })
-
-/* BLT: Branch if Less Than */
-RVOP(blt, { BRANCH_FUNC(int32_t, >=); })
-
-/* BGE: Branch if Greater Than */
-RVOP(bge, { BRANCH_FUNC(int32_t, <); })
-
-/* BLTU: Branch if Less Than Unsigned */
-RVOP(bltu, { BRANCH_FUNC(uint32_t, >=); })
-
-/* BGEU: Branch if Greater Than Unsigned */
-RVOP(bgeu, { BRANCH_FUNC(uint32_t, <); })
-
-/* LB: Load Byte */
-RVOP(lb, {
-    rv->X[ir->rd] =
-        sign_extend_b(rv->io.mem_read_b(rv, rv->X[ir->rs1] + ir->imm));
-})
-
-/* LH: Load Halfword */
-RVOP(lh, {
-    const uint32_t addr = rv->X[ir->rs1] + ir->imm;
-    RV_EXC_MISALIGN_HANDLER(1, load, false, 1);
-    rv->X[ir->rd] = sign_extend_h(rv->io.mem_read_s(rv, addr));
-})
-
-/* LW: Load Word */
-RVOP(lw, {
-    const uint32_t addr = rv->X[ir->rs1] + ir->imm;
-    RV_EXC_MISALIGN_HANDLER(3, load, false, 1);
-    rv->X[ir->rd] = rv->io.mem_read_w(rv, addr);
-})
-
-/* LBU: Load Byte Unsigned */
-RVOP(lbu, { rv->X[ir->rd] = rv->io.mem_read_b(rv, rv->X[ir->rs1] + ir->imm); })
-
-/* LHU: Load Halfword Unsigned */
-RVOP(lhu, {
-    const uint32_t addr = rv->X[ir->rs1] + ir->imm;
-    RV_EXC_MISALIGN_HANDLER(1, load, false, 1);
-    rv->X[ir->rd] = rv->io.mem_read_s(rv, addr);
-})
-
-/* SB: Store Byte */
-RVOP(sb, { rv->io.mem_write_b(rv, rv->X[ir->rs1] + ir->imm, rv->X[ir->rs2]); })
-
-/* SH: Store Halfword */
-RVOP(sh, {
-    const uint32_t addr = rv->X[ir->rs1] + ir->imm;
-    RV_EXC_MISALIGN_HANDLER(1, store, false, 1);
-    rv->io.mem_write_s(rv, addr, rv->X[ir->rs2]);
-})
-
-/* SW: Store Word */
-RVOP(sw, {
-    const uint32_t addr = rv->X[ir->rs1] + ir->imm;
-    RV_EXC_MISALIGN_HANDLER(3, store, false, 1);
-    rv->io.mem_write_w(rv, addr, rv->X[ir->rs2]);
-})
-
-/* ADDI adds the sign-extended 12-bit immediate to register rs1. Arithmetic
- * overflow is ignored and the result is simply the low XLEN bits of the
- * result. ADDI rd, rs1, 0 is used to implement the MV rd, rs1 assembler
- * pseudo-instruction.
- */
-RVOP(addi, { rv->X[ir->rd] = (int32_t) (rv->X[ir->rs1]) + ir->imm; })
-
-/* SLTI place the value 1 in register rd if register rs1 is less than the
- * signextended immediate when both are treated as signed numbers, else 0 is
- * written to rd.
- */
-RVOP(slti, { rv->X[ir->rd] = ((int32_t) (rv->X[ir->rs1]) < ir->imm) ? 1 : 0; })
-
-/* SLTIU places the value 1 in register rd if register rs1 is less than the
- * immediate when both are treated as unsigned numbers, else 0 is written to rd.
- */
-RVOP(sltiu, { rv->X[ir->rd] = (rv->X[ir->rs1] < (uint32_t) ir->imm) ? 1 : 0; })
-
-/* XORI: Exclusive OR Immediate */
-RVOP(xori, { rv->X[ir->rd] = rv->X[ir->rs1] ^ ir->imm; })
-
-/* ORI: OR Immediate */
-RVOP(ori, { rv->X[ir->rd] = rv->X[ir->rs1] | ir->imm; })
-
-/* ANDI performs bitwise AND on register rs1 and the sign-extended 12-bit
- * immediate and place the result in rd.
- */
-RVOP(andi, { rv->X[ir->rd] = rv->X[ir->rs1] & ir->imm; })
-
-/* SLLI performs logical left shift on the value in register rs1 by the shift
- * amount held in the lower 5 bits of the immediate.
- */
-RVOP(slli, { rv->X[ir->rd] = rv->X[ir->rs1] << (ir->imm & 0x1f); })
-
-/* SRLI performs logical right shift on the value in register rs1 by the shift
- * amount held in the lower 5 bits of the immediate.
- */
-RVOP(srli, { rv->X[ir->rd] = rv->X[ir->rs1] >> (ir->imm & 0x1f); })
-
-/* SRAI performs arithmetic right shift on the value in register rs1 by the
- * shift amount held in the lower 5 bits of the immediate.
- */
-RVOP(srai, { rv->X[ir->rd] = ((int32_t) rv->X[ir->rs1]) >> (ir->imm & 0x1f); })
-
-/* ADD */
-RVOP(add, {
-    rv->X[ir->rd] = (int32_t) (rv->X[ir->rs1]) + (int32_t) (rv->X[ir->rs2]);
-})
-
-/* SUB: Substract */
-RVOP(sub, {
-    rv->X[ir->rd] = (int32_t) (rv->X[ir->rs1]) - (int32_t) (rv->X[ir->rs2]);
-})
-
-/* SLL: Shift Left Logical */
-RVOP(sll, { rv->X[ir->rd] = rv->X[ir->rs1] << (rv->X[ir->rs2] & 0x1f); })
-
-/* SLT: Set on Less Than */
-RVOP(slt, {
-    rv->X[ir->rd] =
-        ((int32_t) (rv->X[ir->rs1]) < (int32_t) (rv->X[ir->rs2])) ? 1 : 0;
-})
-
-/* SLTU: Set on Less Than Unsigned */
-RVOP(sltu, { rv->X[ir->rd] = (rv->X[ir->rs1] < rv->X[ir->rs2]) ? 1 : 0; })
-
-/* XOR: Exclusive OR */
-RVOP(xor, {
-  rv->X[ir->rd] = rv->X[ir->rs1] ^ rv->X[ir->rs2];
-})
-
-/* SRL: Shift Right Logical */
-RVOP(srl, { rv->X[ir->rd] = rv->X[ir->rs1] >> (rv->X[ir->rs2] & 0x1f); })
-
-/* SRA: Shift Right Arithmetic */
-RVOP(sra,
-     { rv->X[ir->rd] = ((int32_t) rv->X[ir->rs1]) >> (rv->X[ir->rs2] & 0x1f); })
-
-/* OR */
-RVOP(or, { rv->X[ir->rd] = rv->X[ir->rs1] | rv->X[ir->rs2]; })
-
-/* AND */
-RVOP(and, { rv->X[ir->rd] = rv->X[ir->rs1] & rv->X[ir->rs2]; })
-
-/* ECALL: Environment Call */
-RVOP(ecall, {
-    rv->compressed = false;
-    rv->io.on_ecall(rv);
-    return true;
-})
-
-/* EBREAK: Environment Break */
-RVOP(ebreak, {
-    rv->compressed = false;
-    rv->io.on_ebreak(rv);
-    return true;
-})
-
-/* WFI: Wait for Interrupt */
-RVOP(wfi, {
-    /* FIXME: Implement */
-    return false;
-})
-
-/* URET: return from traps in U-mode */
-RVOP(uret, {
-    /* FIXME: Implement */
-    return false;
-})
-
-/* SRET: return from traps in S-mode */
-RVOP(sret, {
-    /* FIXME: Implement */
-    return false;
-})
-
-/* HRET: return from traps in H-mode */
-RVOP(hret, {
-    /* FIXME: Implement */
-    return false;
-})
-
-/* MRET: return from traps in U-mode */
-RVOP(mret, {
-    rv->PC = rv->csr_mepc;
-    return true;
-})
-
-#if RV32_HAS(Zifencei) /* RV32 Zifencei Standard Extension */
-RVOP(fencei, {
-    rv->PC += ir->insn_len;
-    /* FIXME: fill real implementations */
-    return true;
-})
-#endif
-
-#if RV32_HAS(Zicsr) /* RV32 Zicsr Standard Extension */
-/* CSRRW: Atomic Read/Write CSR */
-RVOP(csrrw, {
-    uint32_t tmp = csr_csrrw(rv, ir->imm, rv->X[ir->rs1]);
-    rv->X[ir->rd] = ir->rd ? tmp : rv->X[ir->rd];
-})
-
-/* CSRRS: Atomic Read and Set Bits in CSR */
-RVOP(csrrs, {
-    uint32_t tmp =
-        csr_csrrs(rv, ir->imm, (ir->rs1 == rv_reg_zero) ? 0U : rv->X[ir->rs1]);
-    rv->X[ir->rd] = ir->rd ? tmp : rv->X[ir->rd];
-})
-
-/* CSRRC: Atomic Read and Clear Bits in CSR */
-RVOP(csrrc, {
-    uint32_t tmp =
-        csr_csrrc(rv, ir->imm, (ir->rs1 == rv_reg_zero) ? ~0U : rv->X[ir->rs1]);
-    rv->X[ir->rd] = ir->rd ? tmp : rv->X[ir->rd];
-})
-
-/* CSRRWI */
-RVOP(csrrwi, {
-    uint32_t tmp = csr_csrrw(rv, ir->imm, ir->rs1);
-    rv->X[ir->rd] = ir->rd ? tmp : rv->X[ir->rd];
-})
-
-/* CSRRSI */
-RVOP(csrrsi, {
-    uint32_t tmp = csr_csrrs(rv, ir->imm, ir->rs1);
-    rv->X[ir->rd] = ir->rd ? tmp : rv->X[ir->rd];
-})
-
-/* CSRRCI */
-RVOP(csrrci, {
-    uint32_t tmp = csr_csrrc(rv, ir->imm, ir->rs1);
-    rv->X[ir->rd] = ir->rd ? tmp : rv->X[ir->rd];
-})
-#endif
-
-#if RV32_HAS(EXT_M) /* RV32M Standard Extension */
-/* MUL: Multiply */
-RVOP(mul,
-     { rv->X[ir->rd] = (int32_t) rv->X[ir->rs1] * (int32_t) rv->X[ir->rs2]; })
-
-/* MULH: Multiply High Signed Signed */
-RVOP(mulh, {
-    const int64_t a = (int32_t) rv->X[ir->rs1];
-    const int64_t b = (int32_t) rv->X[ir->rs2];
-    rv->X[ir->rd] = ((uint64_t) (a * b)) >> 32;
-})
-
-/* MULHSU: Multiply High Signed Unsigned */
-RVOP(mulhsu, {
-    const int64_t a = (int32_t) rv->X[ir->rs1];
-    const uint64_t b = rv->X[ir->rs2];
-    rv->X[ir->rd] = ((uint64_t) (a * b)) >> 32;
-})
-
-/* MULHU: Multiply High Unsigned Unsigned */
-RVOP(mulhu, {
-    rv->X[ir->rd] =
-        ((uint64_t) rv->X[ir->rs1] * (uint64_t) rv->X[ir->rs2]) >> 32;
-})
-
-/* DIV: Divide Signed */
-/* +------------------------+-----------+----------+-----------+
- * |       Condition        |  Dividend |  Divisor |   DIV[W]  |
- * +------------------------+-----------+----------+-----------+
- * | Division by zero       |  x        |  0       |  −1       |
- * | Overflow (signed only) |  −2^{L−1} |  −1      |  −2^{L−1} |
- * +------------------------+-----------+----------+-----------+
- */
-RVOP(div, {
-    const int32_t dividend = (int32_t) rv->X[ir->rs1];
-    const int32_t divisor = (int32_t) rv->X[ir->rs2];
-    rv->X[ir->rd] = !divisor ? ~0U
-                    : (divisor == -1 && rv->X[ir->rs1] == 0x80000000U)
-                        ? rv->X[ir->rs1] /* overflow */
-                        : (unsigned int) (dividend / divisor);
-})
-
-/* DIVU: Divide Unsigned */
-/* +------------------------+-----------+----------+----------+
- * |       Condition        |  Dividend |  Divisor |  DIVU[W] |
- * +------------------------+-----------+----------+----------+
- * | Division by zero       |  x        |  0       |  2^L − 1 |
- * +------------------------+-----------+----------+----------+
- */
-RVOP(divu, {
-    const uint32_t dividend = rv->X[ir->rs1];
-    const uint32_t divisor = rv->X[ir->rs2];
-    rv->X[ir->rd] = !divisor ? ~0U : dividend / divisor;
-})
-
-/* REM: Remainder Signed */
-/* +------------------------+-----------+----------+---------+
- * |       Condition        |  Dividend |  Divisor |  REM[W] |
- * +------------------------+-----------+----------+---------+
- * | Division by zero       |  x        |  0       |  x      |
- * | Overflow (signed only) |  −2^{L−1} |  −1      |  0      |
- * +------------------------+-----------+----------+---------+
- */
-RVOP(rem, {
-    const int32_t dividend = rv->X[ir->rs1];
-    const int32_t divisor = rv->X[ir->rs2];
-    rv->X[ir->rd] = !divisor ? dividend
-                    : (divisor == -1 && rv->X[ir->rs1] == 0x80000000U)
-                        ? 0 /* overflow */
-                        : (dividend % divisor);
-})
-
-/* REMU: Remainder Unsigned */
-/* +------------------------+-----------+----------+----------+
- * |       Condition        |  Dividend |  Divisor |  REMU[W] |
- * +------------------------+-----------+----------+----------+
- * | Division by zero       |  x        |  0       |  x       |
- * +------------------------+-----------+----------+----------+
- */
-RVOP(remu, {
-    const uint32_t dividend = rv->X[ir->rs1];
-    const uint32_t divisor = rv->X[ir->rs2];
-    rv->X[ir->rd] = !divisor ? dividend : dividend % divisor;
-})
-#endif
-
-#if RV32_HAS(EXT_A) /* RV32A Standard Extension */
-/* At present, AMO is not implemented atomically because the emulated RISC-V
- * core just runs on single thread, and no out-of-order execution happens.
- * In addition, rl/aq are not handled.
- */
-
-/* LR.W: Load Reserved */
-RVOP(lrw, {
-    rv->X[ir->rd] = rv->io.mem_read_w(rv, rv->X[ir->rs1]);
-    /* skip registration of the 'reservation set'
-     * FIXME: uimplemented
-     */
-})
-
-/* SC.W: Store Conditional */
-RVOP(scw, {
-    /* assume the 'reservation set' is valid
-     * FIXME: unimplemented
-     */
-    rv->io.mem_write_w(rv, rv->X[ir->rs1], rv->X[ir->rs2]);
-    rv->X[ir->rd] = 0;
-})
-
-/* AMOSWAP.W: Atomic Swap */
-RVOP(amoswapw, {
-    rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
-    rv->io.mem_write_s(rv, ir->rs1, rv->X[ir->rs2]);
-})
-
-/* AMOADD.W: Atomic ADD */
-RVOP(amoaddw, {
-    rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
-    const int32_t res = (int32_t) rv->X[ir->rd] + (int32_t) rv->X[ir->rs2];
-    rv->io.mem_write_s(rv, ir->rs1, res);
-})
-
-/* AMOXOR.W: Atomix XOR */
-RVOP(amoxorw, {
-    rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
-    const int32_t res = rv->X[ir->rd] ^ rv->X[ir->rs2];
-    rv->io.mem_write_s(rv, ir->rs1, res);
-})
-
-/* AMOAND.W: Atomic AND */
-RVOP(amoandw, {
-    rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
-    const int32_t res = rv->X[ir->rd] & rv->X[ir->rs2];
-    rv->io.mem_write_s(rv, ir->rs1, res);
-})
-
-/* AMOOR.W: Atomic OR */
-RVOP(amoorw, {
-    rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
-    const int32_t res = rv->X[ir->rd] | rv->X[ir->rs2];
-    rv->io.mem_write_s(rv, ir->rs1, res);
-})
-
-/* AMOMIN.W: Atomic MIN */
-RVOP(amominw, {
-    rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
-    const int32_t a = rv->X[ir->rd];
-    const int32_t b = rv->X[ir->rs2];
-    const int32_t res = a < b ? a : b;
-    rv->io.mem_write_s(rv, ir->rs1, res);
-})
-
-/* AMOMAX.W: Atomic MAX */
-RVOP(amomaxw, {
-    rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
-    const int32_t a = rv->X[ir->rd];
-    const int32_t b = rv->X[ir->rs2];
-    const int32_t res = a > b ? a : b;
-    rv->io.mem_write_s(rv, ir->rs1, res);
-})
-
-/* AMOMINU.W */
-RVOP(amominuw, {
-    rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
-    const uint32_t a = rv->X[ir->rd];
-    const uint32_t b = rv->X[ir->rs2];
-    const uint32_t res = a < b ? a : b;
-    rv->io.mem_write_s(rv, ir->rs1, res);
-})
-
-/* AMOMAXU.W */
-RVOP(amomaxuw, {
-    rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
-    const uint32_t a = rv->X[ir->rd];
-    const uint32_t b = rv->X[ir->rs2];
-    const uint32_t res = a > b ? a : b;
-    rv->io.mem_write_s(rv, ir->rs1, res);
-})
-#endif /* RV32_HAS(EXT_A) */
-
-#if RV32_HAS(EXT_F) /* RV32F Standard Extension */
-/* FLW */
-RVOP(flw, {
-    /* copy into the float register */
-    const uint32_t data = rv->io.mem_read_w(rv, rv->X[ir->rs1] + ir->imm);
-    rv->F_int[ir->rd] = data;
-})
-
-/* FSW */
-RVOP(fsw, {
-    /* copy from float registers */
-    uint32_t data = rv->F_int[ir->rs2];
-    rv->io.mem_write_w(rv, rv->X[ir->rs1] + ir->imm, data);
-})
-
-/* FMADD.S */
-RVOP(fmadds,
-     { rv->F[ir->rd] = rv->F[ir->rs1] * rv->F[ir->rs2] + rv->F[ir->rs3]; })
-
-/* FMSUB.S */
-RVOP(fmsubs,
-     { rv->F[ir->rd] = rv->F[ir->rs1] * rv->F[ir->rs2] - rv->F[ir->rs3]; })
-
-/* FNMSUB.S */
-RVOP(fnmsubs,
-     { rv->F[ir->rd] = rv->F[ir->rs3] - (rv->F[ir->rs1] * rv->F[ir->rs2]); })
-
-/* FNMADD.S */
-RVOP(fnmadds,
-     { rv->F[ir->rd] = -(rv->F[ir->rs1] * rv->F[ir->rs2]) - rv->F[ir->rs3]; })
-
-/* FADD.S */
-RVOP(fadds, {
-    if (isnanf(rv->F[ir->rs1]) || isnanf(rv->F[ir->rs2]) ||
-        isnanf(rv->F[ir->rs1] + rv->F[ir->rs2])) {
-        /* raise invalid operation */
-        rv->F_int[ir->rd] = RV_NAN; /* F_int is the integer shortcut of F */
-        rv->csr_fcsr |= FFLAG_INVALID_OP;
-    } else {
-        rv->F[ir->rd] = rv->F[ir->rs1] + rv->F[ir->rs2];
-    }
-    if (isinff(rv->F[ir->rd])) {
-        rv->csr_fcsr |= FFLAG_OVERFLOW;
-        rv->csr_fcsr |= FFLAG_INEXACT;
-    }
-})
-
-/* FSUB.S */
-RVOP(fsubs, {
-    if (isnanf(rv->F[ir->rs1]) || isnanf(rv->F[ir->rs2])) {
-        rv->F_int[ir->rd] = RV_NAN;
-    } else {
-        rv->F[ir->rd] = rv->F[ir->rs1] - rv->F[ir->rs2];
-    }
-})
-
-/* FMUL.S */
-RVOP(fmuls, { rv->F[ir->rd] = rv->F[ir->rs1] * rv->F[ir->rs2]; })
-
-/* FDIV.S */
-RVOP(fdivs, { rv->F[ir->rd] = rv->F[ir->rs1] / rv->F[ir->rs2]; })
-
-/* FSQRT.S */
-RVOP(fsqrts, { rv->F[ir->rd] = sqrtf(rv->F[ir->rs1]); })
-
-/* FSGNJ.S */
-RVOP(fsgnjs, {
-    uint32_t f1 = rv->F_int[ir->rs1];
-    uint32_t f2 = rv->F_int[ir->rs2];
-    uint32_t res;
-    res = (f1 & ~FMASK_SIGN) | (f2 & FMASK_SIGN);
-    rv->F_int[ir->rd] = res;
-})
-
-/* FSGNJN.S */
-RVOP(fsgnjns, {
-    uint32_t f1 = rv->F_int[ir->rs1];
-    uint32_t f2 = rv->F_int[ir->rs2];
-    uint32_t res;
-    res = (f1 & ~FMASK_SIGN) | (~f2 & FMASK_SIGN);
-    rv->F_int[ir->rd] = res;
-})
-
-/* FSGNJX.S */
-RVOP(fsgnjxs, {
-    uint32_t f1 = rv->F_int[ir->rs1];
-    uint32_t f2 = rv->F_int[ir->rs2];
-    uint32_t res;
-    res = f1 ^ (f2 & FMASK_SIGN);
-    rv->F_int[ir->rd] = res;
-})
-
-/* FMIN.S
- * In IEEE754-201x, fmin(x, y) return
- * - min(x,y) if both numbers are not NaN
- * - if one is NaN and another is a number, return the number
- * - if both are NaN, return NaN
- * When input is signaling NaN, raise invalid operation
- */
-RVOP(fmins, {
-    uint32_t a = rv->F_int[ir->rs1];
-    uint32_t b = rv->F_int[ir->rs2];
-    if (is_nan(a) || is_nan(b)) {
-        if (is_snan(a) || is_snan(b))
-            rv->csr_fcsr |= FFLAG_INVALID_OP;
-        if (is_nan(a) && !is_nan(b)) {
-            rv->F[ir->rd] = rv->F[ir->rs2];
-        } else if (!is_nan(a) && is_nan(b)) {
-            rv->F[ir->rd] = rv->F[ir->rs1];
-        } else {
-            rv->F_int[ir->rd] = RV_NAN;
-        }
-    } else {
-        uint32_t a_sign;
-        uint32_t b_sign;
-        a_sign = a & FMASK_SIGN;
-        b_sign = b & FMASK_SIGN;
-        if (a_sign != b_sign) {
-            rv->F[ir->rd] = a_sign ? rv->F[ir->rs1] : rv->F[ir->rs2];
-        } else {
-            rv->F[ir->rd] = (rv->F[ir->rs1] < rv->F[ir->rs2]) ? rv->F[ir->rs1]
-                                                              : rv->F[ir->rs2];
-        }
-    }
-})
-
-/* FMAX.S */
-RVOP(fmaxs, {
-    uint32_t a = rv->F_int[ir->rs1];
-    uint32_t b = rv->F_int[ir->rs2];
-    if (is_nan(a) || is_nan(b)) {
-        if (is_snan(a) || is_snan(b))
-            rv->csr_fcsr |= FFLAG_INVALID_OP;
-        if (is_nan(a) && !is_nan(b)) {
-            rv->F[ir->rd] = rv->F[ir->rs2];
-        } else if (!is_nan(a) && is_nan(b)) {
-            rv->F[ir->rd] = rv->F[ir->rs1];
-        } else {
-            rv->F_int[ir->rd] = RV_NAN;
-        }
-    } else {
-        uint32_t a_sign;
-        uint32_t b_sign;
-        a_sign = a & FMASK_SIGN;
-        b_sign = b & FMASK_SIGN;
-        if (a_sign != b_sign) {
-            rv->F[ir->rd] = a_sign ? rv->F[ir->rs2] : rv->F[ir->rs1];
-        } else {
-            rv->F[ir->rd] = (rv->F[ir->rs1] > rv->F[ir->rs2]) ? rv->F[ir->rs1]
-                                                              : rv->F[ir->rs2];
-        }
-    }
-})
-
-/* FCVT.W.S and FCVT.WU.S convert a floating point number to an integer,
- * the rounding mode is specified in rm field.
- */
-
-/* FCVT.W.S */
-RVOP(fcvtws, { rv->X[ir->rd] = (int32_t) rv->F[ir->rs1]; })
-
-/* FCVT.WU.S */
-RVOP(fcvtwus, { rv->X[ir->rd] = (uint32_t) rv->F[ir->rs1]; })
-
-/* FMV.X.W */
-RVOP(fmvxw, { rv->X[ir->rd] = rv->F_int[ir->rs1]; })
-
-/* FEQ.S performs a quiet comparison: it only sets the invalid operation
- * exception flag if either input is a signaling NaN.
- */
-RVOP(feqs, {
-    rv->X[ir->rd] = (rv->F[ir->rs1] == rv->F[ir->rs2]) ? 1 : 0;
-    if (is_snan(rv->F_int[ir->rs1]) || is_snan(rv->F_int[ir->rs2]))
-        rv->csr_fcsr |= FFLAG_INVALID_OP;
-})
-
-/* FLT.S and FLE.S perform what the IEEE 754-2008 standard refers to as
- * signaling comparisons: that is, they set the invalid operation exception
- * flag if either input is NaN.
- */
-RVOP(flts, {
-    rv->X[ir->rd] = (rv->F[ir->rs1] < rv->F[ir->rs2]) ? 1 : 0;
-    if (is_nan(rv->F_int[ir->rs1]) || is_nan(rv->F_int[ir->rs2]))
-        rv->csr_fcsr |= FFLAG_INVALID_OP;
-})
-
-RVOP(fles, {
-    rv->X[ir->rd] = (rv->F[ir->rs1] <= rv->F[ir->rs2]) ? 1 : 0;
-    if (is_nan(rv->F_int[ir->rs1]) || is_nan(rv->F_int[ir->rs2]))
-        rv->csr_fcsr |= FFLAG_INVALID_OP;
-})
-
-/* FCLASS.S */
-RVOP(fclasss, {
-    uint32_t bits = rv->F_int[ir->rs1];
-    rv->X[ir->rd] = calc_fclass(bits);
-})
-
-/* FCVT.S.W */
-RVOP(fcvtsw, { rv->F[ir->rd] = (int32_t) rv->X[ir->rs1]; })
-
-/* FCVT.S.WU */
-RVOP(fcvtswu, { rv->F[ir->rd] = rv->X[ir->rs1]; })
-
-/* FMV.W.X */
-RVOP(fmvwx, { rv->F_int[ir->rd] = rv->X[ir->rs1]; })
-#endif
-
-#if RV32_HAS(EXT_C) /* RV32C Standard Extension */
-/* C.ADDI4SPN is a CIW-format instruction that adds a zero-extended non-zero
- * immediate, scaledby 4, to the stack pointer, x2, and writes the result to
- * rd'.
- * This instruction is used to generate pointers to stack-allocated variables,
- * and expands to addi rd', x2, nzuimm[9:2].
- */
-RVOP(caddi4spn, { rv->X[ir->rd] = rv->X[2] + (uint16_t) ir->imm; })
-
-/* C.LW loads a 32-bit value from memory into register rd'. It computes an
- * effective address by adding the zero-extended offset, scaled by 4, to the
- * base address in register rs1'. It expands to lw rd', offset[6:2](rs1').
- */
-RVOP(clw, {
-    const uint32_t addr = rv->X[ir->rs1] + (uint32_t) ir->imm;
-    RV_EXC_MISALIGN_HANDLER(3, load, true, 1);
-    rv->X[ir->rd] = rv->io.mem_read_w(rv, addr);
-})
-
-/* C.SW stores a 32-bit value in register rs2' to memory. It computes an
- * effective address by adding the zero-extended offset, scaled by 4, to the
- * base address in register rs1'.
- * It expands to sw rs2', offset[6:2](rs1').
- */
-RVOP(csw, {
-    const uint32_t addr = rv->X[ir->rs1] + (uint32_t) ir->imm;
-    RV_EXC_MISALIGN_HANDLER(3, store, true, 1);
-    rv->io.mem_write_w(rv, addr, rv->X[ir->rs2]);
-})
-
-/* C.NOP */
-RVOP(cnop, {/* no operation */})
-
-/* C.ADDI adds the non-zero sign-extended 6-bit immediate to the value in
- * register rd then writes the result to rd. C.ADDI expands into
- * addi rd, rd, nzimm[5:0]. C.ADDI is only valid when rd'=x0. The code point
- * with both rd=x0 and nzimm=0 encodes the C.NOP instruction; the remaining
- * code points with either rd=x0 or nzimm=0 encode HINTs.
- */
-RVOP(caddi, { rv->X[ir->rd] += (int16_t) ir->imm; })
-
-/* C.JAL */
-RVOP(cjal, {
-    rv->X[1] = rv->PC + ir->insn_len;
-    rv->PC += ir->imm;
-    RV_EXC_MISALIGN_HANDLER(rv->PC, insn, true, 0);
-    return ir->branch_taken->impl(rv, ir->branch_taken);
-})
-
-/* C.LI loads the sign-extended 6-bit immediate, imm, into register rd.
- * C.LI expands into addi rd, x0, imm[5:0].
- * C.LI is only valid when rd=x0; the code points with rd=x0 encode HINTs.
- */
-RVOP(cli, { rv->X[ir->rd] = ir->imm; })
-
-/* C.ADDI16SP is used to adjust the stack pointer in procedure prologues
- * and epilogues. It expands into addi x2, x2, nzimm[9:4].
- * C.ADDI16SP is only valid when nzimm'=0; the code point with nzimm=0 is
- * reserved.
- */
-RVOP(caddi16sp, { rv->X[ir->rd] += ir->imm; })
-
-/* C.LUI loads the non-zero 6-bit immediate field into bits 17–12 of the
- * destination register, clears the bottom 12 bits, and sign-extends bit
- * 17 into all higher bits of the destination.
- * C.LUI expands into lui rd, nzimm[17:12].
- * C.LUI is only valid when rd'={x0, x2}, and when the immediate is not equal
- * to zero.
- */
-RVOP(clui, { rv->X[ir->rd] = ir->imm; })
-
-/* C.SRLI is a CB-format instruction that performs a logical right shift
- * of the value in register rd' then writes the result to rd'. The shift
- * amount is encoded in the shamt field. C.SRLI expands into srli rd',
- * rd', shamt[5:0].
- */
-RVOP(csrli, { rv->X[ir->rs1] >>= ir->shamt; })
-
-/* C.SRAI is defined analogously to C.SRLI, but instead performs an
- * arithmetic right shift. C.SRAI expands to srai rd', rd', shamt[5:0].
- */
-RVOP(csrai, {
-    const uint32_t mask = 0x80000000 & rv->X[ir->rs1];
-    rv->X[ir->rs1] >>= ir->shamt;
-    for (unsigned int i = 0; i < ir->shamt; ++i)
-        rv->X[ir->rs1] |= mask >> i;
-})
-
-/* C.ANDI is a CB-format instruction that computes the bitwise AND of the
- * value in register rd' and the sign-extended 6-bit immediate, then writes
- * the result to rd'. C.ANDI expands to andi rd', rd', imm[5:0].
- */
-RVOP(candi, { rv->X[ir->rs1] &= ir->imm; })
-
-/* C.SUB */
-RVOP(csub, { rv->X[ir->rd] = rv->X[ir->rs1] - rv->X[ir->rs2]; })
-
-/* C.XOR */
-RVOP(cxor, { rv->X[ir->rd] = rv->X[ir->rs1] ^ rv->X[ir->rs2]; })
-
-RVOP(cor, { rv->X[ir->rd] = rv->X[ir->rs1] | rv->X[ir->rs2]; })
-
-RVOP(cand, { rv->X[ir->rd] = rv->X[ir->rs1] & rv->X[ir->rs2]; })
-
-/* C.J performs an unconditional control transfer. The offset is sign-extended
- * and added to the pc to form the jump target address.
- * C.J can therefore target a ±2 KiB range.
- * C.J expands to jal x0, offset[11:1].
- */
-RVOP(cj, {
-    rv->PC += ir->imm;
-    RV_EXC_MISALIGN_HANDLER(rv->PC, insn, true, 0);
-    return ir->branch_taken->impl(rv, ir->branch_taken);
-})
-
-/* C.BEQZ performs conditional control transfers. The offset is sign-extended
- * and added to the pc to form the branch target address.
- * It can therefore target a ±256 B range. C.BEQZ takes the branch if the
- * value in register rs1' is zero. It expands to beq rs1', x0, offset[8:1].
- */
-RVOP(cbeqz, {
-    if (rv->X[ir->rs1]) {
-        branch_taken = false;
-        if (!ir->branch_untaken)
-            goto nextop;
-        rv->PC += ir->insn_len;
-        last_pc = rv->PC;
-        return ir->branch_untaken->impl(rv, ir->branch_untaken);
-    }
-    branch_taken = true;
-    rv->PC += (uint32_t) ir->imm;
-    if (ir->branch_taken) {
-        last_pc = rv->PC;
-        return ir->branch_taken->impl(rv, ir->branch_taken);
-    }
-    return true;
-})
-
-/* C.BEQZ */
-RVOP(cbnez, {
-    if (!rv->X[ir->rs1]) {
-        branch_taken = false;
-        if (!ir->branch_untaken)
-            goto nextop;
-        rv->PC += ir->insn_len;
-        last_pc = rv->PC;
-        return ir->branch_untaken->impl(rv, ir->branch_untaken);
-    }
-    branch_taken = true;
-    rv->PC += (uint32_t) ir->imm;
-    if (ir->branch_taken) {
-        last_pc = rv->PC;
-        return ir->branch_taken->impl(rv, ir->branch_taken);
-    }
-    return true;
-})
-
-/* C.SLLI is a CI-format instruction that performs a logical left shift of
- * the value in register rd then writes the result to rd. The shift amount
- * is encoded in the shamt field. C.SLLI expands into slli rd, rd, shamt[5:0].
- */
-RVOP(cslli, { rv->X[ir->rd] <<= (uint8_t) ir->imm; })
-
-/* C.LWSP */
-RVOP(clwsp, {
-    const uint32_t addr = rv->X[rv_reg_sp] + ir->imm;
-    RV_EXC_MISALIGN_HANDLER(3, load, true, 1);
-    rv->X[ir->rd] = rv->io.mem_read_w(rv, addr);
-})
-
-/* C.JR */
-RVOP(cjr, {
-    rv->PC = rv->X[ir->rs1];
-    return true;
-})
-
-/* C.MV */
-RVOP(cmv, { rv->X[ir->rd] = rv->X[ir->rs2]; })
-
-/* C.EBREAK */
-RVOP(cebreak, {
-    rv->compressed = true;
-    rv->io.on_ebreak(rv);
-    return true;
-})
-
-/* C.JALR */
-RVOP(cjalr, {
-    /* Unconditional jump and store PC+2 to ra */
-    const int32_t jump_to = rv->X[ir->rs1];
-    rv->X[rv_reg_ra] = rv->PC + ir->insn_len;
-    rv->PC = jump_to;
-    RV_EXC_MISALIGN_HANDLER(rv->PC, insn, true, 0);
-    return true;
-})
-
-/* C.ADD adds the values in registers rd and rs2 and writes the result to
- * register rd.
- * C.ADD expands into add rd, rd, rs2.
- * C.ADD is only valid when rs2=x0; the code points with rs2=x0 correspond to
- * the C.JALR and C.EBREAK instructions. The code points with rs2=x0 and rd=x0
- * are HINTs.
- */
-RVOP(cadd, { rv->X[ir->rd] = rv->X[ir->rs1] + rv->X[ir->rs2]; })
-
-/* C.SWSP */
-RVOP(cswsp, {
-    const uint32_t addr = rv->X[2] + ir->imm;
-    RV_EXC_MISALIGN_HANDLER(3, store, true, 1);
-    rv->io.mem_write_w(rv, addr, rv->X[ir->rs2]);
-})
-#endif
-
-/* auipc + addi */
-RVOP(fuse1, { rv->X[ir->rd] = (int32_t) (rv->PC + ir->imm + ir->imm2); })
-
-/* auipc + add */
-RVOP(fuse2, {
-    rv->X[ir->rd] = (int32_t) (rv->X[ir->rs1]) + (int32_t) (rv->PC + ir->imm);
-})
-
-/* multiple sw */
-RVOP(fuse3, {
-    opcode_fuse_t *fuse = ir->fuse;
-    uint32_t addr = rv->X[fuse[0].rs1] + fuse[0].imm;
-    /* the memory addresses of the sw instructions are contiguous, so we only
-     * need to check the first sw instruction to determine if its memory address
-     * is misaligned or if the memory chunk does not exist.
-     */
-    RV_EXC_MISALIGN_HANDLER(3, store, false, 1);
-    rv->io.mem_write_w(rv, addr, rv->X[fuse[0].rs2]);
-    for (int i = 1; i < ir->imm2; i++) {
-        addr = rv->X[fuse[i].rs1] + fuse[i].imm;
-        rv->io.mem_write_w(rv, addr, rv->X[fuse[i].rs2]);
-    }
-})
-
-/* multiple lw */
-RVOP(fuse4, {
-    opcode_fuse_t *fuse = ir->fuse;
-    uint32_t addr = rv->X[fuse[0].rs1] + fuse[0].imm;
-    /* the memory addresses of the lw instructions are contiguous, so we only
-     * need to check the first lw instruction to determine if its memory address
-     * is misaligned or if the memory chunk does not exist.
-     */
-    RV_EXC_MISALIGN_HANDLER(3, load, false, 1);
-    rv->X[fuse[0].rd] = rv->io.mem_read_w(rv, addr);
-    for (int i = 1; i < ir->imm2; i++) {
-        addr = rv->X[fuse[i].rs1] + fuse[i].imm;
-        rv->X[fuse[i].rd] = rv->io.mem_read_w(rv, addr);
-    }
-})
+/* FIXME: Add JIT-based execution path */
 
 static const void *dispatch_table[] = {
 #define _(inst, can_branch) [rv_insn_##inst] = do_##inst,
@@ -1313,6 +213,7 @@ static inline bool insn_is_unconditional_branch(uint8_t opcode)
     return false;
 }
 
+#if !RV32_HAS(JIT)
 /* hash function is used when mapping address into the block map */
 static inline uint32_t hash(size_t k)
 {
@@ -1324,6 +225,7 @@ static inline uint32_t hash(size_t k)
 #endif
     return k;
 }
+#endif
 
 /* allocate a basic block */
 static block_t *block_alloc(const uint8_t bits)
@@ -1333,9 +235,13 @@ static block_t *block_alloc(const uint8_t bits)
     block->n_insn = 0;
     block->predict = NULL;
     block->ir = malloc(block->insn_capacity * sizeof(rv_insn_t));
+#if RV32_HAS(JIT)
+    block->hot = false;
+#endif
     return block;
 }
 
+#if !RV32_HAS(JIT)
 /* insert a block into block map */
 static void block_insert(block_map_t *map, const block_t *block)
 {
@@ -1371,6 +277,7 @@ static block_t *block_find(const block_map_t *map, const uint32_t addr)
     }
     return NULL;
 }
+#endif
 
 static void block_translate(riscv_t *rv, block_t *block)
 {
@@ -1391,6 +298,9 @@ static void block_translate(riscv_t *rv, block_t *block)
             break;
         }
         ir->impl = dispatch_table[ir->opcode];
+#if RV32_HAS(JIT)
+        ir->pc = block->pc_end;
+#endif
         /* compute the end of pc */
         block->pc_end += ir->insn_len;
         block->n_insn++;
@@ -1494,16 +404,23 @@ static void match_pattern(block_t *block)
 static block_t *prev = NULL;
 static block_t *block_find_or_translate(riscv_t *rv)
 {
+#if !RV32_HAS(JIT)
     block_map_t *map = &rv->block_map;
+
     /* lookup the next block in the block map */
     block_t *next = block_find(map, rv->PC);
+#else
+    /* lookup the next block in the block cache */
+    block_t *next = (block_t *) cache_get(rv->cache, rv->PC);
+#endif
 
     if (!next) {
+#if !RV32_HAS(JIT)
         if (map->size * 1.25 > map->block_capacity) {
             block_map_clear(map);
             prev = NULL;
         }
-
+#endif
         /* allocate a new block */
         next = block_alloc(10);
 
@@ -1515,10 +432,17 @@ static block_t *block_find_or_translate(riscv_t *rv)
             /* macro operation fusion */
             match_pattern(next);
 
-
+#if !RV32_HAS(JIT)
         /* insert the block into block map */
         block_insert(&rv->block_map, next);
-
+#else
+        /* insert the block into block cache */
+        block_t *delete_target = cache_put(rv->cache, rv->PC, &(*next));
+        if (delete_target) {
+            free(delete_target->ir);
+            free(delete_target);
+        }
+#endif
         /* update the block prediction.
          * When translating a new block, the block predictor may benefit,
          * but updating it after finding a particular block may penalize
@@ -1530,6 +454,10 @@ static block_t *block_find_or_translate(riscv_t *rv)
 
     return next;
 }
+
+#if RV32_HAS(JIT)
+typedef bool (*exec_block_func_t)(riscv_t *rv, rv_insn_t *ir);
+#endif
 
 void rv_step(riscv_t *rv, int32_t cycles)
 {
@@ -1562,7 +490,11 @@ void rv_step(riscv_t *rv, int32_t cycles)
         if (prev) {
             /* updtae previous block */
             if (prev->pc_start != last_pc)
+#if !RV32_HAS(JIT)
                 prev = block_find(&rv->block_map, last_pc);
+#else
+                prev = cache_get(rv->cache, last_pc);
+#endif
 
             rv_insn_t *last_ir = prev->ir + prev->n_insn - 1;
             /* chain block */
@@ -1575,7 +507,27 @@ void rv_step(riscv_t *rv, int32_t cycles)
         }
         last_pc = rv->PC;
 
-        /* execute the block */
+#if RV32_HAS(JIT)
+        /* execute the block by JIT compiler */
+        exec_block_func_t code = NULL;
+        if (block->hot)
+            code = (exec_block_func_t) cache_get(rv->code_cache, rv->PC);
+        if (!code) {
+            /* check if using frequency of block exceed threshold */
+            if ((block->hot = cache_hot(rv->cache, block->pc_start))) {
+                code = (exec_block_func_t) block_compile(rv);
+                cache_put(rv->code_cache, rv->PC, code);
+            }
+        }
+        if (code) {
+            /* execute machine code */
+            if (unlikely(!code(rv, block->ir)))
+                break;
+            prev = block;
+            continue;
+        }
+#endif
+        /* execute the block by interpreter */
         const rv_insn_t *ir = block->ir;
         if (unlikely(!ir->impl(rv, ir)))
             break;

--- a/src/feature.h
+++ b/src/feature.h
@@ -53,6 +53,11 @@
 #define RV32_FEATURE_ARC 0
 #endif
 
+/* Cache */
+#ifndef RV32_FEATURE_JIT
+#define RV32_FEATURE_JIT 0
+#endif
+
 /* Feature test macro */
 #define RV32_HAS(x) RV32_FEATURE_##x
 

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -8,7 +8,9 @@
 #include <string.h>
 
 #include "riscv_private.h"
+#include "utils.h"
 
+#if !RV32_HAS(JIT)
 /* initialize the block map */
 static void block_map_init(block_map_t *map, const uint8_t bits)
 {
@@ -33,6 +35,7 @@ void block_map_clear(block_map_t *map)
     }
     map->size = 0;
 }
+#endif
 
 riscv_user_t rv_userdata(riscv_t *rv)
 {
@@ -92,8 +95,13 @@ riscv_t *rv_create(const riscv_io_t *io,
 
     rv->output_exit_code = output_exit_code;
 
+#if !RV32_HAS(JIT)
     /* initialize the block map */
     block_map_init(&rv->block_map, 10);
+#else
+    rv->cache = cache_create(10);
+    rv->code_cache = cache_create(6);
+#endif
 
     /* reset */
     rv_reset(rv, 0U);
@@ -116,11 +124,23 @@ bool rv_enables_to_output_exit_code(riscv_t *rv)
     return rv->output_exit_code;
 }
 
+#if RV32_HAS(JIT)
+static void release_block(void *block)
+{
+    free(((block_t *) block)->ir);
+    free(block);
+}
+#endif
+
 void rv_delete(riscv_t *rv)
 {
     assert(rv);
+#if !RV32_HAS(JIT)
     block_map_clear(&rv->block_map);
     free(rv->block_map.map);
+#else
+    cache_free(rv->cache, release_block);
+#endif
     free(rv);
 }
 
@@ -148,3 +168,124 @@ void rv_reset(riscv_t *rv, riscv_word_t pc)
 
     rv->halt = false;
 }
+
+/* get current time in microsecnds and update csr_time register */
+static inline void update_time(riscv_t *rv)
+{
+    struct timeval tv;
+    rv_gettimeofday(&tv);
+
+    uint64_t t = (uint64_t) tv.tv_sec * 1e6 + (uint32_t) tv.tv_usec;
+    rv->csr_time[0] = t & 0xFFFFFFFF;
+    rv->csr_time[1] = t >> 32;
+}
+
+#if RV32_HAS(Zicsr)
+/* get a pointer to a CSR */
+static uint32_t *csr_get_ptr(riscv_t *rv, uint32_t csr)
+{
+    /* csr & 0xFFF prevent sign-extension in decode stage */
+    switch (csr & 0xFFF) {
+    case CSR_MSTATUS: /* Machine Status */
+        return (uint32_t *) (&rv->csr_mstatus);
+    case CSR_MTVEC: /* Machine Trap Handler */
+        return (uint32_t *) (&rv->csr_mtvec);
+    case CSR_MISA: /* Machine ISA and Extensions */
+        return (uint32_t *) (&rv->csr_misa);
+
+    /* Machine Trap Handling */
+    case CSR_MSCRATCH: /* Machine Scratch Register */
+        return (uint32_t *) (&rv->csr_mscratch);
+    case CSR_MEPC: /* Machine Exception Program Counter */
+        return (uint32_t *) (&rv->csr_mepc);
+    case CSR_MCAUSE: /* Machine Exception Cause */
+        return (uint32_t *) (&rv->csr_mcause);
+    case CSR_MTVAL: /* Machine Trap Value */
+        return (uint32_t *) (&rv->csr_mtval);
+    case CSR_MIP: /* Machine Interrupt Pending */
+        return (uint32_t *) (&rv->csr_mip);
+
+    /* Machine Counter/Timers */
+    case CSR_CYCLE: /* Cycle counter for RDCYCLE instruction */
+        return &((uint32_t *) &rv->csr_cycle)[0];
+    case CSR_CYCLEH: /* Upper 32 bits of cycle */
+        return &((uint32_t *) &rv->csr_cycle)[1];
+
+    /* TIME/TIMEH - very roughly about 1 ms per tick */
+    case CSR_TIME: { /* Timer for RDTIME instruction */
+        update_time(rv);
+        return &rv->csr_time[0];
+    }
+    case CSR_TIMEH: { /* Upper 32 bits of time */
+        update_time(rv);
+        return &rv->csr_time[1];
+    }
+    case CSR_INSTRET: /* Number of Instructions Retired Counter */
+        /* Number of Instructions Retired Counter, just use cycle */
+        return (uint32_t *) (&rv->csr_cycle);
+#if RV32_HAS(EXT_F)
+    case CSR_FFLAGS:
+        return (uint32_t *) (&rv->csr_fcsr);
+    case CSR_FCSR:
+        return (uint32_t *) (&rv->csr_fcsr);
+#endif
+    default:
+        return NULL;
+    }
+}
+
+static inline bool csr_is_writable(uint32_t csr)
+{
+    return csr < 0xc00;
+}
+
+uint32_t csr_csrrw(riscv_t *rv, uint32_t csr, uint32_t val)
+{
+    uint32_t *c = csr_get_ptr(rv, csr);
+    if (!c)
+        return 0;
+
+    uint32_t out = *c;
+#if RV32_HAS(EXT_F)
+    if (csr == CSR_FFLAGS)
+        out &= FFLAG_MASK;
+#endif
+    if (csr_is_writable(csr))
+        *c = val;
+
+    return out;
+}
+
+uint32_t csr_csrrs(riscv_t *rv, uint32_t csr, uint32_t val)
+{
+    uint32_t *c = csr_get_ptr(rv, csr);
+    if (!c)
+        return 0;
+
+    uint32_t out = *c;
+#if RV32_HAS(EXT_F)
+    if (csr == CSR_FFLAGS)
+        out &= FFLAG_MASK;
+#endif
+    if (csr_is_writable(csr))
+        *c |= val;
+
+    return out;
+}
+
+uint32_t csr_csrrc(riscv_t *rv, uint32_t csr, uint32_t val)
+{
+    uint32_t *c = csr_get_ptr(rv, csr);
+    if (!c)
+        return 0;
+
+    uint32_t out = *c;
+#if RV32_HAS(EXT_F)
+    if (csr == CSR_FFLAGS)
+        out &= FFLAG_MASK;
+#endif
+    if (csr_is_writable(csr))
+        *c &= ~val;
+    return out;
+}
+#endif

--- a/src/riscv_private.h
+++ b/src/riscv_private.h
@@ -12,7 +12,9 @@
 #endif
 #include "decode.h"
 #include "riscv.h"
-
+#if RV32_HAS(JIT)
+#include "cache.h"
+#endif
 /* CSRs */
 enum {
     /* floating point */
@@ -59,8 +61,12 @@ typedef struct block {
     uint32_t insn_capacity;    /**< maximum of instructions encompased */
     struct block *predict;     /**< block prediction */
     rv_insn_t *ir;             /**< IR as memory blocks */
+#if RV32_HAS(JIT)
+    bool hot; /**< Determine the block is hotspot or not */
+#endif
 } block_t;
 
+#if !RV32_HAS(JIT)
 typedef struct {
     uint32_t block_capacity; /**< max number of entries in the block map */
     uint32_t size;           /**< number of entries currently in the map */
@@ -69,6 +75,7 @@ typedef struct {
 
 /* clear all block in the block map */
 void block_map_clear(block_map_t *map);
+#endif
 
 struct riscv_internal {
     bool halt;
@@ -119,8 +126,13 @@ struct riscv_internal {
     uint32_t csr_mip;
     uint32_t csr_mbadaddr;
 
-    bool compressed;       /**< current instruction is compressed or not */
+    bool compressed; /**< current instruction is compressed or not */
+#if !RV32_HAS(JIT)
     block_map_t block_map; /**< basic block map */
+#else
+    struct cache *cache;
+    struct cache *code_cache;
+#endif
 
     /* print exit code on syscall_exit */
     bool output_exit_code;
@@ -137,3 +149,39 @@ static inline uint32_t sign_extend_b(const uint32_t x)
 {
     return (int32_t) ((int8_t) x);
 }
+
+#if RV32_HAS(EXT_F)
+#include <math.h>
+#include "softfloat.h"
+
+#if defined(__APPLE__)
+static inline int isinff(float x)
+{
+    return __builtin_fabsf(x) == __builtin_inff();
+}
+static inline int isnanf(float x)
+{
+    return x != x;
+}
+#endif
+#endif /* RV32_HAS(EXT_F) */
+
+#if RV32_HAS(Zicsr)
+/* CSRRW (Atomic Read/Write CSR) instruction atomically swaps values in the
+ * CSRs and integer registers. CSRRW reads the old value of the CSR,
+ * zero-extends the value to XLEN bits, and then writes it to register rd.
+ * The initial value in rs1 is written to the CSR.
+ * If rd == x0, then the instruction shall not read the CSR and shall not cause
+ * any of the side effects that might occur on a CSR read.
+ */
+uint32_t csr_csrrw(riscv_t *rv, uint32_t csr, uint32_t val);
+
+/* perform csrrs (atomic read and set) */
+uint32_t csr_csrrs(riscv_t *rv, uint32_t csr, uint32_t val);
+
+/* perform csrrc (atomic read and clear)
+ * Read old value of CSR, zero-extend to XLEN bits, write to rd.
+ * Read value from rs1, use as bit mask to clear bits in CSR.
+ */
+uint32_t csr_csrrc(riscv_t *rv, uint32_t csr, uint32_t val);
+#endif

--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -1,0 +1,946 @@
+/*
+ * rv32emu is freely redistributable under the MIT License. See the file
+ * "LICENSE" for information on usage and redistribution of this file.
+ */
+
+/* Internal */
+RVOP(nop, {/* no operation */})
+
+/* LUI is used to build 32-bit constants and uses the U-type format. LUI
+ * places the U-immediate value in the top 20 bits of the destination
+ * register rd, filling in the lowest 12 bits with zeros. The 32-bit
+ * result is sign-extended to 64 bits.
+ */
+RVOP(lui, { rv->X[ir->rd] = ir->imm; })
+
+/* AUIPC is used to build pc-relative addresses and uses the U-type format.
+ * AUIPC forms a 32-bit offset from the 20-bit U-immediate, filling in the
+ * lowest 12 bits with zeros, adds this offset to the address of the AUIPC
+ * instruction, then places the result in register rd.
+ */
+RVOP(auipc, { rv->X[ir->rd] = ir->imm + rv->PC; })
+
+/* JAL: Jump and Link
+ * store successor instruction address into rd.
+ * add next J imm (offset) to pc.
+ */
+RVOP(jal, {
+    const uint32_t pc = rv->PC;
+    /* Jump */
+    rv->PC += ir->imm;
+    /* link with return address */
+    if (ir->rd)
+        rv->X[ir->rd] = pc + ir->insn_len;
+    /* check instruction misaligned */
+    RV_EXC_MISALIGN_HANDLER(pc, insn, false, 0);
+    return ir->branch_taken->impl(rv, ir->branch_taken);
+})
+
+/* The indirect jump instruction JALR uses the I-type encoding. The target
+ * address is obtained by adding the sign-extended 12-bit I-immediate to the
+ * register rs1, then setting the least-significant bit of the result to zero.
+ * The address of the instruction following the jump (pc+4) is written to
+ * register rd. Register x0 can be used as the destination if the result is
+ * not required.
+ */
+RVOP(jalr, {
+    const uint32_t pc = rv->PC;
+    /* jump */
+    rv->PC = (rv->X[ir->rs1] + ir->imm) & ~1U;
+    /* link */
+    if (ir->rd)
+        rv->X[ir->rd] = pc + ir->insn_len;
+    /* check instruction misaligned */
+    RV_EXC_MISALIGN_HANDLER(pc, insn, false, 0);
+    return true;
+})
+
+/* clang-format off */
+#define BRANCH_FUNC(type, cond)                                  \
+    const uint32_t pc = rv->PC;                                  \
+    if ((type) rv->X[ir->rs1] cond (type) rv->X[ir->rs2]) {      \
+        branch_taken = false;                                    \
+        if (!ir->branch_untaken)                                 \
+            goto nextop;                                         \
+        rv->PC += ir->insn_len;                                  \
+        last_pc = rv->PC;                                        \
+        return ir->branch_untaken->impl(rv, ir->branch_untaken); \
+    }                                                            \
+    branch_taken = true;                                         \
+    rv->PC += ir->imm;                                           \
+    /* check instruction misaligned */                           \
+    RV_EXC_MISALIGN_HANDLER(pc, insn, false, 0);                 \
+    if (ir->branch_taken) {                                      \
+        last_pc = rv->PC;                                        \
+        return ir->branch_taken->impl(rv, ir->branch_taken);     \
+    }                                                            \
+    return true;
+/* clang-format on */
+
+/* BEQ: Branch if Equal */
+RVOP(beq, { BRANCH_FUNC(uint32_t, !=); })
+
+/* BNE: Branch if Not Equal */
+RVOP(bne, { BRANCH_FUNC(uint32_t, ==); })
+
+/* BLT: Branch if Less Than */
+RVOP(blt, { BRANCH_FUNC(int32_t, >=); })
+
+/* BGE: Branch if Greater Than */
+RVOP(bge, { BRANCH_FUNC(int32_t, <); })
+
+/* BLTU: Branch if Less Than Unsigned */
+RVOP(bltu, { BRANCH_FUNC(uint32_t, >=); })
+
+/* BGEU: Branch if Greater Than Unsigned */
+RVOP(bgeu, { BRANCH_FUNC(uint32_t, <); })
+
+/* LB: Load Byte */
+RVOP(lb, {
+    rv->X[ir->rd] =
+        sign_extend_b(rv->io.mem_read_b(rv, rv->X[ir->rs1] + ir->imm));
+})
+
+/* LH: Load Halfword */
+RVOP(lh, {
+    const uint32_t addr = rv->X[ir->rs1] + ir->imm;
+    RV_EXC_MISALIGN_HANDLER(1, load, false, 1);
+    rv->X[ir->rd] = sign_extend_h(rv->io.mem_read_s(rv, addr));
+})
+
+/* LW: Load Word */
+RVOP(lw, {
+    const uint32_t addr = rv->X[ir->rs1] + ir->imm;
+    RV_EXC_MISALIGN_HANDLER(3, load, false, 1);
+    rv->X[ir->rd] = rv->io.mem_read_w(rv, addr);
+})
+
+/* LBU: Load Byte Unsigned */
+RVOP(lbu, { rv->X[ir->rd] = rv->io.mem_read_b(rv, rv->X[ir->rs1] + ir->imm); })
+
+/* LHU: Load Halfword Unsigned */
+RVOP(lhu, {
+    const uint32_t addr = rv->X[ir->rs1] + ir->imm;
+    RV_EXC_MISALIGN_HANDLER(1, load, false, 1);
+    rv->X[ir->rd] = rv->io.mem_read_s(rv, addr);
+})
+
+/* SB: Store Byte */
+RVOP(sb, { rv->io.mem_write_b(rv, rv->X[ir->rs1] + ir->imm, rv->X[ir->rs2]); })
+
+/* SH: Store Halfword */
+RVOP(sh, {
+    const uint32_t addr = rv->X[ir->rs1] + ir->imm;
+    RV_EXC_MISALIGN_HANDLER(1, store, false, 1);
+    rv->io.mem_write_s(rv, addr, rv->X[ir->rs2]);
+})
+
+/* SW: Store Word */
+RVOP(sw, {
+    const uint32_t addr = rv->X[ir->rs1] + ir->imm;
+    RV_EXC_MISALIGN_HANDLER(3, store, false, 1);
+    rv->io.mem_write_w(rv, addr, rv->X[ir->rs2]);
+})
+
+/* ADDI adds the sign-extended 12-bit immediate to register rs1. Arithmetic
+ * overflow is ignored and the result is simply the low XLEN bits of the
+ * result. ADDI rd, rs1, 0 is used to implement the MV rd, rs1 assembler
+ * pseudo-instruction.
+ */
+RVOP(addi, { rv->X[ir->rd] = (int32_t) (rv->X[ir->rs1]) + ir->imm; })
+
+/* SLTI place the value 1 in register rd if register rs1 is less than the
+ * signextended immediate when both are treated as signed numbers, else 0 is
+ * written to rd.
+ */
+RVOP(slti, { rv->X[ir->rd] = ((int32_t) (rv->X[ir->rs1]) < ir->imm) ? 1 : 0; })
+
+/* SLTIU places the value 1 in register rd if register rs1 is less than the
+ * immediate when both are treated as unsigned numbers, else 0 is written to rd.
+ */
+RVOP(sltiu, { rv->X[ir->rd] = (rv->X[ir->rs1] < (uint32_t) ir->imm) ? 1 : 0; })
+
+/* XORI: Exclusive OR Immediate */
+RVOP(xori, { rv->X[ir->rd] = rv->X[ir->rs1] ^ ir->imm; })
+
+/* ORI: OR Immediate */
+RVOP(ori, { rv->X[ir->rd] = rv->X[ir->rs1] | ir->imm; })
+
+/* ANDI performs bitwise AND on register rs1 and the sign-extended 12-bit
+ * immediate and place the result in rd.
+ */
+RVOP(andi, { rv->X[ir->rd] = rv->X[ir->rs1] & ir->imm; })
+
+/* SLLI performs logical left shift on the value in register rs1 by the shift
+ * amount held in the lower 5 bits of the immediate.
+ */
+RVOP(slli, { rv->X[ir->rd] = rv->X[ir->rs1] << (ir->imm & 0x1f); })
+
+/* SRLI performs logical right shift on the value in register rs1 by the shift
+ * amount held in the lower 5 bits of the immediate.
+ */
+RVOP(srli, { rv->X[ir->rd] = rv->X[ir->rs1] >> (ir->imm & 0x1f); })
+
+/* SRAI performs arithmetic right shift on the value in register rs1 by the
+ * shift amount held in the lower 5 bits of the immediate.
+ */
+RVOP(srai, { rv->X[ir->rd] = ((int32_t) rv->X[ir->rs1]) >> (ir->imm & 0x1f); })
+
+/* ADD */
+RVOP(add, {
+    rv->X[ir->rd] = (int32_t) (rv->X[ir->rs1]) + (int32_t) (rv->X[ir->rs2]);
+})
+
+/* SUB: Substract */
+RVOP(sub, {
+    rv->X[ir->rd] = (int32_t) (rv->X[ir->rs1]) - (int32_t) (rv->X[ir->rs2]);
+})
+
+/* SLL: Shift Left Logical */
+RVOP(sll, { rv->X[ir->rd] = rv->X[ir->rs1] << (rv->X[ir->rs2] & 0x1f); })
+
+/* SLT: Set on Less Than */
+RVOP(slt, {
+    rv->X[ir->rd] =
+        ((int32_t) (rv->X[ir->rs1]) < (int32_t) (rv->X[ir->rs2])) ? 1 : 0;
+})
+
+/* SLTU: Set on Less Than Unsigned */
+RVOP(sltu, { rv->X[ir->rd] = (rv->X[ir->rs1] < rv->X[ir->rs2]) ? 1 : 0; })
+
+/* XOR: Exclusive OR */
+RVOP(xor, {
+  rv->X[ir->rd] = rv->X[ir->rs1] ^ rv->X[ir->rs2];
+})
+
+/* SRL: Shift Right Logical */
+RVOP(srl, { rv->X[ir->rd] = rv->X[ir->rs1] >> (rv->X[ir->rs2] & 0x1f); })
+
+/* SRA: Shift Right Arithmetic */
+RVOP(sra,
+     { rv->X[ir->rd] = ((int32_t) rv->X[ir->rs1]) >> (rv->X[ir->rs2] & 0x1f); })
+
+/* OR */
+RVOP(or, { rv->X[ir->rd] = rv->X[ir->rs1] | rv->X[ir->rs2]; })
+
+/* AND */
+RVOP(and, { rv->X[ir->rd] = rv->X[ir->rs1] & rv->X[ir->rs2]; })
+
+/* ECALL: Environment Call */
+RVOP(ecall, {
+    rv->compressed = false;
+    rv->io.on_ecall(rv);
+    return true;
+})
+
+/* EBREAK: Environment Break */
+RVOP(ebreak, {
+    rv->compressed = false;
+    rv->io.on_ebreak(rv);
+    return true;
+})
+
+/* WFI: Wait for Interrupt */
+RVOP(wfi, {
+    /* FIXME: Implement */
+    return false;
+})
+
+/* URET: return from traps in U-mode */
+RVOP(uret, {
+    /* FIXME: Implement */
+    return false;
+})
+
+/* SRET: return from traps in S-mode */
+RVOP(sret, {
+    /* FIXME: Implement */
+    return false;
+})
+
+/* HRET: return from traps in H-mode */
+RVOP(hret, {
+    /* FIXME: Implement */
+    return false;
+})
+
+/* MRET: return from traps in U-mode */
+RVOP(mret, {
+    rv->PC = rv->csr_mepc;
+    return true;
+})
+
+#if RV32_HAS(Zifencei) /* RV32 Zifencei Standard Extension */
+RVOP(fencei, {
+    rv->PC += ir->insn_len;
+    /* FIXME: fill real implementations */
+    return true;
+})
+#endif
+
+#if RV32_HAS(Zicsr) /* RV32 Zicsr Standard Extension */
+/* CSRRW: Atomic Read/Write CSR */
+RVOP(csrrw, {
+    uint32_t tmp = csr_csrrw(rv, ir->imm, rv->X[ir->rs1]);
+    rv->X[ir->rd] = ir->rd ? tmp : rv->X[ir->rd];
+})
+
+/* CSRRS: Atomic Read and Set Bits in CSR */
+RVOP(csrrs, {
+    uint32_t tmp =
+        csr_csrrs(rv, ir->imm, (ir->rs1 == rv_reg_zero) ? 0U : rv->X[ir->rs1]);
+    rv->X[ir->rd] = ir->rd ? tmp : rv->X[ir->rd];
+})
+
+/* CSRRC: Atomic Read and Clear Bits in CSR */
+RVOP(csrrc, {
+    uint32_t tmp =
+        csr_csrrc(rv, ir->imm, (ir->rs1 == rv_reg_zero) ? ~0U : rv->X[ir->rs1]);
+    rv->X[ir->rd] = ir->rd ? tmp : rv->X[ir->rd];
+})
+
+/* CSRRWI */
+RVOP(csrrwi, {
+    uint32_t tmp = csr_csrrw(rv, ir->imm, ir->rs1);
+    rv->X[ir->rd] = ir->rd ? tmp : rv->X[ir->rd];
+})
+
+/* CSRRSI */
+RVOP(csrrsi, {
+    uint32_t tmp = csr_csrrs(rv, ir->imm, ir->rs1);
+    rv->X[ir->rd] = ir->rd ? tmp : rv->X[ir->rd];
+})
+
+/* CSRRCI */
+RVOP(csrrci, {
+    uint32_t tmp = csr_csrrc(rv, ir->imm, ir->rs1);
+    rv->X[ir->rd] = ir->rd ? tmp : rv->X[ir->rd];
+})
+#endif
+
+#if RV32_HAS(EXT_M) /* RV32M Standard Extension */
+/* MUL: Multiply */
+RVOP(mul,
+     { rv->X[ir->rd] = (int32_t) rv->X[ir->rs1] * (int32_t) rv->X[ir->rs2]; })
+
+/* MULH: Multiply High Signed Signed */
+RVOP(mulh, {
+    const int64_t multiplicand = (int32_t) rv->X[ir->rs1];
+    const int64_t multiplier = (int32_t) rv->X[ir->rs2];
+    rv->X[ir->rd] = ((uint64_t) (multiplicand * multiplier)) >> 32;
+})
+
+/* MULHSU: Multiply High Signed Unsigned */
+RVOP(mulhsu, {
+    const int64_t multiplicand = (int32_t) rv->X[ir->rs1];
+    const uint64_t umultiplier = rv->X[ir->rs2];
+    rv->X[ir->rd] = ((uint64_t) (multiplicand * umultiplier)) >> 32;
+})
+
+/* MULHU: Multiply High Unsigned Unsigned */
+RVOP(mulhu, {
+    rv->X[ir->rd] =
+        ((uint64_t) rv->X[ir->rs1] * (uint64_t) rv->X[ir->rs2]) >> 32;
+})
+
+/* DIV: Divide Signed */
+/* +------------------------+-----------+----------+-----------+
+ * |       Condition        |  Dividend |  Divisor |   DIV[W]  |
+ * +------------------------+-----------+----------+-----------+
+ * | Division by zero       |  x        |  0       |  −1       |
+ * | Overflow (signed only) |  −2^{L−1} |  −1      |  −2^{L−1} |
+ * +------------------------+-----------+----------+-----------+
+ */
+RVOP(div, {
+    const int32_t dividend = (int32_t) rv->X[ir->rs1];
+    const int32_t divisor = (int32_t) rv->X[ir->rs2];
+    rv->X[ir->rd] = !divisor ? ~0U
+                    : (divisor == -1 && rv->X[ir->rs1] == 0x80000000U)
+                        ? rv->X[ir->rs1] /* overflow */
+                        : (unsigned int) (dividend / divisor);
+})
+
+/* DIVU: Divide Unsigned */
+/* +------------------------+-----------+----------+----------+
+ * |       Condition        |  Dividend |  Divisor |  DIVU[W] |
+ * +------------------------+-----------+----------+----------+
+ * | Division by zero       |  x        |  0       |  2^L − 1 |
+ * +------------------------+-----------+----------+----------+
+ */
+RVOP(divu, {
+    const uint32_t udividend = rv->X[ir->rs1];
+    const uint32_t udivisor = rv->X[ir->rs2];
+    rv->X[ir->rd] = !udivisor ? ~0U : udividend / udivisor;
+})
+
+/* REM: Remainder Signed */
+/* +------------------------+-----------+----------+---------+
+ * |       Condition        |  Dividend |  Divisor |  REM[W] |
+ * +------------------------+-----------+----------+---------+
+ * | Division by zero       |  x        |  0       |  x      |
+ * | Overflow (signed only) |  −2^{L−1} |  −1      |  0      |
+ * +------------------------+-----------+----------+---------+
+ */
+RVOP(rem, {
+    const int32_t dividend = rv->X[ir->rs1];
+    const int32_t divisor = rv->X[ir->rs2];
+    rv->X[ir->rd] = !divisor ? dividend
+                    : (divisor == -1 && rv->X[ir->rs1] == 0x80000000U)
+                        ? 0 /* overflow */
+                        : (dividend % divisor);
+})
+
+/* REMU: Remainder Unsigned */
+/* +------------------------+-----------+----------+----------+
+ * |       Condition        |  Dividend |  Divisor |  REMU[W] |
+ * +------------------------+-----------+----------+----------+
+ * | Division by zero       |  x        |  0       |  x       |
+ * +------------------------+-----------+----------+----------+
+ */
+RVOP(remu, {
+    const uint32_t udividend = rv->X[ir->rs1];
+    const uint32_t udivisor = rv->X[ir->rs2];
+    rv->X[ir->rd] = !udivisor ? udividend : udividend % udivisor;
+})
+#endif
+
+#if RV32_HAS(EXT_A) /* RV32A Standard Extension */
+/* At present, AMO is not implemented atomically because the emulated RISC-V
+ * core just runs on single thread, and no out-of-order execution happens.
+ * In addition, rl/aq are not handled.
+ */
+
+/* LR.W: Load Reserved */
+RVOP(lrw, {
+    rv->X[ir->rd] = rv->io.mem_read_w(rv, rv->X[ir->rs1]);
+    /* skip registration of the 'reservation set'
+     * FIXME: uimplemented
+     */
+})
+
+/* SC.W: Store Conditional */
+RVOP(scw, {
+    /* assume the 'reservation set' is valid
+     * FIXME: unimplemented
+     */
+    rv->io.mem_write_w(rv, rv->X[ir->rs1], rv->X[ir->rs2]);
+    rv->X[ir->rd] = 0;
+})
+
+/* AMOSWAP.W: Atomic Swap */
+RVOP(amoswapw, {
+    rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
+    rv->io.mem_write_s(rv, ir->rs1, rv->X[ir->rs2]);
+})
+
+/* AMOADD.W: Atomic ADD */
+RVOP(amoaddw, {
+    rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
+    const int32_t res = (int32_t) rv->X[ir->rd] + (int32_t) rv->X[ir->rs2];
+    rv->io.mem_write_s(rv, ir->rs1, res);
+})
+
+/* AMOXOR.W: Atomix XOR */
+RVOP(amoxorw, {
+    rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
+    const int32_t res = rv->X[ir->rd] ^ rv->X[ir->rs2];
+    rv->io.mem_write_s(rv, ir->rs1, res);
+})
+
+/* AMOAND.W: Atomic AND */
+RVOP(amoandw, {
+    rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
+    const int32_t res = rv->X[ir->rd] & rv->X[ir->rs2];
+    rv->io.mem_write_s(rv, ir->rs1, res);
+})
+
+/* AMOOR.W: Atomic OR */
+RVOP(amoorw, {
+    rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
+    const int32_t res = rv->X[ir->rd] | rv->X[ir->rs2];
+    rv->io.mem_write_s(rv, ir->rs1, res);
+})
+
+/* AMOMIN.W: Atomic MIN */
+RVOP(amominw, {
+    rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
+    const int32_t res =
+        rv->X[ir->rd] < rv->X[ir->rs2] ? rv->X[ir->rd] : rv->X[ir->rs2];
+    rv->io.mem_write_s(rv, ir->rs1, res);
+})
+
+/* AMOMAX.W: Atomic MAX */
+RVOP(amomaxw, {
+    rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
+    const int32_t res =
+        rv->X[ir->rd] > rv->X[ir->rs2] ? rv->X[ir->rd] : rv->X[ir->rs2];
+    rv->io.mem_write_s(rv, ir->rs1, res);
+})
+
+/* AMOMINU.W */
+RVOP(amominuw, {
+    rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
+    const uint32_t ures =
+        rv->X[ir->rd] < rv->X[ir->rs2] ? rv->X[ir->rd] : rv->X[ir->rs2];
+    rv->io.mem_write_s(rv, ir->rs1, ures);
+})
+
+/* AMOMAXU.W */
+RVOP(amomaxuw, {
+    rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
+    const uint32_t ures =
+        rv->X[ir->rd] > rv->X[ir->rs2] ? rv->X[ir->rd] : rv->X[ir->rs2];
+    rv->io.mem_write_s(rv, ir->rs1, ures);
+})
+#endif /* RV32_HAS(EXT_A) */
+
+#if RV32_HAS(EXT_F) /* RV32F Standard Extension */
+/* FLW */
+RVOP(flw, {
+    /* copy into the float register */
+    const uint32_t data = rv->io.mem_read_w(rv, rv->X[ir->rs1] + ir->imm);
+    rv->F_int[ir->rd] = data;
+})
+
+/* FSW */
+RVOP(fsw, {
+    /* copy from float registers */
+    uint32_t data = rv->F_int[ir->rs2];
+    rv->io.mem_write_w(rv, rv->X[ir->rs1] + ir->imm, data);
+})
+
+/* FMADD.S */
+RVOP(fmadds,
+     { rv->F[ir->rd] = rv->F[ir->rs1] * rv->F[ir->rs2] + rv->F[ir->rs3]; })
+
+/* FMSUB.S */
+RVOP(fmsubs,
+     { rv->F[ir->rd] = rv->F[ir->rs1] * rv->F[ir->rs2] - rv->F[ir->rs3]; })
+
+/* FNMSUB.S */
+RVOP(fnmsubs,
+     { rv->F[ir->rd] = rv->F[ir->rs3] - (rv->F[ir->rs1] * rv->F[ir->rs2]); })
+
+/* FNMADD.S */
+RVOP(fnmadds,
+     { rv->F[ir->rd] = -(rv->F[ir->rs1] * rv->F[ir->rs2]) - rv->F[ir->rs3]; })
+
+/* FADD.S */
+RVOP(fadds, {
+    if (isnanf(rv->F[ir->rs1]) || isnanf(rv->F[ir->rs2]) ||
+        isnanf(rv->F[ir->rs1] + rv->F[ir->rs2])) {
+        /* raise invalid operation */
+        rv->F_int[ir->rd] = RV_NAN; /* F_int is the integer shortcut of F */
+        rv->csr_fcsr |= FFLAG_INVALID_OP;
+    } else {
+        rv->F[ir->rd] = rv->F[ir->rs1] + rv->F[ir->rs2];
+    }
+    if (isinff(rv->F[ir->rd])) {
+        rv->csr_fcsr |= FFLAG_OVERFLOW;
+        rv->csr_fcsr |= FFLAG_INEXACT;
+    }
+})
+
+/* FSUB.S */
+RVOP(fsubs, {
+    if (isnanf(rv->F[ir->rs1]) || isnanf(rv->F[ir->rs2])) {
+        rv->F_int[ir->rd] = RV_NAN;
+    } else {
+        rv->F[ir->rd] = rv->F[ir->rs1] - rv->F[ir->rs2];
+    }
+})
+
+/* FMUL.S */
+RVOP(fmuls, { rv->F[ir->rd] = rv->F[ir->rs1] * rv->F[ir->rs2]; })
+
+/* FDIV.S */
+RVOP(fdivs, { rv->F[ir->rd] = rv->F[ir->rs1] / rv->F[ir->rs2]; })
+
+/* FSQRT.S */
+RVOP(fsqrts, { rv->F[ir->rd] = sqrtf(rv->F[ir->rs1]); })
+
+/* FSGNJ.S */
+RVOP(fsgnjs, {
+    const uint32_t ures = (((uint32_t) rv->F_int[ir->rs1]) & ~FMASK_SIGN) |
+                          (((uint32_t) rv->F_int[ir->rs2]) & FMASK_SIGN);
+    rv->F_int[ir->rd] = ures;
+})
+
+/* FSGNJN.S */
+RVOP(fsgnjns, {
+    const uint32_t ures = (((uint32_t) rv->F_int[ir->rs1]) & ~FMASK_SIGN) |
+                          (~((uint32_t) rv->F_int[ir->rs2]) & FMASK_SIGN);
+    rv->F_int[ir->rd] = ures;
+})
+
+/* FSGNJX.S */
+RVOP(fsgnjxs, {
+    const uint32_t ures = ((uint32_t) rv->F_int[ir->rs1]) ^
+                          (((uint32_t) rv->F_int[ir->rs2]) & FMASK_SIGN);
+    rv->F_int[ir->rd] = ures;
+})
+
+/* FMIN.S
+ * In IEEE754-201x, fmin(x, y) return
+ * - min(x,y) if both numbers are not NaN
+ * - if one is NaN and another is a number, return the number
+ * - if both are NaN, return NaN
+ * When input is signaling NaN, raise invalid operation
+ */
+RVOP(fmins, {
+    uint32_t a = rv->F_int[ir->rs1];
+    uint32_t b = rv->F_int[ir->rs2];
+    if (is_nan(a) || is_nan(b)) {
+        if (is_snan(a) || is_snan(b))
+            rv->csr_fcsr |= FFLAG_INVALID_OP;
+        if (is_nan(a) && !is_nan(b)) {
+            rv->F[ir->rd] = rv->F[ir->rs2];
+        } else if (!is_nan(a) && is_nan(b)) {
+            rv->F[ir->rd] = rv->F[ir->rs1];
+        } else {
+            rv->F_int[ir->rd] = RV_NAN;
+        }
+    } else {
+        uint32_t a_sign = a & FMASK_SIGN;
+        uint32_t b_sign = b & FMASK_SIGN;
+        if (a_sign != b_sign) {
+            rv->F[ir->rd] = a_sign ? rv->F[ir->rs1] : rv->F[ir->rs2];
+        } else {
+            rv->F[ir->rd] = (rv->F[ir->rs1] < rv->F[ir->rs2]) ? rv->F[ir->rs1]
+                                                              : rv->F[ir->rs2];
+        }
+    }
+})
+
+/* FMAX.S */
+RVOP(fmaxs, {
+    uint32_t a = rv->F_int[ir->rs1];
+    uint32_t b = rv->F_int[ir->rs2];
+    if (is_nan(a) || is_nan(b)) {
+        if (is_snan(a) || is_snan(b))
+            rv->csr_fcsr |= FFLAG_INVALID_OP;
+        if (is_nan(a) && !is_nan(b)) {
+            rv->F[ir->rd] = rv->F[ir->rs2];
+        } else if (!is_nan(a) && is_nan(b)) {
+            rv->F[ir->rd] = rv->F[ir->rs1];
+        } else {
+            rv->F_int[ir->rd] = RV_NAN;
+        }
+    } else {
+        uint32_t a_sign = a & FMASK_SIGN;
+        uint32_t b_sign = b & FMASK_SIGN;
+        if (a_sign != b_sign) {
+            rv->F[ir->rd] = a_sign ? rv->F[ir->rs2] : rv->F[ir->rs1];
+        } else {
+            rv->F[ir->rd] = (rv->F[ir->rs1] > rv->F[ir->rs2]) ? rv->F[ir->rs1]
+                                                              : rv->F[ir->rs2];
+        }
+    }
+})
+
+/* FCVT.W.S and FCVT.WU.S convert a floating point number to an integer,
+ * the rounding mode is specified in rm field.
+ */
+
+/* FCVT.W.S */
+RVOP(fcvtws, { rv->X[ir->rd] = (int32_t) rv->F[ir->rs1]; })
+
+/* FCVT.WU.S */
+RVOP(fcvtwus, { rv->X[ir->rd] = (uint32_t) rv->F[ir->rs1]; })
+
+/* FMV.X.W */
+RVOP(fmvxw, { rv->X[ir->rd] = rv->F_int[ir->rs1]; })
+
+/* FEQ.S performs a quiet comparison: it only sets the invalid operation
+ * exception flag if either input is a signaling NaN.
+ */
+RVOP(feqs, {
+    rv->X[ir->rd] = (rv->F[ir->rs1] == rv->F[ir->rs2]) ? 1 : 0;
+    if (is_snan(rv->F_int[ir->rs1]) || is_snan(rv->F_int[ir->rs2]))
+        rv->csr_fcsr |= FFLAG_INVALID_OP;
+})
+
+/* FLT.S and FLE.S perform what the IEEE 754-2008 standard refers to as
+ * signaling comparisons: that is, they set the invalid operation exception
+ * flag if either input is NaN.
+ */
+RVOP(flts, {
+    rv->X[ir->rd] = (rv->F[ir->rs1] < rv->F[ir->rs2]) ? 1 : 0;
+    if (is_nan(rv->F_int[ir->rs1]) || is_nan(rv->F_int[ir->rs2]))
+        rv->csr_fcsr |= FFLAG_INVALID_OP;
+})
+
+RVOP(fles, {
+    rv->X[ir->rd] = (rv->F[ir->rs1] <= rv->F[ir->rs2]) ? 1 : 0;
+    if (is_nan(rv->F_int[ir->rs1]) || is_nan(rv->F_int[ir->rs2]))
+        rv->csr_fcsr |= FFLAG_INVALID_OP;
+})
+
+/* FCLASS.S */
+RVOP(fclasss, {
+    uint32_t bits = rv->F_int[ir->rs1];
+    rv->X[ir->rd] = calc_fclass(bits);
+})
+
+/* FCVT.S.W */
+RVOP(fcvtsw, { rv->F[ir->rd] = (int32_t) rv->X[ir->rs1]; })
+
+/* FCVT.S.WU */
+RVOP(fcvtswu, { rv->F[ir->rd] = rv->X[ir->rs1]; })
+
+/* FMV.W.X */
+RVOP(fmvwx, { rv->F_int[ir->rd] = rv->X[ir->rs1]; })
+#endif
+
+#if RV32_HAS(EXT_C) /* RV32C Standard Extension */
+/* C.ADDI4SPN is a CIW-format instruction that adds a zero-extended non-zero
+ * immediate, scaledby 4, to the stack pointer, x2, and writes the result to
+ * rd'.
+ * This instruction is used to generate pointers to stack-allocated variables,
+ * and expands to addi rd', x2, nzuimm[9:2].
+ */
+RVOP(caddi4spn, { rv->X[ir->rd] = rv->X[2] + (uint16_t) ir->imm; })
+
+/* C.LW loads a 32-bit value from memory into register rd'. It computes an
+ * effective address by adding the zero-extended offset, scaled by 4, to the
+ * base address in register rs1'. It expands to lw rd', offset[6:2](rs1').
+ */
+RVOP(clw, {
+    const uint32_t addr = rv->X[ir->rs1] + (uint32_t) ir->imm;
+    RV_EXC_MISALIGN_HANDLER(3, load, true, 1);
+    rv->X[ir->rd] = rv->io.mem_read_w(rv, addr);
+})
+
+/* C.SW stores a 32-bit value in register rs2' to memory. It computes an
+ * effective address by adding the zero-extended offset, scaled by 4, to the
+ * base address in register rs1'.
+ * It expands to sw rs2', offset[6:2](rs1').
+ */
+RVOP(csw, {
+    const uint32_t addr = rv->X[ir->rs1] + (uint32_t) ir->imm;
+    RV_EXC_MISALIGN_HANDLER(3, store, true, 1);
+    rv->io.mem_write_w(rv, addr, rv->X[ir->rs2]);
+})
+
+/* C.NOP */
+RVOP(cnop, {/* no operation */})
+
+/* C.ADDI adds the non-zero sign-extended 6-bit immediate to the value in
+ * register rd then writes the result to rd. C.ADDI expands into
+ * addi rd, rd, nzimm[5:0]. C.ADDI is only valid when rd'=x0. The code point
+ * with both rd=x0 and nzimm=0 encodes the C.NOP instruction; the remaining
+ * code points with either rd=x0 or nzimm=0 encode HINTs.
+ */
+RVOP(caddi, { rv->X[ir->rd] += (int16_t) ir->imm; })
+
+/* C.JAL */
+RVOP(cjal, {
+    rv->X[1] = rv->PC + ir->insn_len;
+    rv->PC += ir->imm;
+    RV_EXC_MISALIGN_HANDLER(rv->PC, insn, true, 0);
+    return ir->branch_taken->impl(rv, ir->branch_taken);
+})
+
+/* C.LI loads the sign-extended 6-bit immediate, imm, into register rd.
+ * C.LI expands into addi rd, x0, imm[5:0].
+ * C.LI is only valid when rd=x0; the code points with rd=x0 encode HINTs.
+ */
+RVOP(cli, { rv->X[ir->rd] = ir->imm; })
+
+/* C.ADDI16SP is used to adjust the stack pointer in procedure prologues
+ * and epilogues. It expands into addi x2, x2, nzimm[9:4].
+ * C.ADDI16SP is only valid when nzimm'=0; the code point with nzimm=0 is
+ * reserved.
+ */
+RVOP(caddi16sp, { rv->X[ir->rd] += ir->imm; })
+
+/* C.LUI loads the non-zero 6-bit immediate field into bits 17–12 of the
+ * destination register, clears the bottom 12 bits, and sign-extends bit
+ * 17 into all higher bits of the destination.
+ * C.LUI expands into lui rd, nzimm[17:12].
+ * C.LUI is only valid when rd'={x0, x2}, and when the immediate is not equal
+ * to zero.
+ */
+RVOP(clui, { rv->X[ir->rd] = ir->imm; })
+
+/* C.SRLI is a CB-format instruction that performs a logical right shift
+ * of the value in register rd' then writes the result to rd'. The shift
+ * amount is encoded in the shamt field. C.SRLI expands into srli rd',
+ * rd', shamt[5:0].
+ */
+RVOP(csrli, { rv->X[ir->rs1] >>= ir->shamt; })
+
+/* C.SRAI is defined analogously to C.SRLI, but instead performs an
+ * arithmetic right shift. C.SRAI expands to srai rd', rd', shamt[5:0].
+ */
+RVOP(csrai, {
+    const uint32_t mask = 0x80000000 & rv->X[ir->rs1];
+    rv->X[ir->rs1] >>= ir->shamt;
+    for (unsigned int i = 0; i < ir->shamt; ++i)
+        rv->X[ir->rs1] |= mask >> i;
+})
+
+/* C.ANDI is a CB-format instruction that computes the bitwise AND of the
+ * value in register rd' and the sign-extended 6-bit immediate, then writes
+ * the result to rd'. C.ANDI expands to andi rd', rd', imm[5:0].
+ */
+RVOP(candi, { rv->X[ir->rs1] &= ir->imm; })
+
+/* C.SUB */
+RVOP(csub, { rv->X[ir->rd] = rv->X[ir->rs1] - rv->X[ir->rs2]; })
+
+/* C.XOR */
+RVOP(cxor, { rv->X[ir->rd] = rv->X[ir->rs1] ^ rv->X[ir->rs2]; })
+
+RVOP(cor, { rv->X[ir->rd] = rv->X[ir->rs1] | rv->X[ir->rs2]; })
+
+RVOP(cand, { rv->X[ir->rd] = rv->X[ir->rs1] & rv->X[ir->rs2]; })
+
+/* C.J performs an unconditional control transfer. The offset is sign-extended
+ * and added to the pc to form the jump target address.
+ * C.J can therefore target a ±2 KiB range.
+ * C.J expands to jal x0, offset[11:1].
+ */
+RVOP(cj, {
+    rv->PC += ir->imm;
+    RV_EXC_MISALIGN_HANDLER(rv->PC, insn, true, 0);
+    return ir->branch_taken->impl(rv, ir->branch_taken);
+})
+
+/* C.BEQZ performs conditional control transfers. The offset is sign-extended
+ * and added to the pc to form the branch target address.
+ * It can therefore target a ±256 B range. C.BEQZ takes the branch if the
+ * value in register rs1' is zero. It expands to beq rs1', x0, offset[8:1].
+ */
+RVOP(cbeqz, {
+    if (rv->X[ir->rs1]) {
+        branch_taken = false;
+        if (!ir->branch_untaken)
+            goto nextop;
+        rv->PC += ir->insn_len;
+        last_pc = rv->PC;
+        return ir->branch_untaken->impl(rv, ir->branch_untaken);
+    }
+    branch_taken = true;
+    rv->PC += (uint32_t) ir->imm;
+    if (ir->branch_taken) {
+        last_pc = rv->PC;
+        return ir->branch_taken->impl(rv, ir->branch_taken);
+    }
+    return true;
+})
+
+/* C.BEQZ */
+RVOP(cbnez, {
+    if (!rv->X[ir->rs1]) {
+        branch_taken = false;
+        if (!ir->branch_untaken)
+            goto nextop;
+        rv->PC += ir->insn_len;
+        last_pc = rv->PC;
+        return ir->branch_untaken->impl(rv, ir->branch_untaken);
+    }
+    branch_taken = true;
+    rv->PC += (uint32_t) ir->imm;
+    if (ir->branch_taken) {
+        last_pc = rv->PC;
+        return ir->branch_taken->impl(rv, ir->branch_taken);
+    }
+    return true;
+})
+
+/* C.SLLI is a CI-format instruction that performs a logical left shift of
+ * the value in register rd then writes the result to rd. The shift amount
+ * is encoded in the shamt field. C.SLLI expands into slli rd, rd, shamt[5:0].
+ */
+RVOP(cslli, { rv->X[ir->rd] <<= (uint8_t) ir->imm; })
+
+/* C.LWSP */
+RVOP(clwsp, {
+    const uint32_t addr = rv->X[rv_reg_sp] + ir->imm;
+    RV_EXC_MISALIGN_HANDLER(3, load, true, 1);
+    rv->X[ir->rd] = rv->io.mem_read_w(rv, addr);
+})
+
+/* C.JR */
+RVOP(cjr, {
+    rv->PC = rv->X[ir->rs1];
+    return true;
+})
+
+/* C.MV */
+RVOP(cmv, { rv->X[ir->rd] = rv->X[ir->rs2]; })
+
+/* C.EBREAK */
+RVOP(cebreak, {
+    rv->compressed = true;
+    rv->io.on_ebreak(rv);
+    return true;
+})
+
+/* C.JALR */
+RVOP(cjalr, {
+    /* Unconditional jump and store PC+2 to ra */
+    const int32_t jump_to = rv->X[ir->rs1];
+    rv->X[rv_reg_ra] = rv->PC + ir->insn_len;
+    rv->PC = jump_to;
+    RV_EXC_MISALIGN_HANDLER(rv->PC, insn, true, 0);
+    return true;
+})
+
+/* C.ADD adds the values in registers rd and rs2 and writes the result to
+ * register rd.
+ * C.ADD expands into add rd, rd, rs2.
+ * C.ADD is only valid when rs2=x0; the code points with rs2=x0 correspond to
+ * the C.JALR and C.EBREAK instructions. The code points with rs2=x0 and rd=x0
+ * are HINTs.
+ */
+RVOP(cadd, { rv->X[ir->rd] = rv->X[ir->rs1] + rv->X[ir->rs2]; })
+
+/* C.SWSP */
+RVOP(cswsp, {
+    const uint32_t addr = rv->X[2] + ir->imm;
+    RV_EXC_MISALIGN_HANDLER(3, store, true, 1);
+    rv->io.mem_write_w(rv, addr, rv->X[ir->rs2]);
+})
+#endif
+
+/* auipc + addi */
+RVOP(fuse1, { rv->X[ir->rd] = (int32_t) (rv->PC + ir->imm + ir->imm2); })
+
+/* auipc + add */
+RVOP(fuse2, {
+    rv->X[ir->rd] = (int32_t) (rv->X[ir->rs1]) + (int32_t) (rv->PC + ir->imm);
+})
+
+/* multiple sw */
+RVOP(fuse3, {
+    const opcode_fuse_t *fuse = ir->fuse;
+    uint32_t addr = rv->X[fuse[0].rs1] + fuse[0].imm;
+    /* the memory addresses of the sw instructions are contiguous, so we only
+     * need to check the first sw instruction to determine if its memory address
+     * is misaligned or if the memory chunk does not exist.
+     */
+    RV_EXC_MISALIGN_HANDLER(3, store, false, 1);
+    rv->io.mem_write_w(rv, addr, rv->X[fuse[0].rs2]);
+    for (int i = 1; i < ir->imm2; i++) {
+        addr = rv->X[fuse[i].rs1] + fuse[i].imm;
+        rv->io.mem_write_w(rv, addr, rv->X[fuse[i].rs2]);
+    }
+})
+
+/* multiple lw */
+RVOP(fuse4, {
+    const opcode_fuse_t *fuse = ir->fuse;
+    uint32_t addr = rv->X[fuse[0].rs1] + fuse[0].imm;
+    /* the memory addresses of the lw instructions are contiguous, so we only
+     * need to check the first lw instruction to determine if its memory address
+     * is misaligned or if the memory chunk does not exist.
+     */
+    RV_EXC_MISALIGN_HANDLER(3, load, false, 1);
+    rv->X[fuse[0].rd] = rv->io.mem_read_w(rv, addr);
+    for (int i = 1; i < ir->imm2; i++) {
+        addr = rv->X[fuse[i].rs1] + fuse[i].imm;
+        rv->X[fuse[i].rd] = rv->io.mem_read_w(rv, addr);
+    }
+})

--- a/src/utils.h
+++ b/src/utils.h
@@ -3,6 +3,8 @@
 #include <sys/time.h>
 #include <time.h>
 
+#define GOLDEN_RATIO_32 0x61C88647
+
 /* Obtain the system 's notion of the current Greenwich time.
  * TODO: manipulate current time zone.
  */

--- a/tests/scimark2/Makefile
+++ b/tests/scimark2/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean                                                                                                                                                 
+.PHONY: clean
 
 include ../../mk/toolchain.mk
 

--- a/tools/coremark.py
+++ b/tools/coremark.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+import subprocess
+import re
+import numpy
+import os
+
+iter = 10
+res = []
+file_exist = os.path.exists('build/rv32emu')
+if not file_exist:
+    print("Please compile before running test")
+    exit(1)
+print("Start Test CoreMark benchmark")
+comp_proc = subprocess.check_output(
+    'build/rv32emu build/coremark.elf', shell=True).decode("utf-8")
+if not comp_proc or comp_proc.find("Error") != -1:
+    print("Test Error")
+    exit(1)
+else:
+    print("Test Pass")
+
+for i in range(iter):
+    print("Running CoreMark benchmark - Run #{}".format(i + 1))
+    comp_proc = subprocess.check_output(
+        'build/rv32emu build/coremark.elf', shell=True).decode("utf-8")
+    if not comp_proc:
+        print("Fail\n")
+        exit(1)
+    else:
+        res.append(float(re.findall(
+            r'Iterations/Sec   : [0-9]+.[0-9]+', comp_proc)[0][19:]))
+
+mean = numpy.mean(res, dtype=numpy.float64)
+deviation = numpy.std(res, dtype=numpy.float64)
+for n in res:
+    if (abs(n - mean) > (deviation * 2)):
+        res.remove(n)
+
+print("{:.3f}".format(numpy.mean(res, dtype=numpy.float64)))

--- a/tools/gen-jit-template.py
+++ b/tools/gen-jit-template.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+
+'''
+This script serves as a code generator for creating JIT code templates 
+based on existing code files in the 'src' directory, eliminating the need 
+for writing duplicated code.
+'''
+
+import re
+import sys
+
+INSN = {
+    "Zifencei": ["fencei"],
+    "Zicsr": [
+        "csrrw",
+        "csrrs",
+        "csrrc",
+        "csrrw",
+        "csrrsi",
+        "csrrci"],
+    "EXT_M": [
+        "mul",
+        "mulh",
+        "mulhsu",
+        "mulhu",
+        "div",
+        "divu",
+        "rem",
+        "remu"],
+    "EXT_A": [
+        "lrw",
+        "scw",
+        "amoswapw",
+        "amoaddw",
+        "amoxorw",
+        "amoandw",
+        "amoorw",
+        "amominw",
+        "amomaxw",
+        "amominuw",
+        "amomaxuw"],
+    "EXT_F": [
+        "flw",
+        "fsw",
+        "fmadds",
+        "fmsubs",
+        "fnmsubs",
+        "fnmadds",
+        "fadds",
+        "fsubs",
+        "fmuls",
+        "fdivs",
+        "fsqrts",
+        "fsgnjs",
+        "fsgnjns",
+        "fsgnjxs",
+        "fmins",
+        "fmaxs",
+        "fcvtws",
+        "fcvtwus",
+        "fmvxw",
+        "feqs",
+        "flts",
+        "fles",
+        "fclasss",
+        "fcvtsw",
+        "fcvtswu",
+        "fmvwx"],
+    "EXT_C": [
+        "caddi4spn",
+        "clw",
+        "csw",
+        "cnop",
+        "caddi",
+        "cjal",
+        "cli",
+        "caddi16sp",
+        "clui",
+        "csrli",
+        "csrai",
+        "candi",
+        "csub",
+        "cxor",
+        "cor",
+        "cand",
+        "cj",
+        "cbeqz",
+        "cbnez",
+        "cslli",
+        "clwsp",
+        "cjr",
+        "cmv",
+        "cebreak",
+        "cjalr",
+        "cadd",
+        "cswsp",
+    ],
+}
+EXT_LIST = ["Zifencei", "Zicsr", "EXT_M", "EXT_A", "EXT_F", "EXT_C"]
+SKIPLIST = [
+    "jal",
+    "beq",
+    "bne",
+    "blt",
+    "bge",
+    "bltu",
+    "bgeu",
+    "lb",
+    "lh",
+    "lw",
+    "lbu",
+    "lhu",
+    "sb",
+    "sh",
+    "sw",
+    "clw",
+    "csw",
+    "cjal",
+    "cj",
+    "cbeqz",
+    "cbnez",
+    "fuse3",
+    "fuse4"]
+# check enabled extension in Makefile
+
+def parse_argv(EXT_LIST, SKIPLIST):
+    for argv in sys.argv:
+        if argv.find("RV32_FEATURE_") != -1:
+            ext = argv[argv.find("RV32_FEATURE_") + 13:-2]
+            if argv[-1:] == "1" and EXT_LIST.count(ext):
+                EXT_LIST.remove(ext)
+    for ext in EXT_LIST:
+        SKIPLIST += INSN[ext]
+
+
+def remove_comment(str):
+    return re.sub(r'/\*[\s|\S]+?\*/\n', "", str)
+
+parse_argv(EXT_LIST, SKIPLIST)
+# prepare PROLOGUE
+output = "#define PROLOGUE\\\n  \"#include <stdint.h>\\n\"\\\n \"#include <stdbool.h>\\n\"\\\n"
+f = open('src/riscv.h', 'r')
+lines = f.read()
+lines = remove_comment(lines)
+output = output + "\"" + \
+    re.sub("\n", "\"\\\n\"", re.findall(
+        r'enum[\S|\s]+?riscv_io_t;', lines)[0]) + "\"\\\n"
+f = open('src/riscv_private.h', 'r')
+lines = f.read()
+lines = remove_comment(lines)
+lines = re.sub(r'#if RV32_HAS\(GDBSTUB\)[\s|\S]+?#endif\n', "", lines)
+lines = re.sub(r'#if !RV32_HAS\(JIT\)[\s|\S]+?#endif\n', "", lines)
+lines = re.sub(r"#if RV32_HAS\(EXT_F\)", "", lines)
+lines = re.sub('#endif\n', "", lines)
+output = output + "\"" + \
+    re.sub("\n", "\"\\\n\"", re.findall(
+        r'struct riscv_internal[\S|\s]+?bool output_exit_code;\n};', lines)[0]) + "\"\\\n"
+f = open('src/io.h', 'r')
+lines = f.read()
+lines = remove_comment(lines)
+output = output + "\"" + \
+    re.sub("\n", "\"\\\n\"", re.findall(
+        r'typedef[\S|\s]+?memory_t;', lines)[0]) + "\"\\\n"
+f = open('src/state.h', 'r')
+lines = f.read()
+lines = remove_comment(lines)
+lines = re.sub('map_t fd_map;', "", lines)
+output = output + "\"" + \
+    re.sub("\n", "\"\\\n\"", re.findall(
+        r'typedef[\S|\s]+?state_t;', lines)[0]) + "\"\\\n"
+f = open('src/decode.h', 'r')
+lines = f.read()
+lines = remove_comment(lines)
+lines = re.sub(r'#if[\s|\S]+?\)\n', "", lines)
+lines = re.sub('#endif\n', "", lines)
+output = output + "\"" + \
+    re.sub("\n", "\"\\\n\"", re.findall(
+        r'typedef[\S|\s]+?rv_insn_t;', lines)[0]) + "\"\\\n"
+output += "\"bool start(volatile riscv_t *rv, rv_insn_t *ir) {\"\\\n"
+output += "\" uint32_t pc, addr, udividend, udivisor, tmp, data, mask, ures, \"\\\n"
+output += "\"a, b, jump_to;\"\\\n"
+output += "\"  int32_t dividend, divisor, res;\"\\\n"
+output += "\"  int64_t multiplicand, multiplier;\"\\\n"
+output += "\"  uint64_t umultiplier;\"\\\n"
+output += "\"  memory_t *m = ((state_t *)rv->userdata)->mem;\"\\\n"
+output += "\"  chunk_t *c;\"\n"
+
+f = open('src/rv32_template.c', 'r')
+lines = f.read()
+# remove exception handler
+lines = re.sub(r'RV_EXC[\S]+?\([\S|\s]+?\);\s', "", lines)
+# replace variable
+lines = re.sub(r'const [u]*int[32|64]+_t', "", lines)
+lines = re.sub("uint32_t tmp", "tmp", lines)
+lines = re.sub("uint32_t a", "a", lines)
+lines = re.sub("uint32_t b", "b", lines)
+lines = re.sub("uint32_t a_sign", "a_sign", lines)
+lines = re.sub("uint32_t b_sign", "b_sign", lines)
+lines = re.sub("uint32_t data", "data", lines)
+lines = re.sub("uint32_t bits", "bits", lines)
+str2 = re.findall(r'RVOP\([\s|\S]+?}\)', lines)
+op = []
+impl = []
+for i in range(len(str2)):
+    tmp = remove_comment(str2[i])
+    op.append(tmp[5:tmp.find(',')])
+    impl.append(tmp[tmp.find('{') + 1:-2])
+
+f.close()
+# generate jit template
+for i in range(len(str2)):
+    if (not SKIPLIST.count(op[i])):
+        output = output + "RVOP(" + op[i] + ", { strcat(gencode, "
+        substr = impl[i].split("\n")
+        for str in substr:
+            if (str != ""):
+                output = output + '\"' + str + '\\n\"'
+        output = output + ");})\n"
+sys.stdout.write(output)


### PR DESCRIPTION
According to the MIR author statement, MIR does not generate position-independent code. This means that the code can only be executed in the location where it was originally generated. Since it is not possible to move the generated code to a specific memory location, we need to refactor a code cache that solely stores the memory address of the generated code.

The following statistics demonstrate the performance improvement observed when importing JIT (Just-in-Time) compilation on various host machines.

* Core i7-8700

|Metric| rv32emu (interpreter) |rv32emu (JIT) |Speedup|
|--------| -------- | -------- | -------- | 
| CoreMark | 1155.174 (iter/s)| 1932.496 (iter/s) |+67.2％|
| dhrystone  | 1282 DMIPS |2495.11 DMIPS |+94.6%|

* eMAG 8180

|Metric| rv32emu (interpreter) |rv32emu (baseline JIT) |Speedup|
|--------| -------- | -------- | -------- | 
| CoreMark | 438.073 (iter/s)| 644.426 (iter/s) |+47.1％|
| dhrystone  | 354.60 DMIPS |867.00 DMIPS |+144%|