### PR TITLE
Enhance sfx_handler to accomodate more formats

### DIFF
--- a/docs/demo.md
+++ b/docs/demo.md
@@ -18,6 +18,9 @@
 * 1: Fist
 * 3: Shotgun
 
+### Music and sound effect(sfx)
+Support music and sound effects.
+
 ## Quake
 **source**: [quake-embedded](https://github.com/sysprog21/quake-embedded/)
 
@@ -47,6 +50,9 @@ make
 
 You may use the mouse to adjust the pitch and yaw angle
 
+### Music and sound effect(sfx)
+Support sound effects but not music currently because Quake needs a CD-ROM and the extracted pak file doesn't contain any music or bgm-related files.
+
 ### Limitations
 * Mouse wheel input is not supported
-* All sound functions are not implemented
+* Music related functions in Quake are not implemented

--- a/docs/syscall.md
+++ b/docs/syscall.md
@@ -174,7 +174,7 @@ The request is similar to how music is managed earlier in the description and su
 Music data is defined in a structure called `musicinfo_t`. The SDL2_mixer library is used by the emulator to play music using the fields `data` and `size` in the structure.
 
 #### Sound Effect(sfx)
-`sfxinfo_t` is a structure that defines sound effect data and size. The `data` and `size` fields of the structure are used to play sound effect with the SDL2_mixer library.
+`sfxinfo_t` is a structure that defines sound effect data and size. The `data` and `size` fields of the structure are used to play sound effect with the SDL2_mixer library. Currently, support sound effect of [Doom's WAV](https://doomwiki.org/wiki/Sound) format and [normal WAV](https://en.wikipedia.org/wiki/WAV) format(includes [RIFF header](https://en.wikipedia.org/wiki/Resource_Interchange_File_Format)).
 
 ### `setup_audio` - setup or shutdown sound system
 


### PR DESCRIPTION
Quake's WAV format is different from Doom's WAV format, so we must improve the sfx_handler by determinating the format type before playing sound effect in order to accommodate Quake's WAV format.