### PR TITLE
Handle csr mstatus and misa correctly

### DIFF
--- a/src/riscv.c
+++ b/src/riscv.c
@@ -254,8 +254,18 @@ void rv_reset(riscv_t *rv, riscv_word_t pc, int argc, char **args)
     rv->csr_mtvec = 0;
     rv->csr_cycle = 0;
     rv->csr_mstatus = 0;
-
+    rv->csr_misa |= MISA_SUPER | MISA_USER | MISA_I;
+#if RV32_HAS(EXT_A)
+    rv->csr_misa |= MISA_A;
+#endif
+#if RV32_HAS(EXT_C)
+    rv->csr_misa |= MISA_C;
+#endif
+#if RV32_HAS(EXT_M)
+    rv->csr_misa |= MISA_M;
+#endif
 #if RV32_HAS(EXT_F)
+    rv->csr_misa |= MISA_F;
     /* reset float registers */
     memset(rv->F, 0, sizeof(float) * N_RV_REGS);
     rv->csr_fcsr = 0;

--- a/src/riscv.h
+++ b/src/riscv.h
@@ -67,6 +67,18 @@ enum {
 };
 /* clang-format on */
 
+#define MISA_SUPER (1 << ('S' - 'A'))
+#define MISA_USER (1 << ('U' - 'A'))
+#define MISA_I (1 << ('I' - 'A'))
+#define MISA_M (1 << ('M' - 'A'))
+#define MISA_A (1 << ('A' - 'A'))
+#define MISA_F (1 << ('F' - 'A'))
+#define MISA_C (1 << ('C' - 'A'))
+#define MSTATUS_MPIE_SHIFT 7
+#define MSTATUS_MPP_SHIFT 11
+#define MSTATUS_MPIE (1 << MSTATUS_MPIE_SHIFT)
+#define MSTATUS_MPP (3 << MSTATUS_MPP_SHIFT)
+
 /* forward declaration for internal structure */
 typedef struct riscv_internal riscv_t;
 typedef void *riscv_user_t;

--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -285,6 +285,7 @@ RVOP(hret, {
 
 /* MRET: return from traps in U-mode */
 RVOP(mret, {
+    rv->csr_mstatus = MSTATUS_MPIE;
     rv->PC = rv->csr_mepc;
     return true;
 })


### PR DESCRIPTION
In the privileged arch-test, we need to set the extensions we used in the Machine ISA Register and set the Machine Status Register to privileged mode when we invoke the exception handler