### PR TITLE
Consolidate memory R/W operations

### DIFF
--- a/src/emulate.c
+++ b/src/emulate.c
@@ -414,49 +414,48 @@ RVOP(bgeu, { BRANCH_FUNC(uint32_t, <); })
 
 /* LB: Load Byte */
 RVOP(lb, {
-    rv->X[ir->rd] =
-        sign_extend_b(rv->io.mem_read_b(rv, rv->X[ir->rs1] + ir->imm));
+    rv->X[ir->rd] = sign_extend_b(rv->io.mem_read_b(rv->X[ir->rs1] + ir->imm));
 })
 
 /* LH: Load Halfword */
 RVOP(lh, {
     const uint32_t addr = rv->X[ir->rs1] + ir->imm;
     RV_EXC_MISALIGN_HANDLER(1, load, false, 1);
-    rv->X[ir->rd] = sign_extend_h(rv->io.mem_read_s(rv, addr));
+    rv->X[ir->rd] = sign_extend_h(rv->io.mem_read_s(addr));
 })
 
 /* LW: Load Word */
 RVOP(lw, {
     const uint32_t addr = rv->X[ir->rs1] + ir->imm;
     RV_EXC_MISALIGN_HANDLER(3, load, false, 1);
-    rv->X[ir->rd] = rv->io.mem_read_w(rv, addr);
+    rv->X[ir->rd] = rv->io.mem_read_w(addr);
 })
 
 /* LBU: Load Byte Unsigned */
-RVOP(lbu, { rv->X[ir->rd] = rv->io.mem_read_b(rv, rv->X[ir->rs1] + ir->imm); })
+RVOP(lbu, { rv->X[ir->rd] = rv->io.mem_read_b(rv->X[ir->rs1] + ir->imm); })
 
 /* LHU: Load Halfword Unsigned */
 RVOP(lhu, {
     const uint32_t addr = rv->X[ir->rs1] + ir->imm;
     RV_EXC_MISALIGN_HANDLER(1, load, false, 1);
-    rv->X[ir->rd] = rv->io.mem_read_s(rv, addr);
+    rv->X[ir->rd] = rv->io.mem_read_s(addr);
 })
 
 /* SB: Store Byte */
-RVOP(sb, { rv->io.mem_write_b(rv, rv->X[ir->rs1] + ir->imm, rv->X[ir->rs2]); })
+RVOP(sb, { rv->io.mem_write_b(rv->X[ir->rs1] + ir->imm, rv->X[ir->rs2]); })
 
 /* SH: Store Halfword */
 RVOP(sh, {
     const uint32_t addr = rv->X[ir->rs1] + ir->imm;
     RV_EXC_MISALIGN_HANDLER(1, store, false, 1);
-    rv->io.mem_write_s(rv, addr, rv->X[ir->rs2]);
+    rv->io.mem_write_s(addr, rv->X[ir->rs2]);
 })
 
 /* SW: Store Word */
 RVOP(sw, {
     const uint32_t addr = rv->X[ir->rs1] + ir->imm;
     RV_EXC_MISALIGN_HANDLER(3, store, false, 1);
-    rv->io.mem_write_w(rv, addr, rv->X[ir->rs2]);
+    rv->io.mem_write_w(addr, rv->X[ir->rs2]);
 })
 
 /* ADDI adds the sign-extended 12-bit immediate to register rs1. Arithmetic
@@ -729,7 +728,7 @@ RVOP(remu, {
 
 /* LR.W: Load Reserved */
 RVOP(lrw, {
-    rv->X[ir->rd] = rv->io.mem_read_w(rv, rv->X[ir->rs1]);
+    rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
     /* skip registration of the 'reservation set'
      * FIXME: uimplemented
      */
@@ -740,78 +739,78 @@ RVOP(scw, {
     /* assume the 'reservation set' is valid
      * FIXME: unimplemented
      */
-    rv->io.mem_write_w(rv, rv->X[ir->rs1], rv->X[ir->rs2]);
+    rv->io.mem_write_w(rv->X[ir->rs1], rv->X[ir->rs2]);
     rv->X[ir->rd] = 0;
 })
 
 /* AMOSWAP.W: Atomic Swap */
 RVOP(amoswapw, {
-    rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
-    rv->io.mem_write_s(rv, ir->rs1, rv->X[ir->rs2]);
+    rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
+    rv->io.mem_write_s(ir->rs1, rv->X[ir->rs2]);
 })
 
 /* AMOADD.W: Atomic ADD */
 RVOP(amoaddw, {
-    rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
+    rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
     const int32_t res = (int32_t) rv->X[ir->rd] + (int32_t) rv->X[ir->rs2];
-    rv->io.mem_write_s(rv, ir->rs1, res);
+    rv->io.mem_write_s(ir->rs1, res);
 })
 
 /* AMOXOR.W: Atomix XOR */
 RVOP(amoxorw, {
-    rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
+    rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
     const int32_t res = rv->X[ir->rd] ^ rv->X[ir->rs2];
-    rv->io.mem_write_s(rv, ir->rs1, res);
+    rv->io.mem_write_s(ir->rs1, res);
 })
 
 /* AMOAND.W: Atomic AND */
 RVOP(amoandw, {
-    rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
+    rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
     const int32_t res = rv->X[ir->rd] & rv->X[ir->rs2];
-    rv->io.mem_write_s(rv, ir->rs1, res);
+    rv->io.mem_write_s(ir->rs1, res);
 })
 
 /* AMOOR.W: Atomic OR */
 RVOP(amoorw, {
-    rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
+    rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
     const int32_t res = rv->X[ir->rd] | rv->X[ir->rs2];
-    rv->io.mem_write_s(rv, ir->rs1, res);
+    rv->io.mem_write_s(ir->rs1, res);
 })
 
 /* AMOMIN.W: Atomic MIN */
 RVOP(amominw, {
-    rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
+    rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
     const int32_t a = rv->X[ir->rd];
     const int32_t b = rv->X[ir->rs2];
     const int32_t res = a < b ? a : b;
-    rv->io.mem_write_s(rv, ir->rs1, res);
+    rv->io.mem_write_s(ir->rs1, res);
 })
 
 /* AMOMAX.W: Atomic MAX */
 RVOP(amomaxw, {
-    rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
+    rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
     const int32_t a = rv->X[ir->rd];
     const int32_t b = rv->X[ir->rs2];
     const int32_t res = a > b ? a : b;
-    rv->io.mem_write_s(rv, ir->rs1, res);
+    rv->io.mem_write_s(ir->rs1, res);
 })
 
 /* AMOMINU.W */
 RVOP(amominuw, {
-    rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
+    rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
     const uint32_t a = rv->X[ir->rd];
     const uint32_t b = rv->X[ir->rs2];
     const uint32_t res = a < b ? a : b;
-    rv->io.mem_write_s(rv, ir->rs1, res);
+    rv->io.mem_write_s(ir->rs1, res);
 })
 
 /* AMOMAXU.W */
 RVOP(amomaxuw, {
-    rv->X[ir->rd] = rv->io.mem_read_w(rv, ir->rs1);
+    rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
     const uint32_t a = rv->X[ir->rd];
     const uint32_t b = rv->X[ir->rs2];
     const uint32_t res = a > b ? a : b;
-    rv->io.mem_write_s(rv, ir->rs1, res);
+    rv->io.mem_write_s(ir->rs1, res);
 })
 #endif /* RV32_HAS(EXT_A) */
 
@@ -819,7 +818,7 @@ RVOP(amomaxuw, {
 /* FLW */
 RVOP(flw, {
     /* copy into the float register */
-    const uint32_t data = rv->io.mem_read_w(rv, rv->X[ir->rs1] + ir->imm);
+    const uint32_t data = rv->io.mem_read_w(rv->X[ir->rs1] + ir->imm);
     rv->F_int[ir->rd] = data;
 })
 
@@ -827,7 +826,7 @@ RVOP(flw, {
 RVOP(fsw, {
     /* copy from float registers */
     uint32_t data = rv->F_int[ir->rs2];
-    rv->io.mem_write_w(rv, rv->X[ir->rs1] + ir->imm, data);
+    rv->io.mem_write_w(rv->X[ir->rs1] + ir->imm, data);
 })
 
 /* FMADD.S */
@@ -1039,7 +1038,7 @@ RVOP(caddi4spn, { rv->X[ir->rd] = rv->X[2] + (uint16_t) ir->imm; })
 RVOP(clw, {
     const uint32_t addr = rv->X[ir->rs1] + (uint32_t) ir->imm;
     RV_EXC_MISALIGN_HANDLER(3, load, true, 1);
-    rv->X[ir->rd] = rv->io.mem_read_w(rv, addr);
+    rv->X[ir->rd] = rv->io.mem_read_w(addr);
 })
 
 /* C.SW stores a 32-bit value in register rs2' to memory. It computes an
@@ -1050,7 +1049,7 @@ RVOP(clw, {
 RVOP(csw, {
     const uint32_t addr = rv->X[ir->rs1] + (uint32_t) ir->imm;
     RV_EXC_MISALIGN_HANDLER(3, store, true, 1);
-    rv->io.mem_write_w(rv, addr, rv->X[ir->rs2]);
+    rv->io.mem_write_w(addr, rv->X[ir->rs2]);
 })
 
 /* C.NOP */
@@ -1190,7 +1189,7 @@ RVOP(cslli, { rv->X[ir->rd] <<= (uint8_t) ir->imm; })
 RVOP(clwsp, {
     const uint32_t addr = rv->X[rv_reg_sp] + ir->imm;
     RV_EXC_MISALIGN_HANDLER(3, load, true, 1);
-    rv->X[ir->rd] = rv->io.mem_read_w(rv, addr);
+    rv->X[ir->rd] = rv->io.mem_read_w(addr);
 })
 
 /* C.JR */
@@ -1232,7 +1231,7 @@ RVOP(cadd, { rv->X[ir->rd] = rv->X[ir->rs1] + rv->X[ir->rs2]; })
 RVOP(cswsp, {
     const uint32_t addr = rv->X[2] + ir->imm;
     RV_EXC_MISALIGN_HANDLER(3, store, true, 1);
-    rv->io.mem_write_w(rv, addr, rv->X[ir->rs2]);
+    rv->io.mem_write_w(addr, rv->X[ir->rs2]);
 })
 #endif
 
@@ -1253,10 +1252,10 @@ RVOP(fuse3, {
      * is misaligned or if the memory chunk does not exist.
      */
     RV_EXC_MISALIGN_HANDLER(3, store, false, 1);
-    rv->io.mem_write_w(rv, addr, rv->X[fuse[0].rs2]);
+    rv->io.mem_write_w(addr, rv->X[fuse[0].rs2]);
     for (int i = 1; i < ir->imm2; i++) {
         addr = rv->X[fuse[i].rs1] + fuse[i].imm;
-        rv->io.mem_write_w(rv, addr, rv->X[fuse[i].rs2]);
+        rv->io.mem_write_w(addr, rv->X[fuse[i].rs2]);
     }
 })
 
@@ -1269,10 +1268,10 @@ RVOP(fuse4, {
      * is misaligned or if the memory chunk does not exist.
      */
     RV_EXC_MISALIGN_HANDLER(3, load, false, 1);
-    rv->X[fuse[0].rd] = rv->io.mem_read_w(rv, addr);
+    rv->X[fuse[0].rd] = rv->io.mem_read_w(addr);
     for (int i = 1; i < ir->imm2; i++) {
         addr = rv->X[fuse[i].rs1] + fuse[i].imm;
-        rv->X[fuse[i].rd] = rv->io.mem_read_w(rv, addr);
+        rv->X[fuse[i].rd] = rv->io.mem_read_w(addr);
     }
 })
 
@@ -1382,7 +1381,7 @@ static void block_translate(riscv_t *rv, block_t *block)
         memset(ir, 0, sizeof(rv_insn_t));
 
         /* fetch the next instruction */
-        const uint32_t insn = rv->io.mem_ifetch(rv, block->pc_end);
+        const uint32_t insn = rv->io.mem_ifetch(block->pc_end);
 
         /* decode the instruction */
         if (!rv_decode(ir, insn)) {

--- a/src/gdbstub.c
+++ b/src/gdbstub.c
@@ -48,20 +48,13 @@ static int rv_write_reg(void *args, int regno, size_t data)
 static int rv_read_mem(void *args, size_t addr, size_t len, void *val)
 {
     riscv_t *rv = (riscv_t *) args;
-    state_t *s = rv_userdata(rv);
 
     int err = 0;
     for (size_t i = 0; i < len; i++) {
         /* FIXME: This is implemented as a simple workaround for reading
          * an invalid address. We may have to do error handling in the
          * mem_read_* function directly. */
-        uint32_t addr_hi = (addr + i) >> 16;
-        if (!s->mem->chunks[addr_hi]) {
-            err = EFAULT;
-            continue;
-        }
-
-        *((uint8_t *) val + i) = rv->io.mem_read_b(rv, addr + i);
+        *((uint8_t *) val + i) = rv->io.mem_read_b(addr + i);
     }
 
     return err;
@@ -72,7 +65,7 @@ static int rv_write_mem(void *args, size_t addr, size_t len, void *val)
     riscv_t *rv = (riscv_t *) args;
 
     for (size_t i = 0; i < len; i++)
-        rv->io.mem_write_b(rv, addr + i, *((uint8_t *) val + i));
+        rv->io.mem_write_b(addr + i, *((uint8_t *) val + i));
 
     return 0;
 }

--- a/src/io.c
+++ b/src/io.c
@@ -5,65 +5,59 @@
 
 #include <assert.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#if !defined(_WIN32)
+#define USE_MMAP 1
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
 
 #include "io.h"
-#include "mpool.h"
 
-static const uint32_t mask_lo = 0xffff;
-static const uint32_t mask_hi = ~(0xffff);
-
-static struct mpool *mp;
+static uint8_t *data_memory_base;
+/* set memory size to 2^32 bytes */
+#define MEM_SIZE 0x100000000ULL
 
 memory_t *memory_new()
 {
-    memory_t *m = calloc(1, sizeof(memory_t));
-    /* Initialize the mpool size to sizeof(chunk_t) << 2, and it will extend
-     * automatically if needed */
-    mp = mpool_create(sizeof(chunk_t) << 2, sizeof(chunk_t));
-    return m;
+    memory_t *mem = malloc(sizeof(memory_t));
+#if defined(USE_MMAP)
+    data_memory_base = mmap(NULL, MEM_SIZE, PROT_READ | PROT_WRITE,
+                            MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+    if (data_memory_base == MAP_FAILED)
+        return NULL;
+#else
+    data_memory_base = malloc(MEM_SIZE);
+    if (data_memory_base)
+        return NULL;
+#endif
+    mem->mem_base = data_memory_base;
+    mem->mem_size = MEM_SIZE;
+    return mem;
 }
 
-void memory_delete(memory_t *m)
+void memory_delete(memory_t *mem)
 {
-    if (!m)
-        return;
-    mpool_destory(mp);
-    free(m);
+    munmap(mem->mem_base, MEM_SIZE);
 }
 
-void memory_read(memory_t *m, uint8_t *dst, uint32_t addr, uint32_t size)
+void memory_read(memory_t *mem, uint8_t *dst, uint32_t addr, uint32_t size)
 {
-    /* test if this read is entirely within one chunk */
-    if ((addr & mask_hi) == ((addr + size) & mask_hi)) {
-        chunk_t *c;
-        if ((c = m->chunks[addr >> 16])) {
-            /* get the subchunk pointer */
-            const uint32_t p = (addr & mask_lo);
-
-            /* copy over the data */
-            memcpy(dst, c->data + p, size);
-        } else {
-            memset(dst, 0, size);
-        }
-    } else {
-        /* naive copy */
-        for (uint32_t i = 0; i < size; ++i) {
-            uint32_t p = addr + i;
-            chunk_t *c = m->chunks[p >> 16];
-            dst[i] = c ? c->data[p & 0xffff] : 0;
-        }
-    }
+    memcpy(dst, mem->mem_base + addr, size);
 }
 
-uint32_t memory_read_str(memory_t *m, uint8_t *dst, uint32_t addr, uint32_t max)
+uint32_t memory_read_str(memory_t *mem,
+                         uint8_t *dst,
+                         uint32_t addr,
+                         uint32_t max)
 {
     uint32_t len = 0;
     const uint8_t *end = dst + max;
     for (;; ++len, ++dst) {
         uint8_t ch = 0;
-        memory_read(m, &ch, addr + len, 1);
+        memory_read(mem, &ch, addr + len, 1);
         if (dst < end)
             *dst = ch;
         if (!ch)
@@ -72,76 +66,40 @@ uint32_t memory_read_str(memory_t *m, uint8_t *dst, uint32_t addr, uint32_t max)
     return len + 1;
 }
 
-uint32_t memory_ifetch(memory_t *m, uint32_t addr)
+uint32_t memory_ifetch(uint32_t addr)
 {
-    const uint32_t addr_lo = addr & mask_lo;
-    assert((addr_lo & 1) == 0);
-
-    chunk_t *c = m->chunks[addr >> 16];
-    assert(c);
-    return *(const uint32_t *) (c->data + addr_lo);
+    return *(const uint32_t *) (data_memory_base + addr);
 }
 
-uint32_t memory_read_w(memory_t *m, uint32_t addr)
-{
-    const uint32_t addr_lo = addr & mask_lo;
-    chunk_t *c = m->chunks[addr >> 16];
-    return *(const uint32_t *) (c->data + addr_lo);
-}
-
-uint16_t memory_read_s(memory_t *m, uint32_t addr)
-{
-    const uint32_t addr_lo = addr & mask_lo;
-    chunk_t *c = m->chunks[addr >> 16];
-    return *(const uint16_t *) (c->data + addr_lo);
-}
-
-uint8_t memory_read_b(memory_t *m, uint32_t addr)
-{
-    chunk_t *c = m->chunks[addr >> 16];
-    return c->data[addr & mask_lo];
-}
-
-void memory_write(memory_t *m, uint32_t addr, const uint8_t *src, uint32_t size)
-{
-    for (uint32_t i = 0; i < size; ++i) {
-        const uint32_t addr_lo = (addr + i) & mask_lo,
-                       addr_hi = (addr + i) >> 16;
-        chunk_t *c = m->chunks[addr_hi];
-        if (!c) {
-            c = mpool_calloc(mp);
-            m->chunks[addr_hi] = c;
-        }
-        c->data[addr_lo] = src[i];
+#define MEM_READ_IMPL(size, type)                   \
+    type memory_read_##size(uint32_t addr)          \
+    {                                               \
+        return *(type *) (data_memory_base + addr); \
     }
+
+MEM_READ_IMPL(w, uint32_t);
+MEM_READ_IMPL(s, uint16_t);
+MEM_READ_IMPL(b, uint8_t);
+
+void memory_write(memory_t *mem,
+                  uint32_t addr,
+                  const uint8_t *src,
+                  uint32_t size)
+{
+    memcpy(mem->mem_base + addr, src, size);
 }
 
-#define MEM_WRITE_IMPL(size, type)                                           \
-    void memory_write_##size(memory_t *m, uint32_t addr, const uint8_t *src) \
-    {                                                                        \
-        const uint32_t addr_lo = addr & mask_lo, addr_hi = addr >> 16;       \
-        chunk_t *c = m->chunks[addr_hi];                                     \
-        if (unlikely(!c)) {                                                  \
-            c = mpool_calloc(mp);                                            \
-            m->chunks[addr_hi] = c;                                          \
-        }                                                                    \
-        *(type *) (c->data + addr_lo) = *(const type *) src;                 \
+#define MEM_WRITE_IMPL(size, type)                                 \
+    void memory_write_##size(uint32_t addr, const uint8_t *src)    \
+    {                                                              \
+        *(type *) (data_memory_base + addr) = *(const type *) src; \
     }
 
 MEM_WRITE_IMPL(w, uint32_t);
 MEM_WRITE_IMPL(s, uint16_t);
 MEM_WRITE_IMPL(b, uint8_t);
 
-void memory_fill(memory_t *m, uint32_t addr, uint32_t size, uint8_t val)
+void memory_fill(memory_t *mem, uint32_t addr, uint32_t size, uint8_t val)
 {
-    for (uint32_t i = 0; i < size; ++i) {
-        uint32_t p = addr + i;
-        uint32_t x = p >> 16;
-        chunk_t *c = m->chunks[x];
-        if (!c) {
-            c = mpool_calloc(mp);
-            m->chunks[x] = c;
-        }
-        c->data[p & 0xffff] = val;
-    }
+    memset(mem->mem_base + addr, val, size);
 }

--- a/src/io.h
+++ b/src/io.h
@@ -7,12 +7,13 @@
 
 #include <stdint.h>
 
-typedef struct {
-    uint8_t data[0x10000];
-} chunk_t;
+/* Directly map a memory with a size of 2^32 bytes. All memory read/write
+ * operations can access this memory through the memory subsystem.
+ */
 
 typedef struct {
-    chunk_t *chunks[0x10000];
+    uint8_t *mem_base;
+    uint64_t mem_size;
 } memory_t;
 
 memory_t *memory_new();
@@ -25,16 +26,16 @@ uint32_t memory_read_str(memory_t *m,
                          uint32_t max);
 
 /* read an instruction from memory */
-uint32_t memory_ifetch(memory_t *m, uint32_t addr);
+uint32_t memory_ifetch(uint32_t addr);
 
 /* read a word from memory */
-uint32_t memory_read_w(memory_t *m, uint32_t addr);
+uint32_t memory_read_w(uint32_t addr);
 
 /* read a short from memory */
-uint16_t memory_read_s(memory_t *m, uint32_t addr);
+uint16_t memory_read_s(uint32_t addr);
 
 /* read a byte from memory */
-uint8_t memory_read_b(memory_t *m, uint32_t addr);
+uint8_t memory_read_b(uint32_t addr);
 
 /* read a length of data from memory */
 void memory_read(memory_t *m, uint8_t *dst, uint32_t addr, uint32_t size);
@@ -44,10 +45,10 @@ void memory_write(memory_t *m,
                   const uint8_t *src,
                   uint32_t size);
 
-void memory_write_w(memory_t *m, uint32_t addr, const uint8_t *src);
+void memory_write_w(uint32_t addr, const uint8_t *src);
 
-void memory_write_s(memory_t *m, uint32_t addr, const uint8_t *src);
+void memory_write_s(uint32_t addr, const uint8_t *src);
 
-void memory_write_b(memory_t *m, uint32_t addr, const uint8_t *src);
+void memory_write_b(uint32_t addr, const uint8_t *src);
 
 void memory_fill(memory_t *m, uint32_t addr, uint32_t size, uint8_t val);

--- a/src/main.c
+++ b/src/main.c
@@ -36,16 +36,13 @@ static const char *opt_prog_name = "a.out";
 static bool opt_misaligned = false;
 
 #define MEMIO(op) on_mem_##op
-#define IO_HANDLER_IMPL(type, op, RW)                                        \
-    static IIF(RW)(                                                          \
-        /* W */ void MEMIO(op)(riscv_t * rv, riscv_word_t addr,              \
-                               riscv_##type##_t data),                       \
-        /* R */ riscv_##type##_t MEMIO(op)(riscv_t * rv, riscv_word_t addr)) \
-    {                                                                        \
-        state_t *s = rv_userdata(rv);                                        \
-        IIF(RW)                                                              \
-        (memory_##op(s->mem, addr, (uint8_t *) &data),                       \
-         return memory_##op(s->mem, addr));                                  \
+#define IO_HANDLER_IMPL(type, op, RW)                                     \
+    static IIF(RW)(                                                       \
+        /* W */ void MEMIO(op)(riscv_word_t addr, riscv_##type##_t data), \
+        /* R */ riscv_##type##_t MEMIO(op)(riscv_word_t addr))            \
+    {                                                                     \
+        IIF(RW)                                                           \
+        (memory_##op(addr, (uint8_t *) &data), return memory_##op(addr)); \
     }
 
 #define R 0
@@ -170,7 +167,7 @@ static bool parse_args(int argc, char **args)
     return true;
 }
 
-static void dump_test_signature(riscv_t *rv, elf_t *elf)
+static void dump_test_signature(elf_t *elf)
 {
     uint32_t start = 0, end = 0;
     const struct Elf32_Sym *sym;
@@ -189,11 +186,9 @@ static void dump_test_signature(riscv_t *rv, elf_t *elf)
     if ((sym = elf_get_symbol(elf, "end_signature")))
         end = sym->st_value;
 
-    state_t *s = rv_userdata(rv);
-
     /* dump it word by word */
     for (uint32_t addr = start; addr < end; addr += 4)
-        fprintf(f, "%08x\n", memory_read_w(s->mem, addr));
+        fprintf(f, "%08x\n", memory_read_w(addr));
 
     fclose(f);
 }
@@ -270,7 +265,7 @@ int main(int argc, char **args)
 
     /* dump test result in test mode */
     if (opt_arch_test)
-        dump_test_signature(rv, elf);
+        dump_test_signature(elf);
 
     /* finalize the RISC-V runtime */
     elf_delete(elf);

--- a/src/riscv.h
+++ b/src/riscv.h
@@ -71,21 +71,15 @@ typedef uint32_t riscv_exception_t;
 typedef float riscv_float_t;
 
 /* memory read handlers */
-typedef riscv_word_t (*riscv_mem_ifetch)(riscv_t *rv, riscv_word_t addr);
-typedef riscv_word_t (*riscv_mem_read_w)(riscv_t *rv, riscv_word_t addr);
-typedef riscv_half_t (*riscv_mem_read_s)(riscv_t *rv, riscv_word_t addr);
-typedef riscv_byte_t (*riscv_mem_read_b)(riscv_t *rv, riscv_word_t addr);
+typedef riscv_word_t (*riscv_mem_ifetch)(riscv_word_t addr);
+typedef riscv_word_t (*riscv_mem_read_w)(riscv_word_t addr);
+typedef riscv_half_t (*riscv_mem_read_s)(riscv_word_t addr);
+typedef riscv_byte_t (*riscv_mem_read_b)(riscv_word_t addr);
 
 /* memory write handlers */
-typedef void (*riscv_mem_write_w)(riscv_t *rv,
-                                  riscv_word_t addr,
-                                  riscv_word_t data);
-typedef void (*riscv_mem_write_s)(riscv_t *rv,
-                                  riscv_word_t addr,
-                                  riscv_half_t data);
-typedef void (*riscv_mem_write_b)(riscv_t *rv,
-                                  riscv_word_t addr,
-                                  riscv_byte_t data);
+typedef void (*riscv_mem_write_w)(riscv_word_t addr, riscv_word_t data);
+typedef void (*riscv_mem_write_s)(riscv_word_t addr, riscv_half_t data);
+typedef void (*riscv_mem_write_b)(riscv_word_t addr, riscv_byte_t data);
 
 /* system instruction handlers */
 typedef void (*riscv_on_ecall)(riscv_t *rv);

--- a/src/syscall.c
+++ b/src/syscall.c
@@ -134,8 +134,6 @@ static void syscall_brk(riscv_t *rv)
 
 static void syscall_gettimeofday(riscv_t *rv)
 {
-    state_t *s = rv_userdata(rv); /* access userdata */
-
     /* get the parameters */
     riscv_word_t tv = rv_get_reg(rv, rv_reg_a0);
     riscv_word_t tz = rv_get_reg(rv, rv_reg_a1);
@@ -144,8 +142,8 @@ static void syscall_gettimeofday(riscv_t *rv)
     if (tv) {
         struct timeval tv_s;
         rv_gettimeofday(&tv_s);
-        memory_write_w(s->mem, tv + 0, (const uint8_t *) &tv_s.tv_sec);
-        memory_write_w(s->mem, tv + 8, (const uint8_t *) &tv_s.tv_usec);
+        memory_write_w(tv + 0, (const uint8_t *) &tv_s.tv_sec);
+        memory_write_w(tv + 8, (const uint8_t *) &tv_s.tv_usec);
     }
 
     if (tz) {
@@ -158,8 +156,6 @@ static void syscall_gettimeofday(riscv_t *rv)
 
 static void syscall_clock_gettime(riscv_t *rv)
 {
-    state_t *s = rv_userdata(rv); /* access userdata */
-
     /* get the parameters */
     riscv_word_t id = rv_get_reg(rv, rv_reg_a0);
     riscv_word_t tp = rv_get_reg(rv, rv_reg_a1);
@@ -178,8 +174,8 @@ static void syscall_clock_gettime(riscv_t *rv)
     if (tp) {
         struct timespec tp_s;
         rv_clock_gettime(&tp_s);
-        memory_write_w(s->mem, tp + 0, (const uint8_t *) &tp_s.tv_sec);
-        memory_write_w(s->mem, tp + 8, (const uint8_t *) &tp_s.tv_nsec);
+        memory_write_w(tp + 0, (const uint8_t *) &tp_s.tv_sec);
+        memory_write_w(tp + 8, (const uint8_t *) &tp_s.tv_nsec);
     }
 
     /* success */

--- a/src/syscall_sdl.c
+++ b/src/syscall_sdl.c
@@ -110,7 +110,7 @@ static void event_push(riscv_t *rv, event_t event)
     uint32_t count;
     memory_read(s->mem, (void *) &count, event_count, sizeof(uint32_t));
     count += 1;
-    memory_write_w(s->mem, event_count, (void *) &count);
+    memory_write(s->mem, event_count, (void *) &count, sizeof(uint32_t));
 }
 
 static inline uint32_t round_pow2(uint32_t x)


### PR DESCRIPTION
In the current memory design, we did not allocate any memory initially. As a result, we had to check whether memory was allocated before reading or writing data, leading to a deterioration in the performance of memory I/O instructions. To overcome this limitation, we have implemented a new memory design that directly maps a memory size of $2^{32}$ bytes. With this enhancement, every memory read or write operation can directly access memory without the need for any checks.

The following statistics demonstrate the performance improvements achieved by the proposed memory I/O operations.

|  Metric  | original |  proposed | Speedup |
|----------|----------------|----------------|-------|
| Dhrystone |     1151.44    |    1374.20     | +19.3%|