### PR TITLE
Link the register jump

### DIFF
--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -51,6 +51,9 @@ RVOP(jalr, {
         rv->X[ir->rd] = pc + ir->insn_len;
     /* check instruction misaligned */
     RV_EXC_MISALIGN_HANDLER(pc, insn, false, 0);
+    block_t *block = block_find(&rv->block_map, rv->PC);
+    if (block)
+        return block->ir->impl(rv, block->ir);
     return true;
 })
 
@@ -904,6 +907,9 @@ RVOP(clwsp, {
 /* C.JR */
 RVOP(cjr, {
     rv->PC = rv->X[ir->rs1];
+    block_t *block = block_find(&rv->block_map, rv->PC);
+    if (block)
+        return block->ir->impl(rv, block->ir);
     return true;
 })
 
@@ -924,6 +930,9 @@ RVOP(cjalr, {
     rv->X[rv_reg_ra] = rv->PC + ir->insn_len;
     rv->PC = jump_to;
     RV_EXC_MISALIGN_HANDLER(rv->PC, insn, true, 0);
+    block_t *block = block_find(&rv->block_map, rv->PC);
+    if (block)
+        return block->ir->impl(rv, block->ir);
     return true;
 })
 


### PR DESCRIPTION
Originally, the interpreter would exit the execution loop if the instruction was a register jump, which posed a critical performance issue. To address this problem, we now search for the next block at the end of the execution of a register jump. If we find the next block, we link the register jump to it.

As shown in below analysis, this modification improves the overall performance by 1~2%.

* Core i7-11700

| Metric  | Original       |    Proposed    | Speedup |
|---------|----------------|----------------|-------|
| CoreMark| 1931.047 iter/s| 1956.64 iter/s | +1.33%|
| stream  |   79.156 sec   |   77.123 sec   | +2.57%|

Close: #223