### PR TITLE
Support passing argc and argv to target program

### DIFF
--- a/.ci/gdbstub-test.sh
+++ b/.ci/gdbstub-test.sh
@@ -17,7 +17,7 @@ if [ -z ${GDB} ]; then
     exit 1
 fi
 
-build/rv32emu --gdbstub build/puzzle.elf &
+build/rv32emu -g build/puzzle.elf &
 PID=$!
 
 # Before starting GDB, we should ensure rv32emu is still running.

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,9 @@ CFLAGS += -Wno-unused-label
 CFLAGS += -include src/common.h
 
 # Set the default stack pointer
-CFLAGS += -D DEFAULT_STACK_ADDR=0xFFFFF000
+CFLAGS += -D DEFAULT_STACK_ADDR=0xFFFE000
+# Set the default args starting address
+CFLAGS += -D DEFAULT_ARGS_ADDR=0xFFFF000
 
 OBJS_EXT :=
 
@@ -140,7 +142,7 @@ check: $(BIN)
 EXPECTED_aes = Dec 15 2022 16:35:12 Test results AES-128 ECB encryption: PASSED! AES-128 ECB decryption: PASSED! AES-128 CBC encryption: PASSED! AES-128 CBC decryption: PASSED! AES-128 CFB encryption: PASSED! AES-128 CFB decryption: PASSED! AES-128 OFB encryption: PASSED! AES-128 OFB decryption: PASSED! AES-128 CTR encryption: PASSED! AES-128 CTR decryption: PASSED! AES-128 XTS encryption: PASSED! AES-128 XTS decryption: PASSED! AES-128 validate CMAC : PASSED! AES-128 Poly-1305 mac : PASSED! AES-128 GCM encryption: PASSED! AES-128 GCM decryption: PASSED! AES-128 CCM encryption: PASSED! AES-128 CCM decryption: PASSED! AES-128 OCB encryption: PASSED! AES-128 OCB decryption: PASSED! AES-128 SIV encryption: PASSED! AES-128 SIV decryption: PASSED! AES-128 GCMSIV encrypt: PASSED! AES-128 GCMSIV decrypt: PASSED! AES-128 EAX encryption: PASSED! AES-128 EAX decryption: PASSED! AES-128 key wrapping  : PASSED! AES-128 key unwrapping: PASSED! AES-128 FF1 encryption: PASSED! AES-128 FPE decryption: PASSED! +-> Let's do some extra tests AES-128 OCB encryption: PASSED! AES-128 OCB decryption: PASSED! AES-128 GCMSIV encrypt: PASSED! AES-128 GCMSIV decrypt: PASSED! AES-128 GCMSIV encrypt: PASSED! AES-128 GCMSIV decrypt: PASSED! AES-128 SIV encryption: PASSED! AES-128 SIV decryption: PASSED! AES-128 SIV encryption: PASSED! AES-128 SIV decryption: PASSED! AES-128 EAX encryption: PASSED! AES-128 EAX decryption: PASSED! AES-128 EAX encryption: PASSED! AES-128 EAX decryption: PASSED! AES-128 Poly-1305 mac : PASSED! inferior exit code 0
 misalign: $(BIN)
 	$(Q)$(PRINTF) "Running aes.elf ... "; 
-	$(Q)if [ "$(shell $(BIN) --misalign $(OUT)/aes.elf | uniq)" = "$(EXPECTED_aes)" ]; then \
+	$(Q)if [ "$(shell $(BIN) -m $(OUT)/aes.elf | uniq)" = "$(EXPECTED_aes)" ]; then \
         $(call notice, [OK]); \
 	else	\
         $(PRINTF) "Failed.\n"; \

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ CFLAGS += -Wno-unused-label
 CFLAGS += -include src/common.h
 
 # Set the default stack pointer
-CFLAGS += -D DEFAULT_STACK_ADDR=0xFFFE000
+CFLAGS += -D DEFAULT_STACK_ADDR=0xFFFFE000
 # Set the default args starting address
-CFLAGS += -D DEFAULT_ARGS_ADDR=0xFFFF000
+CFLAGS += -D DEFAULT_ARGS_ADDR=0xFFFFF000
 
 OBJS_EXT :=
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ a limited number of [GDB Remote Serial Protocol](https://sourceware.org/gdb/onli
 You must first build the emulator and set `ENABLE_GDBSTUB` to `1` in the `Makefile` in order
 to activate this feature. After that, you might execute it using the command below.
 ```shell
-build/rv32emu --gdbstub <binary>
+build/rv32emu -g <binary>
 ```
 
 The `<binary>` should be the ELF file in RISC-V 32 bit format. Additionally, it is advised
@@ -162,14 +162,14 @@ command line is available, you can communicate with `rv32emu`.
 
 ### Dump registers as JSON
 
-If an option `--dump-registers [filename]` is specified, the emulator outputs registers as JSON format.
+If an option `-d [filename]` is specified, the emulator outputs registers as JSON format.
 This can be used for tests using the emulator, such as compiler tests.
 
-You can use the option with `--quiet` to use the output directly.
+You can use the option with `-q` to use the output directly.
 
 ```
 # Read the register x10 (a0).
-$ build/rv32emu --dump-registers - out.elf --quiet | jq .x10
+$ build/rv32emu -d - out.elf -q | jq .x10
 ```
 
 ## Contributing

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -135,17 +135,15 @@ void rv_reset(riscv_t *rv, riscv_word_t pc, int argc, char **args)
     /* set the reset address */
     rv->PC = pc;
 
-    state_t *s = rv_userdata(rv);
-
     /* set the default stack pointer */
     rv->X[rv_reg_sp] = DEFAULT_STACK_ADDR;
 
-    /* set emulating program's argc and args */
     /*
-     * store argc, args to state->mem
-     * so that, we can use offset technique to compatible
-     * 32-bit emulated program on 64-bit emulator
-     * memory layout of arguments like below:
+     * store argc and args of target program to state->mem
+     * thus, we can use offset technique for emulating
+     * 32/64-bit target program on 64-bit emulator
+     *
+     * memory layout of arguments as below:
      * -----------------------
      * |    NULL            |
      * -----------------------
@@ -172,7 +170,9 @@ void rv_reset(riscv_t *rv, riscv_word_t pc, int argc, char **args)
      *
      * TODO: access to envp
      */
+
     int i;
+    state_t *s = rv_userdata(rv);
 
     /* copy args to DRAM */
     uintptr_t args_size = (1 + argc + 1) * sizeof(uint32_t);

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -195,12 +195,12 @@ void rv_reset(riscv_t *rv, riscv_word_t pc, int argc, char **args)
         const char *arg = args[i];
         args_len = strlen(arg);
         memory_write(s->mem, (uintptr_t) args_p, (void *) arg,
-                     (args_len + 1) * sizeof(char));
+                     (args_len + 1) * sizeof(uint8_t));
         args_space[args_space_idx++] = args_len + 1;
-        args_p = (uintptr_t *) (((char *) args_p) + args_len + 1);
+        args_p = (uintptr_t *) ((uintptr_t) args_p + args_len + 1);
         args_len_total += args_len + 1;
     }
-    args_p = (uintptr_t *) (((char *) args_p) - args_len_total);
+    args_p = (uintptr_t *) ((uintptr_t) args_p - args_len_total);
     args_p--; /* point to argc */
 
     /* ready to push argc, args to stack */
@@ -222,7 +222,7 @@ void rv_reset(riscv_t *rv, riscv_word_t pc, int argc, char **args)
         uintptr_t offset = (uintptr_t) args_p;
         memory_write(s->mem, (uintptr_t) sp, (void *) &offset,
                      sizeof(uintptr_t));
-        args_p = (uintptr_t *) (((char *) args_p) + args_space[i]);
+        args_p = (uintptr_t *) ((uintptr_t) args_p + args_space[i]);
         sp = (uintptr_t *) ((uint32_t *) sp + 1);
     }
     memory_fill(s->mem, (uintptr_t) sp, sizeof(uint32_t), 0);

--- a/src/riscv.h
+++ b/src/riscv.h
@@ -109,13 +109,15 @@ typedef struct {
 /* create a RISC-V emulator */
 riscv_t *rv_create(const riscv_io_t *io,
                    riscv_user_t user_data,
+                   int argc,
+                   char **args,
                    bool output_exit_code);
 
 /* delete a RISC-V emulator */
 void rv_delete(riscv_t *rv);
 
 /* reset the RISC-V processor */
-void rv_reset(riscv_t *rv, riscv_word_t pc);
+void rv_reset(riscv_t *rv, riscv_word_t pc, int argc, char **args);
 
 #if RV32_HAS(GDBSTUB)
 /* Run the RISC-V emulator as gdbstub */

--- a/tests/arch-test-target/rv32emu/riscof_rv32emu.py
+++ b/tests/arch-test-target/rv32emu/riscof_rv32emu.py
@@ -133,7 +133,7 @@ class rv32emu(pluginTemplate):
             # echo statement.
             if self.target_run:
             # set up the simulation command. Template is for spike. Please change.
-                simcmd = self.dut_exe + ' --arch-test {0} {1}'.format(sig_file, elf)
+                simcmd = self.dut_exe + ' -a {0} {1}'.format(sig_file, elf)
             else:
                 simcmd = 'echo "NO RUN"'
 

--- a/tests/readelf/readelf.c
+++ b/tests/readelf/readelf.c
@@ -30,8 +30,7 @@ void read_elf_data(const char *path, int flags)
 
 int main(int argc, char *argv[])
 {
-    /* FIXME: use correct argv[0] */
-    read_elf_data("build/readelf.elf", FLAG_ELF_HEADER | FLAG_SECTION_HEADER);
+    read_elf_data(argv[0], FLAG_ELF_HEADER | FLAG_SECTION_HEADER);
 
     return 0;
 }


### PR DESCRIPTION
Half close #150, I left envp in TODO

I assumed all emulator's option are passed before the target program and its args thus I modify the parse_args function consequently