### PR TITLE
Support static analysis of registers

### DIFF
--- a/mk/tools.mk
+++ b/mk/tools.mk
@@ -13,7 +13,7 @@ deps += $(HIST_OBJS:%.o=%.o.d)
 
 $(OUT)/%.o: tools/%.c
 	$(VECHO) "  CC\t$@\n"
-	$(Q)$(CC) -o $@ $(CFLAGS) -Isrc -c -MMD -MF $@.d $<
+	$(Q)$(CC) -o $@ $(CFLAGS) -Wno-missing-field-initializers -Isrc -c -MMD -MF $@.d $<
 
 # GDBSTUB is diabled for excluding the mini-gdb during compilation
 $(HIST_BIN): $(HIST_OBJS)

--- a/src/common.h
+++ b/src/common.h
@@ -67,6 +67,20 @@
 /* run the 1st parameter */
 #define IIF_1(t, ...) t
 
+/* Accept any number of args >= N, but expand to just the Nth one. The macro
+ * that calls the function still only supports 4 args, but the set of values
+ * that might need to be returned is 1 larger, so N is increased to 6.
+ */
+#define _GET_NTH_ARG(_1, _2, _3, _4, _5, N, ...) N
+
+/* Count how many args are in a variadic macro. The GCC/Clang extension is used
+ * to handle the case where ... expands to nothing. A placeholder arg is added
+ * before ##VA_ARGS (its value is irrelevant but necessary to preserve the
+ * shifting offset).
+ * Additionally, 0 is added as a valid value in the N position.
+ */
+#define COUNT_VARARGS(...) _GET_NTH_ARG("ignored", ##__VA_ARGS__, 4, 3, 2, 1, 0)
+
 #if defined(__GNUC__) || defined(__clang__)
 #define __HAVE_TYPEOF 1
 #endif

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -278,7 +278,7 @@ static inline bool insn_is_misaligned(uint32_t pc)
 
 /* can-branch information for each RISC-V instruction */
 enum {
-#define _(inst, can_branch) __rv_insn_##inst##_canbranch = can_branch,
+#define _(inst, can_branch, reg_mask) __rv_insn_##inst##_canbranch = can_branch,
     RISCV_INSN_LIST
 #undef _
 };
@@ -427,7 +427,7 @@ static bool do_fuse5(riscv_t *rv, const rv_insn_t *ir)
 /* clang-format off */
 static const void *dispatch_table[] = {
     /* RV32 instructions */
-#define _(inst, can_branch) [rv_insn_##inst] = do_##inst,
+#define _(inst, can_branch, reg_mask) [rv_insn_##inst] = do_##inst,
     RISCV_INSN_LIST
 #undef _
     /* Macro operation fusion instructions */
@@ -440,7 +440,7 @@ static const void *dispatch_table[] = {
 static inline bool insn_is_branch(uint8_t opcode)
 {
     switch (opcode) {
-#define _(inst, can_branch) IIF(can_branch)(case rv_insn_##inst:, )
+#define _(inst, can_branch, reg_mask) IIF(can_branch)(case rv_insn_##inst:, )
         RISCV_INSN_LIST
 #undef _
         return true;
@@ -785,8 +785,8 @@ void dump_registers(riscv_t *rv, char *out_file_path)
     }
 
     fprintf(f, "{\n");
-    for (unsigned i = 0; i < RV_N_REGS; i++) {
-        char *comma = i < RV_N_REGS - 1 ? "," : "";
+    for (unsigned i = 0; i < N_RV_REGS; i++) {
+        char *comma = i < N_RV_REGS - 1 ? "," : "";
         fprintf(f, "  \"x%d\": %u%s\n", i, rv->X[i], comma);
     }
     fprintf(f, "}\n");

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -64,14 +64,14 @@ riscv_word_t rv_get_pc(riscv_t *rv)
 void rv_set_reg(riscv_t *rv, uint32_t reg, riscv_word_t in)
 {
     assert(rv);
-    if (reg < RV_N_REGS && reg != rv_reg_zero)
+    if (reg < N_RV_REGS && reg != rv_reg_zero)
         rv->X[reg] = in;
 }
 
 riscv_word_t rv_get_reg(riscv_t *rv, uint32_t reg)
 {
     assert(rv);
-    if (reg < RV_N_REGS)
+    if (reg < N_RV_REGS)
         return rv->X[reg];
 
     return ~0U;
@@ -130,7 +130,7 @@ void rv_delete(riscv_t *rv)
 void rv_reset(riscv_t *rv, riscv_word_t pc, int argc, char **args)
 {
     assert(rv);
-    memset(rv->X, 0, sizeof(uint32_t) * RV_N_REGS);
+    memset(rv->X, 0, sizeof(uint32_t) * N_RV_REGS);
 
     /* set the reset address */
     rv->PC = pc;
@@ -237,7 +237,7 @@ void rv_reset(riscv_t *rv, riscv_word_t pc, int argc, char **args)
 
 #if RV32_HAS(EXT_F)
     /* reset float registers */
-    memset(rv->F, 0, sizeof(float) * RV_N_REGS);
+    memset(rv->F, 0, sizeof(float) * N_RV_REGS);
     rv->csr_fcsr = 0;
 #endif
 

--- a/src/riscv.h
+++ b/src/riscv.h
@@ -11,6 +11,40 @@
 extern "C" {
 #endif
 
+#define RV_REGS_LIST                                   \
+    _(zero) /* hard-wired zero, ignoring any writes */ \
+    _(ra)   /* return address */                       \
+    _(sp)   /* stack pointer */                        \
+    _(gp)   /* global pointer */                       \
+    _(tp)   /* thread pointer */                       \
+    _(t0)   /* temporary/alternate link register */    \
+    _(t1)   /* temporaries */                          \
+    _(t2)                                              \
+    _(s0) /* saved register/frame pointer */           \
+    _(s1)                                              \
+    _(a0) /* function arguments / return values */     \
+    _(a1)                                              \
+    _(a2) /* function arguments */                     \
+    _(a3)                                              \
+    _(a4)                                              \
+    _(a5)                                              \
+    _(a6)                                              \
+    _(a7)                                              \
+    _(s2) /* saved register */                         \
+    _(s3)                                              \
+    _(s4)                                              \
+    _(s5)                                              \
+    _(s6)                                              \
+    _(s7)                                              \
+    _(s8)                                              \
+    _(s9)                                              \
+    _(s10)                                             \
+    _(s11)                                             \
+    _(t3) /* temporary register */                     \
+    _(t4)                                              \
+    _(t5)                                              \
+    _(t6)
+
 /* RISC-V registers (mnemonics, ABI names)
  *
  * There are 32 registers in RISC-V. The program counter is a further register
@@ -25,39 +59,10 @@ extern "C" {
  * the stack pointer.
  */
 enum {
-    rv_reg_zero = 0, /* hard-wired zero, ignoring any writes */
-    rv_reg_ra,       /* return address */
-    rv_reg_sp,       /* stack pointer */
-    rv_reg_gp,       /* global pointer */
-    rv_reg_tp,       /* thread pointer */
-    rv_reg_t0,       /* temporary/alternate link register */
-    rv_reg_t1,       /* temporaries */
-    rv_reg_t2,
-    rv_reg_s0, /* saved register/frame pointer */
-    rv_reg_s1,
-    rv_reg_a0, /* function arguments / return values */
-    rv_reg_a1,
-    rv_reg_a2, /* function arguments */
-    rv_reg_a3,
-    rv_reg_a4,
-    rv_reg_a5,
-    rv_reg_a6,
-    rv_reg_a7,
-    rv_reg_s2, /* saved register */
-    rv_reg_s3,
-    rv_reg_s4,
-    rv_reg_s5,
-    rv_reg_s6,
-    rv_reg_s7,
-    rv_reg_s8,
-    rv_reg_s9,
-    rv_reg_s10,
-    rv_reg_s11,
-    rv_reg_t3, /* temporary register */
-    rv_reg_t4,
-    rv_reg_t5,
-    rv_reg_t6,
-    RV_N_REGS, /* NOTE: shoule be the last */
+#define _(reg) rv_reg_##reg,
+    RV_REGS_LIST
+#undef _
+        N_RV_REGS
 };
 
 /* forward declaration for internal structure */

--- a/src/riscv_private.h
+++ b/src/riscv_private.h
@@ -77,7 +77,7 @@ struct riscv_internal {
     riscv_io_t io;
 
     /* integer registers */
-    riscv_word_t X[RV_N_REGS];
+    riscv_word_t X[N_RV_REGS];
     riscv_word_t PC;
 
     /* user provided data */
@@ -100,8 +100,8 @@ struct riscv_internal {
 #if RV32_HAS(EXT_F)
     /* float registers */
     union {
-        riscv_float_t F[RV_N_REGS];
-        uint32_t F_int[RV_N_REGS]; /* integer shortcut */
+        riscv_float_t F[N_RV_REGS];
+        uint32_t F_int[N_RV_REGS]; /* integer shortcut */
     };
     uint32_t csr_fcsr;
 #endif

--- a/tools/rv_histogram.c
+++ b/tools/rv_histogram.c
@@ -18,28 +18,46 @@
 #include "decode.h"
 #include "elf.h"
 
+typedef void (*hist_record_handler)(rv_insn_t *);
+
 static bool ascending_order = false;
+static bool show_reg = false;
 static const char *elf_prog = NULL;
 
-typedef struct {
-    char insn_str[16];
-    size_t freq;
-} rv_insn_hist_t;
+hist_record_handler hist_record;
+static const char *insn_reg;
+static size_t freq;
+static size_t max_freq = 0;
+static size_t total_freq = 0;
+static unsigned short max_col;
+static unsigned short used_col;
 
-static rv_insn_hist_t rv_insn_stats[] = {
-#define _(inst, can_branch) {#inst, 0},
-    RISCV_INSN_LIST _(unknown, 0)
+typedef struct {
+    char insn_reg[16]; /* insn or reg   */
+    size_t freq;       /* frequency     */
+    uint8_t reg_mask;  /* 0x1=rs1, 0x2=rs2, 0x4=rs3, 0x8=rd */
+} rv_hist_t;
+
+static rv_hist_t rv_insn_stats[] = {
+#define _(inst, can_branch, reg_mask) {#inst, 0, reg_mask},
+    RISCV_INSN_LIST _(unknown, 0, 0)
+#undef _
+};
+
+static rv_hist_t rv_reg_stats[] = {
+#define _(reg) {#reg, 0},
+    RV_REGS_LIST
 #undef _
 };
 
 static int cmp_dec(const void *a, const void *b)
 {
-    return ((rv_insn_hist_t *) b)->freq - ((rv_insn_hist_t *) a)->freq;
+    return ((rv_hist_t *) b)->freq - ((rv_hist_t *) a)->freq;
 }
 
 static int cmp_asc(const void *a, const void *b)
 {
-    return ((rv_insn_hist_t *) a)->freq - ((rv_insn_hist_t *) b)->freq;
+    return ((rv_hist_t *) a)->freq - ((rv_hist_t *) b)->freq;
 }
 
 /* used to adjust the length of histogram bar */
@@ -54,6 +72,14 @@ static unsigned short get_win_max_col()
     ioctl(STDOUT_FILENO, TIOCGWINSZ, &terminal_size);
     return terminal_size.ws_col;
 #endif
+}
+
+static void find_max_freq(const rv_hist_t *stats, size_t stats_size)
+{
+    for (size_t i = 0; i < stats_size; i++) {
+        if (stats[i].freq > max_freq)
+            max_freq = stats[i].freq;
+    }
 }
 
 static const char *fmt = "%3d. %-10s%5.2f%% [%-10zu] %s\n";
@@ -110,19 +136,24 @@ static void print_usage(const char *filename)
     fprintf(stderr,
             "rv_histogram which loads an ELF file to execute.\n"
             "Usage: %s [option] [elf_file_path]\n"
-            "available option: -a, print the histogram in ascending order\n",
+            "available options: -a, print the histogram in "
+            "ascending order(default is on decending order)\n"
+            "                 : -r, analysis on registers\n",
             filename);
 }
 
 static bool parse_args(int argc, char **args)
 {
-    const char *optstr = "a";
+    const char *optstr = "ar";
     int opt;
 
     while ((opt = getopt(argc, args, optstr)) != -1) {
         switch (opt) {
         case 'a':
             ascending_order = true;
+            break;
+        case 'r':
+            show_reg = true;
             break;
         default:
             return false;
@@ -134,12 +165,62 @@ static bool parse_args(int argc, char **args)
     return true;
 }
 
+void print_hist_stats(const rv_hist_t *stats, size_t stats_size)
+{
+    char hist_bar[max_col * 3 + 1];
+    float percent;
+    size_t idx = 1;
+
+    for (size_t i = 0; i < stats_size; i++) {
+        insn_reg = stats[i].insn_reg;
+        freq = stats[i].freq;
+
+        percent = (float) freq / total_freq;
+        if (percent < 0.01)
+            continue;
+
+        printf(fmt, idx, insn_reg, percent, freq,
+               gen_hist_bar(hist_bar, sizeof(hist_bar), freq, max_freq, max_col,
+                            used_col));
+        idx++;
+    }
+}
+
+void reg_hist_incr(rv_insn_t *ir)
+{
+    if (!ir)
+        return;
+
+    uint8_t reg_mask = rv_insn_stats[ir->opcode].reg_mask;
+
+    if (reg_mask & 0x1)
+        rv_reg_stats[ir->rs1].freq++;
+    if (reg_mask & 0x2)
+        rv_reg_stats[ir->rs2].freq++;
+    if (reg_mask & 0x4)
+        rv_reg_stats[ir->rs3].freq++;
+    if (reg_mask & 0x8)
+        rv_reg_stats[ir->rd].freq++;
+}
+
+void insn_hist_incr(rv_insn_t *ir)
+{
+    if (!ir) {
+        rv_insn_stats[N_RISCV_INSN_LIST].freq++;
+        return;
+    }
+    rv_insn_stats[ir->opcode].freq++;
+}
+
 int main(int argc, char *args[])
 {
     if (!parse_args(argc, args) || !elf_prog) {
         print_usage(args[0]);
         return 1;
     }
+
+    /* resolver of histogram accounting */
+    hist_record = show_reg ? reg_hist_incr : insn_hist_incr;
 
     elf_t *e = elf_new();
     if (!elf_open(e, elf_prog)) {
@@ -153,8 +234,8 @@ int main(int argc, char *args[])
         fprintf(stderr, "malloc for section headers failed\n");
         return 1;
     }
+
     uintptr_t *elf_first_byte = (uintptr_t *) get_elf_first_byte(e);
-    size_t total_insn = 0;
     rv_insn_t ir;
     bool res;
 
@@ -189,49 +270,36 @@ int main(int argc, char *args[])
 
             /* unknown instruction */
             if (!res) {
-                rv_insn_stats[N_RISCV_INSN_LIST].freq++;
+                hist_record(NULL);
                 continue;
             }
 
-            rv_insn_stats[ir.opcode].freq++;
-            total_insn++;
+            hist_record(&ir);
+            total_freq++;
         }
     }
 
-    /* decending order on default */
-    qsort(rv_insn_stats, ARRAYS_SIZE(rv_insn_stats), sizeof(rv_insn_hist_t),
-          ascending_order ? cmp_asc : cmp_dec);
+    max_col = get_win_max_col();
+    used_col = get_used_col();
 
-    unsigned short max_col = get_win_max_col();
-    unsigned short used_col = get_used_col();
-    char hist_bar[max_col * 3 + 1];
-    char *insn_str;
-    size_t insn_freq;
-    size_t max_insn_freq = 0;
-    float percent;
+    if (show_reg) {
+        qsort(rv_reg_stats, ARRAYS_SIZE(rv_reg_stats), sizeof(rv_hist_t),
+              ascending_order ? cmp_asc : cmp_dec);
 
-    /* 1 for unknown */
-    for (int i = 0; i < N_RISCV_INSN_LIST + 1; i++) {
-        if (rv_insn_stats[i].freq > max_insn_freq)
-            max_insn_freq = rv_insn_stats[i].freq;
-    }
+        printf("+--------------------------------------+\n");
+        printf("| RV32 Target Register Usage Histogram |\n");
+        printf("+--------------------------------------+\n");
+        find_max_freq(rv_reg_stats, N_RV_REGS);
+        print_hist_stats(rv_reg_stats, N_RV_REGS);
+    } else {
+        qsort(rv_insn_stats, ARRAYS_SIZE(rv_insn_stats), sizeof(rv_hist_t),
+              ascending_order ? cmp_asc : cmp_dec);
 
-    printf("+---------------------------------------------+\n");
-    printf("| RV32 Target Instruction Frequency Histogram |\n");
-    printf("+---------------------------------------------+\n");
-
-    /* 1 for unknown */
-    for (int i = 0; i < N_RISCV_INSN_LIST + 1; i++) {
-        insn_str = rv_insn_stats[i].insn_str;
-        insn_freq = rv_insn_stats[i].freq;
-
-        percent = (float) insn_freq / total_insn;
-        if (percent < 0.01)
-            continue;
-
-        printf(fmt, i + 1, insn_str, percent, insn_freq,
-               gen_hist_bar(hist_bar, sizeof(hist_bar), insn_freq,
-                            max_insn_freq, max_col, used_col));
+        printf("+---------------------------------------------+\n");
+        printf("| RV32 Target Instruction Frequency Histogram |\n");
+        printf("+---------------------------------------------+\n");
+        find_max_freq(rv_insn_stats, N_RISCV_INSN_LIST + 1);
+        print_hist_stats(rv_insn_stats, N_RISCV_INSN_LIST + 1);
     }
 
     free(shdrs);


### PR DESCRIPTION
Introduce `reg_used_mask` in `rv_insn_t` structure, so that we can know which registers are used during the static analysis of the instruction.

Also, refactor the initialization of enumeration of registers with X-macro for reusing the macro in the tool