### PR TITLE
jit: Fix float-point instruction

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -68,13 +68,13 @@ uint32_t memory_read_str(memory_t *mem,
 
 uint32_t memory_ifetch(uint32_t addr)
 {
-    return *(const uint32_t *) (data_memory_base + addr);
+    return *((const uint32_t *) (data_memory_base + addr));
 }
 
-#define MEM_READ_IMPL(size, type)                   \
-    type memory_read_##size(uint32_t addr)          \
-    {                                               \
-        return *(type *) (data_memory_base + addr); \
+#define MEM_READ_IMPL(size, type)                     \
+    type memory_read_##size(uint32_t addr)            \
+    {                                                 \
+        return *((type *) (data_memory_base + addr)); \
     }
 
 MEM_READ_IMPL(w, uint32_t);
@@ -89,10 +89,10 @@ void memory_write(memory_t *mem,
     memcpy(mem->mem_base + addr, src, size);
 }
 
-#define MEM_WRITE_IMPL(size, type)                                 \
-    void memory_write_##size(uint32_t addr, const uint8_t *src)    \
-    {                                                              \
-        *(type *) (data_memory_base + addr) = *(const type *) src; \
+#define MEM_WRITE_IMPL(size, type)                                     \
+    void memory_write_##size(uint32_t addr, const uint8_t *src)        \
+    {                                                                  \
+        *((type *) (data_memory_base + addr)) = *((const type *) src); \
     }
 
 MEM_WRITE_IMPL(w, uint32_t);

--- a/src/riscv_private.h
+++ b/src/riscv_private.h
@@ -93,20 +93,6 @@ struct riscv_internal {
     /* user provided data */
     riscv_user_t userdata;
 
-#if RV32_HAS(GDBSTUB)
-    /* gdbstub instance */
-    gdbstub_t gdbstub;
-
-    bool debug_mode;
-
-    /* GDB instruction breakpoint */
-    breakpoint_map_t breakpoint_map;
-
-    /* The flag to notify interrupt from GDB client: it should
-     * be accessed by atomic operation when starting the GDBSTUB. */
-    bool is_interrupted;
-#endif
-
 #if RV32_HAS(EXT_F)
     /* float registers */
     union {
@@ -130,6 +116,21 @@ struct riscv_internal {
     uint32_t csr_mbadaddr;
 
     bool compressed; /**< current instruction is compressed or not */
+
+#if RV32_HAS(GDBSTUB)
+    /* gdbstub instance */
+    gdbstub_t gdbstub;
+
+    bool debug_mode;
+
+    /* GDB instruction breakpoint */
+    breakpoint_map_t breakpoint_map;
+
+    /* The flag to notify interrupt from GDB client: it should
+     * be accessed by atomic operation when starting the GDBSTUB. */
+    bool is_interrupted;
+#endif
+
 #if !RV32_HAS(JIT)
     block_map_t block_map; /**< basic block map */
 #else

--- a/tools/gen-jit-template.py
+++ b/tools/gen-jit-template.py
@@ -113,6 +113,8 @@ SKIPLIST = [
     "sb",
     "sh",
     "sw",
+    "flw",
+    "fsw",
     "clw",
     "csw",
     "cjal",
@@ -137,6 +139,7 @@ def parse_argv(EXT_LIST, SKIPLIST):
 
 
 def remove_comment(str):
+    str = re.sub(r'//[\s|\S]+?\n', "", str)
     return re.sub(r'/\*[\s|\S]+?\*/\n', "", str)
 
 
@@ -152,6 +155,13 @@ lines = remove_comment(lines)
 output = output + "\"" + \
     re.sub("\n", "\"\\\n\"", re.findall(
         r'enum[\S|\s]+?riscv_io_t;', lines)[0]) + "\"\\\n"
+if sys.argv.count("RV32_FEATURE_EXT_F=1"):
+    f = open('src/softfloat.h', 'r')
+    lines = f.read()
+    lines = remove_comment(lines)
+    output = output + "\"" + \
+        re.sub("\n", "\"\\\n\"", re.findall(
+            r'enum[\S|\s]+?};', lines)[0]) + "\"\\\n"
 f = open('src/riscv_private.h', 'r')
 lines = f.read()
 lines = remove_comment(lines)


### PR DESCRIPTION
1. Trace the file src/softfloat.h in gen-jit script to include an enumeration for floating point instructions.
2. To simplify the definition of JIT gencode, we adjust the data structure of riscv_internal by placing the fields needed by JIT at the top.

Solve: https://github.com/sysprog21/rv32emu/issues/169