### PR TITLE
Tweak memory allocation size for portability

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -17,8 +17,17 @@
 #include "io.h"
 
 static uint8_t *data_memory_base;
-/* set memory size to 2^32 bytes */
-#define MEM_SIZE 0x100000000ULL
+
+/*
+ * set memory size to 2^32 - 1 bytes
+ *
+ * The memory size is set to 2^32 - 1 bytes in order
+ * to make rv32emu portable for both 32-bit and 64-bit platforms.
+ * As a result, rv32emu can access any segment of the memory in
+ * either platform. Furthermore, it is safe because most of the 
+ * test cases' data memory usage will not exceed this memory size.
+ */
+#define MEM_SIZE 0xFFFFFFFFULL
 
 memory_t *memory_new()
 {


### PR DESCRIPTION
From opinion of @qwe661234 at [previous discussion](https://github.com/sysprog21/rv32emu/pull/183), the data memory usage of most test cases would not reach 0xFFFFFFFF. Thus, it is safe for the changing of memory size allocation to 0xFFFFFFFF such that we do not need to check the platform during compilation. 

Close #161