### PR TITLE
CI: Implementing benchmark regression tests

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -43,7 +43,9 @@ jobs:
           name: Benchmarks
           tool: 'customBiggerIsBetter'
           output-file-path: benchmark_output.txt
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.RV32EMU_BENCH_TOKEN }}
+          gh-repository: 'github.com/sysprog21/rv32emu-bench'
+          gh-pages-branch: 'master'
           auto-push: true
           comment-always: true
           benchmark-data-dir-path: .

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,7 +8,7 @@ jobs:
     if: contains(toJSON(github.event.head_commit.message), 'Merge pull request ') == false
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3.6.0
+      - uses: actions/checkout@v4
       - name: Test changed files
         id: changed-files
         uses: tj-actions/changed-files@v39
@@ -21,10 +21,7 @@ jobs:
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
             github.event_name == 'workflow_dispatch'}}
         run: |
-            sudo apt-get update
-            sudo apt-get install libsdl2-dev libsdl2-mixer-dev
             sudo pip3 install numpy
-            sh .ci/riscv-toolchain-install.sh
         shell: bash
       - name: default build
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
@@ -34,7 +31,7 @@ jobs:
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
             github.event_name == 'workflow_dispatch'}}
         run: |
-          ./tests/benchmark_combiner.py
+          tests/bench-aggregator.py
       - name: Store benchmark results
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
             github.event_name == 'workflow_dispatch'}}
@@ -42,7 +39,7 @@ jobs:
         with:
           name: Benchmarks
           tool: 'customBiggerIsBetter'
-          output-file-path: benchmark_output.txt
+          output-file-path: benchmark_output.json
           github-token: ${{ secrets.RV32EMU_BENCH_TOKEN }}
           gh-repository: 'github.com/sysprog21/rv32emu-bench'
           gh-pages-branch: 'master'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,49 @@
+name: Benchmark
+
+on: [push, pull_request_target, workflow_dispatch]
+
+jobs:
+  benchmark:
+    name: Performance regression check
+    if: contains(toJSON(github.event.head_commit.message), 'Merge pull request ') == false
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3.6.0
+      - name: Test changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v39
+        with:
+          files: |
+              src/decode.c
+              src/emulate.c
+              src/rv32_template.c
+      - name: install-dependencies
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
+            github.event_name == 'workflow_dispatch'}}
+        run: |
+            sudo apt-get update
+            sudo apt-get install libsdl2-dev libsdl2-mixer-dev
+            sudo pip3 install numpy
+            sh .ci/riscv-toolchain-install.sh
+        shell: bash
+      - name: default build
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
+            github.event_name == 'workflow_dispatch'}}
+        run: make
+      - name: Run benchmark
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
+            github.event_name == 'workflow_dispatch'}}
+        run: |
+          ./tests/benchmark_combiner.py
+      - name: Store benchmark results
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
+            github.event_name == 'workflow_dispatch'}}
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Benchmarks
+          tool: 'customBiggerIsBetter'
+          output-file-path: benchmark_output.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          comment-always: true
+          benchmark-data-dir-path: .

--- a/tests/bench-aggregator.py
+++ b/tests/bench-aggregator.py
@@ -20,12 +20,12 @@ for b in benchmarks:
 
 # combine benchmarks output data
 benchmarks_output = [
-    "dhrystone_output.txt", 
-    "coremark_output.txt"
+    "dhrystone_output.json", 
+    "coremark_output.json"
 ]
 benchmark_data = [load_benchmark(bo) for bo in benchmarks_output]
 
-benchmark_output = "benchmark_output.txt"
+benchmark_output = "benchmark_output.json"
 f = open(benchmark_output, "w")
 f.write(json.dumps(benchmark_data, indent=4))
 f.close()

--- a/tests/benchmark_combiner.py
+++ b/tests/benchmark_combiner.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import json
+import subprocess
+
+def run_benchmark(cmd):
+    subprocess.run(cmd, shell=True, check=True)
+
+def load_benchmark(file):
+    f = open(file, "r")
+    return json.load(f)
+
+# run benchmarks
+benchmarks = [
+    "bash tests/dhrystone.sh",
+    "python3 tests/coremark.py"
+]
+for b in benchmarks:
+    run_benchmark(b)
+
+# combine benchmarks output data
+benchmarks_output = [
+    "dhrystone_output.txt", 
+    "coremark_output.txt"
+]
+benchmark_data = [load_benchmark(bo) for bo in benchmarks_output]
+
+benchmark_output = "benchmark_output.txt"
+f = open(benchmark_output, "w")
+f.write(json.dumps(benchmark_data, indent=4))
+f.close()

--- a/tests/coremark.py
+++ b/tests/coremark.py
@@ -3,6 +3,7 @@ import subprocess
 import re
 import numpy
 import os
+import json
 
 iter = 10
 res = []
@@ -37,3 +38,14 @@ for n in res:
         res.remove(n)
 
 print("{:.3f}".format(numpy.mean(res, dtype=numpy.float64)))
+
+#save Average Iterations/Sec in JSON format for benchmark action workflow
+benchmark_output = "coremark_output.txt"
+benchmark_data = {
+    "name":"Coremark", 
+    "unit":"Average iterations/sec over 10 runs", 
+    "value":float("{:.3f}".format(numpy.mean(res, dtype=numpy.float64)))
+}
+f = open(benchmark_output, "w")
+f.write(json.dumps(benchmark_data))
+f.close()

--- a/tests/coremark.py
+++ b/tests/coremark.py
@@ -40,7 +40,7 @@ for n in res:
 print("{:.3f}".format(numpy.mean(res, dtype=numpy.float64)))
 
 #save Average Iterations/Sec in JSON format for benchmark action workflow
-benchmark_output = "coremark_output.txt"
+benchmark_output = "coremark_output.json"
 benchmark_data = {
     "name":"Coremark", 
     "unit":"Average iterations/sec over 10 runs", 

--- a/tests/dhrystone.sh
+++ b/tests/dhrystone.sh
@@ -67,7 +67,7 @@ do
 done
 
 #dhrystone benchmark output file
-benchmark_output=dhrystone_output.txt
+benchmark_output=dhrystone_output.json
 # empty the file
 echo -n "" > $benchmark_output
 

--- a/tests/dhrystone.sh
+++ b/tests/dhrystone.sh
@@ -66,6 +66,11 @@ do
     fi
 done
 
+#dhrystone benchmark output file
+benchmark_output=dhrystone_output.txt
+# empty the file
+echo -n "" > $benchmark_output
+
 # Calculate average DMIPS excluding outliers
 num_filtered=${#filtered_dmips[@]}
 if ((num_filtered > 0)); then
@@ -79,6 +84,14 @@ if ((num_filtered > 0)); then
     echo "--------------------------"
     echo "Average DMIPS : $average_dmips"
     echo "--------------------------"
+
+    #save Average DMIPS in JSON format for benchmark action workflow
+    echo -n '{' >> $benchmark_output
+    echo -n '"name": "Dhrystone",' >> $benchmark_output
+    echo -n '"unit": "Average DMIPS over 10 runs",' >> $benchmark_output
+    echo -n '"value": ' >> $benchmark_output
+    echo -n $average_dmips >> $benchmark_output
+    echo -n '}' >> $benchmark_output
 else
     fail
 fi


### PR DESCRIPTION
Using "pull_request_target" is required since benchmark action updates data in the "gh-pages" branch for visualization in gitHub pages, and "pull_request" does not grant the "GITHUB_TOKEN" needed for that purpose.

We also want "workflow_dispatch" because we require a method for running the benchmark the first time so that we can store the base benchmark and utilize it for benchmark comparison in the future.

Before merging this PR, please do the following:
1. Create a branch called "gh-pages", this is the default branch for gitHub repository to deploy our web-based  benchmark visualization. This branch can be left only ".git" directory.
2. Go to the setting of  repository  > Action > General > make sure that "read and write" permission is granted in "Workflow permissions" section

After merging this PR, please run the workflow called `Benchmark` manually via "Run workflow" button to generate the base benchmark. Note that it should be used in a reasonable timing in order not to mess up the benchmark visualization afterwards.

Last, the benchmark CI should work!

Close #166
