### PR TITLE
Improve macro-op fusion: skip nop and add lui + addi

### DIFF
--- a/src/decode.h
+++ b/src/decode.h
@@ -163,7 +163,8 @@
     _(fuse1, 0)                            \
     _(fuse2, 0)                            \
     _(fuse3, 0)                            \
-    _(fuse4, 0)
+    _(fuse4, 0)                            \
+    _(fuse5, 0)
 /* clang-format on */
 
 /* IR list */
@@ -253,7 +254,7 @@ typedef struct rv_insn {
     uint8_t shamt;
 #endif
     /* fuse operation */
-    int16_t imm2;
+    int32_t imm2;
     opcode_fuse_t *fuse;
 
     /* instruction length */


### PR DESCRIPTION
1. Refine origin fused instruction by skipping insturction nop and correctly updating value to register.
2. Add new fused insturction lui + addi.

Benchmark dhrystone gains about 3% performance improvement base on this modification.

Close: #177 