### PR TITLE
Avoid recursive jump for better loop detection

### DIFF
--- a/src/emulate.c
+++ b/src/emulate.c
@@ -405,19 +405,8 @@ static void block_translate(riscv_t *rv, block_t *block)
         block->pc_end += ir->insn_len;
         block->n_insn++;
         /* stop on branch */
-        if (insn_is_branch(ir->opcode)) {
-            /* recursive jump translation */
-            if (ir->opcode == rv_insn_jal
-#if RV32_HAS(EXT_C)
-                || ir->opcode == rv_insn_cj || ir->opcode == rv_insn_cjal
-#endif
-            ) {
-                block->pc_end = block->pc_end - ir->insn_len + ir->imm;
-                ir->branch_taken = ir + 1;
-                continue;
-            }
+        if (insn_is_branch(ir->opcode))
             break;
-        }
     }
     block->ir[block->n_insn - 1].tailcall = true;
 }
@@ -622,6 +611,14 @@ void rv_step(riscv_t *rv, int32_t cycles)
                     else if (!branch_taken &&
                              (!last_ir->branch_untaken || clear_flag))
                         last_ir->branch_untaken = block->ir;
+                } else if (last_ir->opcode == rv_insn_jal
+#if RV32_HAS(EXT_C)
+                           || last_ir->opcode == rv_insn_cj ||
+                           last_ir->opcode == rv_insn_cjal
+#endif
+                ) {
+                    if (!last_ir->branch_taken || clear_flag)
+                        last_ir->branch_taken = block->ir;
                 }
             }
         }


### PR DESCRIPTION
Previously, we employed recursive jump translation to implement an extended basic block. Nevertheless, this approach makes it challenging to detect loop paths since we position the loop's entry block inside the block, and its using frequency would not be updated.

Based on this observation, it becomes necessary to eliminate the recursive jump translation. By doing so, we can accurately update the using frequency of the loop's entry block.

As shown in the performance results below, we gain 4% performance improvement when running coreMark and 37% when running SciMark2, but we lost 1% performance when running dhrysone.

* Intel Core i7-11700

|   Metric   | origin  | proposed |Speedup|
|--------- |--------- |--------- |--------- |
| CoreMark   | 2193.28 | 2289.26  |  +4%  |
| SciMark2   |   13.45 |   18.48  |  +37%  |
| Dhrystone  | 1413.11 | 1447.11  |  -1%  |

See: #142