### PR TITLE
Reduce memory usage for instruction block

### DIFF
--- a/src/decode.h
+++ b/src/decode.h
@@ -298,6 +298,8 @@ typedef struct rv_insn {
      * specific IR array without the need for additional copying.
      */
     struct rv_insn *branch_taken, *branch_untaken;
+
+    struct rv_insn *next;
 } rv_insn_t;
 
 /* decode the RISC-V instruction */

--- a/src/riscv_private.h
+++ b/src/riscv_private.h
@@ -56,15 +56,17 @@ enum {
 typedef struct block {
     uint32_t n_insn;           /**< number of instructions encompased */
     uint32_t pc_start, pc_end; /**< address range of the basic block */
-    uint32_t insn_capacity;    /**< maximum of instructions encompased */
     struct block *predict;     /**< block prediction */
-    rv_insn_t *ir;             /**< IR as memory blocks */
+
+    rv_insn_t *ir_head, *ir_tail; /**< the first and last ir for this block */
 } block_t;
 
 typedef struct {
     uint32_t block_capacity; /**< max number of entries in the block map */
     uint32_t size;           /**< number of entries currently in the map */
     block_t **map;           /**< block map */
+
+    struct mpool *block_mp, *block_ir_mp;
 } block_map_t;
 
 /* clear all block in the block map */

--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -53,7 +53,7 @@ RVOP(jalr, {
     RV_EXC_MISALIGN_HANDLER(pc, insn, false, 0);
     block_t *block = block_find(&rv->block_map, rv->PC);
     if (block)
-        return block->ir->impl(rv, block->ir);
+        return block->ir_head->impl(rv, block->ir_head);
     return true;
 })
 
@@ -924,7 +924,7 @@ RVOP(cjr, {
     rv->PC = rv->X[ir->rs1];
     block_t *block = block_find(&rv->block_map, rv->PC);
     if (block)
-        return block->ir->impl(rv, block->ir);
+        return block->ir_head->impl(rv, block->ir_head);
     return true;
 })
 
@@ -947,7 +947,7 @@ RVOP(cjalr, {
     RV_EXC_MISALIGN_HANDLER(rv->PC, insn, true, 0);
     block_t *block = block_find(&rv->block_map, rv->PC);
     if (block)
-        return block->ir->impl(rv, block->ir);
+        return block->ir_head->impl(rv, block->ir_head);
     return true;
 })
 


### PR DESCRIPTION
The original strategy for the allocation of instruction blocks is waste of memory. For every single block, we always create a space that can contain (1 << 10) `rv_insn_t`. However, we usually don't have that much instruction in one block in most of the case.

We can simply know the heap usage by using valgrind. We can see that 20,306,989 bytes are allocated on the run of `puzzle.elf` for the old design.
```
$ valgrind ./build/rv32emu ./build/puzzle.elf
==62803== Memcheck, a memory error detector
==62803== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==62803== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==62803== Command: ./build/rv32emu ./build/puzzle.elf
==62803== 
==62803== Warning: set address range perms: large range [0x59c87000, 0x159c87000) (defined)
success in 2005 trials
inferior exit code 0
==62803== Warning: set address range perms: large range [0x59c87000, 0x159c87000) (noaccess)
==62803== 
==62803== HEAP SUMMARY:
==62803==     in use at exit: 39,124 bytes in 259 blocks
==62803==   total heap usage: 1,281 allocs, 1,022 frees, 20,306,989 bytes allocated
==62803== 
==62803== LEAK SUMMARY:
==62803==    definitely lost: 0 bytes in 0 blocks
==62803==    indirectly lost: 0 bytes in 0 blocks
==62803==      possibly lost: 0 bytes in 0 blocks
==62803==    still reachable: 37,108 bytes in 238 blocks
==62803==         suppressed: 0 bytes in 0 blocks
==62803== Rerun with --leak-check=full to see details of leaked memory
==62803== 
==62803== For lists of detected and suppressed errors, rerun with: -s
==62803== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

To address the issue, we can simply maintain a pool of `rv_insn_t`, and take only the required numbers of  `rv_insn_t` space from it. This ensures heap allocation only happens when the pool is out of `rv_insn_t`. By using the parameter `BLOCK_POOL_SIZE`, we have the flexibility to get the balance between the numbers of `calloc` calls and the memory usage. 

In this way, we have great improvement for the heap memory allocation. As the following result, only 313,461 bytes are allocated on the `puzzle.elf` example.
```
$ valgrind ./build/rv32emu ./build/puzzle.elf
==62927== Memcheck, a memory error detector
==62927== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==62927== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==62927== Command: ./build/rv32emu ./build/puzzle.elf
==62927== 
==62927== Warning: set address range perms: large range [0x59c87000, 0x159c87000) (defined)
success in 2005 trials
inferior exit code 0
==62927== Warning: set address range perms: large range [0x59c87000, 0x159c87000) (noaccess)
==62927== 
==62927== HEAP SUMMARY:
==62927==     in use at exit: 39,124 bytes in 259 blocks
==62927==   total heap usage: 940 allocs, 681 frees, 313,461 bytes allocated
==62927== 
==62927== LEAK SUMMARY:
==62927==    definitely lost: 0 bytes in 0 blocks
==62927==    indirectly lost: 0 bytes in 0 blocks
==62927==      possibly lost: 0 bytes in 0 blocks
==62927==    still reachable: 37,108 bytes in 238 blocks
==62927==         suppressed: 0 bytes in 0 blocks
==62927== Rerun with --leak-check=full to see details of leaked memory
==62927== 
==62927== For lists of detected and suppressed errors, rerun with: -s
==62927== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

Because two instructions in sequence may now be separated into two discontinuous memory spaces, a drawback of this design is the cost of random access to the instruction. It seems that we only need random access to the instructions for some fuse operations, I think this might not be a big problem. We can still linear search that instruction with `GET_NEXT_N_INSN` macro in a relatively inefficient manner. The design could also introduce some cache locality issues two for the discontinuous memory spaces, but we may be able to adjust `BLOCK_POOL_SIZE` to trade-off for this.
