### PR TITLE
Remove useless IR fields

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -125,7 +125,6 @@ static char funcbuf[128] = {0};
         code;                                                       \
         if (!insn_is_branch(ir->opcode)) {                          \
             GEN("  rv->PC += %d;\n", ir->insn_len);                 \
-            GEN("  ir = ir + 1;\n");                                \
             NEXT_INSN(pc + ir->insn_len);                           \
         }                                                           \
     }
@@ -143,7 +142,6 @@ RVOP(jal, {
     if (ir->rd) {
         GEN("  rv->X[%u] = pc + %u;\n", ir->rd, ir->insn_len);
     }
-    GEN("  ir = ir->branch_taken;\n");
     NEXT_INSN(pc + ir->imm);
 })
 
@@ -152,7 +150,6 @@ RVOP(jal, {
         #type, ir->rs2);                                                      \
     UPDATE_PC(ir->imm);                                                       \
     if (ir->branch_taken) {                                                   \
-        GEN("    ir = ir->branch_taken;\n");                                  \
         NEXT_INSN(pc + ir->imm);                                              \
     } else {                                                                  \
         GEN("    return true;\n");                                            \
@@ -160,7 +157,6 @@ RVOP(jal, {
     GEN("  }\n");                                                             \
     UPDATE_PC(ir->insn_len);                                                  \
     if (ir->branch_untaken) {                                                 \
-        GEN("  ir = ir->branch_untaken;\n");                                  \
         NEXT_INSN(pc + ir->insn_len);                                         \
     } else {                                                                  \
         GEN("  return true;\n");                                              \
@@ -226,13 +222,11 @@ RVOP(csw, {
 RVOP(cjal, {
     GEN("  rv->X[1] = rv->PC + %u;\n", ir->insn_len);
     UPDATE_PC(ir->imm);
-    GEN("  ir = ir->branch_taken;\n");
     NEXT_INSN(pc + ir->imm);
 })
 
 RVOP(cj, {
     UPDATE_PC(ir->imm);
-    GEN("  ir = ir->branch_taken;\n");
     NEXT_INSN(pc + ir->imm);
 })
 
@@ -240,7 +234,6 @@ RVOP(cbeqz, {
     GEN("  if (!rv->X[%u]){\n", ir->rs1);
     UPDATE_PC(ir->imm);
     if (ir->branch_taken) {
-        GEN("    ir = ir->branch_taken;\n");
         NEXT_INSN(pc + ir->imm);
     } else {
         GEN("    return true;\n");
@@ -248,7 +241,6 @@ RVOP(cbeqz, {
     GEN("  }\n");
     UPDATE_PC(ir->insn_len);
     if (ir->branch_untaken) {
-        GEN("  ir = ir->branch_untaken;\n");
         NEXT_INSN(pc + ir->insn_len);
     } else {
         GEN("  return true;\n");
@@ -259,7 +251,6 @@ RVOP(cbnez, {
     GEN("  if (rv->X[%u]){\n", ir->rs1);
     UPDATE_PC(ir->imm);
     if (ir->branch_taken) {
-        GEN("    ir = ir->branch_taken;\n");
         NEXT_INSN(pc + ir->imm);
     } else {
         GEN("    return true;\n");
@@ -267,7 +258,6 @@ RVOP(cbnez, {
     GEN("  }\n");
     UPDATE_PC(ir->insn_len);
     if (ir->branch_untaken) {
-        GEN("  ir = ir->branch_untaken;\n");
         NEXT_INSN(pc + ir->insn_len);
     } else {
         GEN("  return true;\n");

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -459,7 +459,7 @@ static block_t *block_find_or_translate(riscv_t *rv)
 }
 
 #if RV32_HAS(JIT)
-typedef bool (*exec_block_func_t)(riscv_t *rv, rv_insn_t *ir);
+typedef bool (*exec_block_func_t)(riscv_t *rv);
 #endif
 
 void rv_step(riscv_t *rv, int32_t cycles)
@@ -531,7 +531,7 @@ void rv_step(riscv_t *rv, int32_t cycles)
         }
         if (code) {
             /* execute machine code */
-            code(rv, block->ir);
+            code(rv);
             /* block should not be extended if execution mode is jit */
             prev = NULL;
             continue;

--- a/tools/gen-jit-template.py
+++ b/tools/gen-jit-template.py
@@ -183,7 +183,7 @@ lines = re.sub('#endif\n', "", lines)
 output = output + "\"" + \
     re.sub("\n", "\"\\\n\"", re.findall(
         r'typedef[\S|\s]+?rv_insn_t;', lines)[0]) + "\"\\\n"
-output += "\"bool start(volatile riscv_t *rv, rv_insn_t *ir) {\"\\\n"
+output += "\"bool start(riscv_t *rv) {\"\\\n"
 output += "\" uint32_t pc, addr, udividend, udivisor, tmp, data, mask, ures, \"\\\n"
 output += "\"a, b, jump_to;\"\\\n"
 output += "\"  int32_t dividend, divisor, res;\"\\\n"


### PR DESCRIPTION
IR feilds have been evaluated IR as constant values prior to code generation, so they are useless IR in code generation.