### PR TITLE
Fix round_pow2 function for edge cases

### DIFF
--- a/src/syscall_sdl.c
+++ b/src/syscall_sdl.c
@@ -175,6 +175,8 @@ static void event_push(riscv_t *rv, event_t event)
 
 static inline uint32_t round_pow2(uint32_t x)
 {
+    if (x <= 1)
+        return 1;
 #if defined(__GNUC__) || defined(__clang__)
     x = 1 << (32 - __builtin_clz(x - 1));
 #else


### PR DESCRIPTION
The round_pow2 function was returning incorrect values when the input x was less than or equal to 1. Specifically, it was returning 2 for x=1 when compiled with GCC or Clang, and 0 for x=0 when compiled with other compilers. According to the documentation in syscall.md, both of these cases should return 1. This commit addresses the issue by explicitly handling these edge cases and returning 1.