### PR TITLE
Improve calc_fclass() with binary decision tree

### DIFF
--- a/src/softfloat.h
+++ b/src/softfloat.h
@@ -35,29 +35,45 @@ static inline uint32_t calc_fclass(uint32_t f)
     const uint32_t expn = f & FMASK_EXPN;
     const uint32_t frac = f & FMASK_FRAC;
 
-    /* TODO: optimize with a binary decision tree */
-
     uint32_t out = 0;
-    /* 0x001    rs1 is -INF */
-    out |= (f == 0xff800000) ? 0x001 : 0;
-    /* 0x002    rs1 is negative normal */
-    out |= (expn && (expn != FMASK_EXPN) && sign) ? 0x002 : 0;
-    /* 0x004    rs1 is negative subnormal */
-    out |= (!expn && frac && sign) ? 0x004 : 0;
-    /* 0x008    rs1 is -0 */
-    out |= (f == 0x80000000) ? 0x008 : 0;
-    /* 0x010    rs1 is +0 */
-    out |= (f == 0x00000000) ? 0x010 : 0;
-    /* 0x020    rs1 is positive subnormal */
-    out |= (!expn && frac && !sign) ? 0x020 : 0;
-    /* 0x040    rs1 is positive normal */
-    out |= (expn && (expn != FMASK_EXPN) && !sign) ? 0x040 : 0;
-    /* 0x080    rs1 is +INF */
-    out |= (expn == FMASK_EXPN && !frac && !sign) ? 0x080 : 0;
-    /* 0x100    rs1 is a signaling NaN */
-    out |= (expn == FMASK_EXPN && frac && !(frac & FMASK_QNAN)) ? 0x100 : 0;
-    /* 0x200    rs1 is a quiet NaN */
-    out |= (expn == FMASK_EXPN && (frac & FMASK_QNAN)) ? 0x200 : 0;
+
+    /*
+     * 0x001    rs1 is -INF
+     * 0x002    rs1 is negative normal
+     * 0x004    rs1 is negative subnormal
+     * 0x008    rs1 is -0
+     * 0x010    rs1 is +0
+     * 0x020    rs1 is positive subnormal
+     * 0x040    rs1 is positive normal
+     * 0x080    rs1 is +INF
+     * 0x100    rs1 is a signaling NaN
+     * 0x200    rs1 is a quiet NaN
+     */
+
+    /* Check the exponent bits */
+    if (expn) {
+        if (expn != FMASK_EXPN) {
+            /* Check if it is negative normal or positive normal */
+            out = sign ? 0x002 : 0x040;
+        } else {
+            /* Check if it is NaN */
+            if (frac) {
+                out = frac & FMASK_QNAN ? 0x200 : 0x100;
+            } else if (!sign) {
+                /* Check if it is +INF */
+                out = 0x080;
+            } else {
+                /* Check if it is -INF */
+                out = 0x001;
+            }
+        }
+    } else if (frac) {
+        /* Check if it is negative or positive subnormal */
+        out = sign ? 0x004 : 0x020;
+    } else {
+        /* Check if it is +0 or -0 */
+        out = sign ? 0x008 : 0x010;
+    }
 
     return out;
 }


### PR DESCRIPTION
I have optimized the calc_fclass function by changing it into a binary decision tree. This optimization significantly improves the performance of the function, resulting in a speedup of approximately 69% in my test. The test I wrote to evaluate the performance: https://github.com/visitorckw/rv32emu-calc_fclass-optimization/