### PR TITLE
Fix typo

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -536,7 +536,7 @@ void cache_free(cache_t *cache, void (*callback)(void *))
 #endif
             callback(entry->value);
     }
-    mpool_destory(cache_mp);
+    mpool_destroy(cache_mp);
     free(cache->map->ht_list_head);
     free(cache->map);
     free(cache);

--- a/src/mpool.c
+++ b/src/mpool.c
@@ -132,7 +132,7 @@ void mpool_free(mpool_t *mp, void *target)
     mp->chunk_count++;
 }
 
-void mpool_destory(mpool_t *mp)
+void mpool_destroy(mpool_t *mp)
 {
 #if defined(USE_MMAP)
     size_t mem_size = mp->page_count * getpagesize();

--- a/src/mpool.h
+++ b/src/mpool.h
@@ -37,7 +37,7 @@ void *mpool_calloc(struct mpool *mp);
 void mpool_free(struct mpool *mp, void *target);
 
 /**
- * mpool_destory - destroy a memory pool
+ * mpool_destroy - destroy a memory pool
  * @mp: a pointer points to the target memory pool
  */
-void mpool_destory(struct mpool *mp);
+void mpool_destroy(struct mpool *mp);


### PR DESCRIPTION
The function mpool_destory was incorrectly named, and this commit corrects the function name to mpool_destroy.