### PR TITLE
WIP: Prefetch next operation inside execution loop

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -51,6 +51,13 @@
 #define MUST_TAIL
 #endif
 
+/* built-in prefetch intrinsic */
+#if defined(__GNUC__) || defined(__clang__)
+#define PREFETCH(x) __builtin_prefetch(x, 0)
+#else
+#define PREFETCH(x)
+#endif
+
 /* Pattern Matching for C macros.
  * https://github.com/pfultz2/Cloak/wiki/C-Preprocessor-tricks,-tips,-and-idioms
  */

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -301,12 +301,13 @@ static uint32_t last_pc = 0;
     {                                                       \
         rv->X[rv_reg_zero] = 0;                             \
         rv->csr_cycle++;                                    \
+        const rv_insn_t *next = ir + 1;                     \
+        PREFETCH(next);                                     \
         code;                                               \
     nextop:                                                 \
         rv->PC += ir->insn_len;                             \
         if (unlikely(RVOP_NO_NEXT(ir)))                     \
             return true;                                    \
-        const rv_insn_t *next = ir + 1;                     \
         MUST_TAIL return next->impl(rv, next);              \
     }
 


### PR DESCRIPTION
Data operations loops and function call loops have a difference: data accesses can be predicted due to modern microprocessors implementing a prefetch mechanism. This patch adds an explicit prefetch to the next operation before executing the current one. By hinting to the processor about an upcoming jump, it can pre-load the L1 code cache and potentially save clock cycles when the next function is called.

Both Dhrystone and Richards benchmarks benefit from the commit, showing a speedup of up to 13% on Ryzen Threadripper 2990WX.