### PR TITLE
Manipulate csr_cycle and PC by registers. Drop insn_len

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -1726,10 +1726,9 @@ bool rv_decode(rv_insn_t *ir, uint32_t insn)
     /* If the last 2-bit is one of 0b00, 0b01, and 0b10, it is
      * a 16-bit instruction.
      */
-    if ((insn & FC_OPCODE) != 3) {
+    if (is_compressed(insn)) {
         insn &= 0x0000FFFF;
         const uint16_t c_index = (insn & FC_FUNC3) >> 11 | (insn & FC_OPCODE);
-        ir->insn_len = INSN_16;
 
         /* decode instruction (compressed instructions) */
         const decode_t op = rvc_jump_table[c_index];
@@ -1740,7 +1739,6 @@ bool rv_decode(rv_insn_t *ir, uint32_t insn)
 
     /* standard uncompressed instruction */
     const uint32_t index = (insn & INSN_6_2) >> 2;
-    ir->insn_len = INSN_32;
 
     /* decode instruction */
     const decode_t op = rv_jump_table[index];

--- a/src/decode.c
+++ b/src/decode.c
@@ -1255,7 +1255,7 @@ static inline bool op_caddi(rv_insn_t *ir, const uint32_t insn)
     /* dispatch from rd/rs1 field */
     switch (ir->rd) {
     case 0: /* C.NOP */
-        ir->opcode = rv_insn_nop;
+        ir->opcode = rv_insn_cnop;
         break;
     default: /* C.ADDI */
         /* Add 6-bit signed immediate to rds, serving as NOP for X0 register. */
@@ -1320,7 +1320,7 @@ static inline bool op_clui(rv_insn_t *ir, const uint32_t insn)
     /* dispatch from rd/rs1 region */
     switch (ir->rd) {
     case 0: /* Code point: rd = x0 is HINTS */
-        ir->opcode = rv_insn_nop;
+        ir->opcode = rv_insn_cnop;
         break;
     case 2: { /* C.ADDI16SP */
         ir->imm = c_decode_caddi16sp_nzimm(insn);
@@ -1381,7 +1381,7 @@ static inline bool op_cmisc_alu(rv_insn_t *ir, const uint32_t insn)
         /* Code point: rd = x0 is HINTS
          * Code point: shamt = 0 is HINTS
          */
-        ir->opcode = (!ir->rs1 || !ir->shamt) ? rv_insn_nop : rv_insn_csrli;
+        ir->opcode = (!ir->rs1 || !ir->shamt) ? rv_insn_cnop : rv_insn_csrli;
         break;
     case 1: /* C.SRAI */
         ir->shamt = c_decode_cbtype_shamt(insn);
@@ -1448,7 +1448,7 @@ static inline bool op_cslli(rv_insn_t *ir, const uint32_t insn)
     tmp |= (insn & FCI_IMM_6_2) >> 2;
     ir->imm = tmp;
     ir->rd = c_decode_rd(insn);
-    ir->opcode = ir->rd ? rv_insn_cslli : rv_insn_nop;
+    ir->opcode = ir->rd ? rv_insn_cslli : rv_insn_cnop;
     return true;
 }
 
@@ -1470,7 +1470,7 @@ static inline bool op_clwsp(rv_insn_t *ir, const uint32_t insn)
     ir->rd = c_decode_rd(insn);
 
     /* reserved for rd = x0 */
-    ir->opcode = ir->rd ? rv_insn_clwsp : rv_insn_nop;
+    ir->opcode = ir->rd ? rv_insn_clwsp : rv_insn_cnop;
     return true;
 }
 
@@ -1594,7 +1594,7 @@ static inline bool op_ccr(rv_insn_t *ir, const uint32_t insn)
             break;
         default: /* C.MV */
             /* Code point: rd = x0 is HINTS */
-            ir->opcode = ir->rd ? rv_insn_cmv : rv_insn_nop;
+            ir->opcode = ir->rd ? rv_insn_cmv : rv_insn_cnop;
             break;
         }
         break;
@@ -1603,12 +1603,12 @@ static inline bool op_ccr(rv_insn_t *ir, const uint32_t insn)
             ir->opcode = rv_insn_ebreak;
         else if (ir->rs1 && ir->rs2) { /* C.ADD */
             /* Code point: rd = x0 is HINTS */
-            ir->opcode = ir->rd ? rv_insn_cadd : rv_insn_nop;
+            ir->opcode = ir->rd ? rv_insn_cadd : rv_insn_cnop;
         } else if (ir->rs1 && !ir->rs2) /* C.JALR */
             ir->opcode = rv_insn_cjalr;
         else { /* rs2 != x0 AND rs1 = x0 */
             /* Hint */
-            ir->opcode = rv_insn_nop;
+            ir->opcode = rv_insn_cnop;
         }
         break;
     default:

--- a/src/decode.h
+++ b/src/decode.h
@@ -152,7 +152,7 @@ enum op_field {
         _(caddi4spn, 0, 2, ENC(rd))                 \
         _(clw, 0, 2, ENC(rs1, rd))                  \
         _(csw, 0, 2, ENC(rs1, rs2))                 \
-        /* cnop is mapped to nop */                 \
+        _(cnop, 0, 2, ENC())                        \
         _(caddi, 0, 2, ENC(rd))                     \
         _(cjal, 1, 2, ENC())                        \
         _(cli, 0, 2, ENC(rd))                       \

--- a/src/decode.h
+++ b/src/decode.h
@@ -28,160 +28,161 @@ enum op_field {
 #define ENC_GEN(X, A) ENCN(X, A)
 #define ENC(...) ENC_GEN(ENC, COUNT_VARARGS(__VA_ARGS__))(__VA_ARGS__)
 
-/* RISC-V instruction list in format _(instruction-name, can-branch, reg-mask)
+/* RISC-V instruction list in format _(instruction-name, can-branch, insn_len,
+ * reg-mask)
  */
 /* clang-format off */
-#define RV_INSN_LIST                             \
-    _(nop, 0, ENC(rs1, rd))                      \
-    /* RV32I Base Instruction Set */             \
-    _(lui, 0, ENC(rd))                           \
-    _(auipc, 0, ENC(rd))                         \
-    _(jal, 1, ENC(rd))                           \
-    _(jalr, 1, ENC(rs1, rd))                     \
-    _(beq, 1, ENC(rs1, rs2))                     \
-    _(bne, 1, ENC(rs1, rs2))                     \
-    _(blt, 1, ENC(rs1, rs2))                     \
-    _(bge, 1, ENC(rs1, rs2))                     \
-    _(bltu, 1, ENC(rs1, rs2))                    \
-    _(bgeu, 1, ENC(rs1, rs2))                    \
-    _(lb, 0, ENC(rs1, rd))                       \
-    _(lh, 0, ENC(rs1, rd))                       \
-    _(lw, 0, ENC(rs1, rd))                       \
-    _(lbu, 0, ENC(rs1, rd))                      \
-    _(lhu, 0, ENC(rs1, rd))                      \
-    _(sb, 0, ENC(rs1, rs2))                      \
-    _(sh, 0, ENC(rs1, rs2))                      \
-    _(sw, 0, ENC(rs1, rs2))                      \
-    _(addi, 0, ENC(rs1, rd))                     \
-    _(slti, 0, ENC(rs1, rd))                     \
-    _(sltiu, 0, ENC(rs1, rd))                    \
-    _(xori, 0, ENC(rs1, rd))                     \
-    _(ori, 0, ENC(rs1, rd))                      \
-    _(andi, 0, ENC(rs1, rd))                     \
-    _(slli, 0, ENC(rs1, rd))                     \
-    _(srli, 0, ENC(rs1, rd))                     \
-    _(srai, 0, ENC(rs1, rd))                     \
-    _(add, 0, ENC(rs1, rs2, rd))                 \
-    _(sub, 0, ENC(rs1, rs2, rd))                 \
-    _(sll, 0, ENC(rs1, rs2, rd))                 \
-    _(slt, 0, ENC(rs1, rs2, rd))                 \
-    _(sltu, 0, ENC(rs1, rs2, rd))                \
-    _(xor, 0, ENC(rs1, rs2, rd))                 \
-    _(srl, 0, ENC(rs1, rs2, rd))                 \
-    _(sra, 0, ENC(rs1, rs2, rd))                 \
-    _(or, 0, ENC(rs1, rs2, rd))                  \
-    _(and, 0, ENC(rs1, rs2, rd))                 \
-    _(ecall, 1, ENC(rs1, rd))                    \
-    _(ebreak, 1, ENC(rs1, rd))                   \
-    /* RISC-V Privileged Instruction */          \
-    _(wfi, 0, ENC(rs1, rd))                      \
-    _(uret, 0, ENC(rs1, rd))                     \
-    _(sret, 0, ENC(rs1, rd))                     \
-    _(hret, 0, ENC(rs1, rd))                     \
-    _(mret, 1, ENC(rs1, rd))                     \
-    /* RV32 Zifencei Standard Extension */       \
-    IIF(RV32_HAS(Zifencei))(                     \
-        _(fencei, 1, ENC(rs1, rd))               \
-    )                                            \
-    /* RV32 Zicsr Standard Extension */          \
-    IIF(RV32_HAS(Zicsr))(                        \
-        _(csrrw, 0, ENC(rs1, rd))                \
-        _(csrrs, 0, ENC(rs1, rd))                \
-        _(csrrc, 0, ENC(rs1, rd))                \
-        _(csrrwi, 0, ENC(rs1, rd))               \
-        _(csrrsi, 0, ENC(rs1, rd))               \
-        _(csrrci, 0, ENC(rs1, rd))               \
-    )                                            \
-    /* RV32M Standard Extension */               \
-    IIF(RV32_HAS(EXT_M))(                        \
-        _(mul, 0, ENC(rs1, rs2, rd))             \
-        _(mulh, 0, ENC(rs1, rs2, rd))            \
-        _(mulhsu, 0, ENC(rs1, rs2, rd))          \
-        _(mulhu, 0, ENC(rs1, rs2, rd))           \
-        _(div, 0, ENC(rs1, rs2, rd))             \
-        _(divu, 0, ENC(rs1, rs2, rd))            \
-        _(rem, 0, ENC(rs1, rs2, rd))             \
-        _(remu, 0, ENC(rs1, rs2, rd))            \
-    )                                            \
-    /* RV32A Standard Extension */               \
-    IIF(RV32_HAS(EXT_A))(                        \
-        _(lrw, 0, ENC(rs1, rs2, rd))             \
-        _(scw, 0, ENC(rs1, rs2, rd))             \
-        _(amoswapw, 0, ENC(rs1, rs2, rd))        \
-        _(amoaddw, 0, ENC(rs1, rs2, rd))         \
-        _(amoxorw, 0, ENC(rs1, rs2, rd))         \
-        _(amoandw, 0, ENC(rs1, rs2, rd))         \
-        _(amoorw, 0, ENC(rs1, rs2, rd))          \
-        _(amominw, 0, ENC(rs1, rs2, rd))         \
-        _(amomaxw, 0, ENC(rs1, rs2, rd))         \
-        _(amominuw, 0, ENC(rs1, rs2, rd))        \
-        _(amomaxuw, 0, ENC(rs1, rs2, rd))        \
-    )                                            \
-    /* RV32F Standard Extension */               \
-    IIF(RV32_HAS(EXT_F))(                        \
-        _(flw, 0, ENC(rs1, rd))                  \
-        _(fsw, 0, ENC(rs1, rs2))                 \
-        _(fmadds, 0, ENC(rs1, rs2, rs3, rd))     \
-        _(fmsubs, 0, ENC(rs1, rs2, rs3, rd))     \
-        _(fnmsubs, 0, ENC(rs1, rs2, rs3, rd))    \
-        _(fnmadds, 0, ENC(rs1, rs2, rs3, rd))    \
-        _(fadds, 0, ENC(rs1, rs2, rd))           \
-        _(fsubs, 0, ENC(rs1, rs2, rd))           \
-        _(fmuls, 0, ENC(rs1, rs2, rd))           \
-        _(fdivs, 0, ENC(rs1, rs2, rd))           \
-        _(fsqrts, 0, ENC(rs1, rs2, rd))          \
-        _(fsgnjs, 0, ENC(rs1, rs2, rd))          \
-        _(fsgnjns, 0, ENC(rs1, rs2, rd))         \
-        _(fsgnjxs, 0, ENC(rs1, rs2, rd))         \
-        _(fmins, 0, ENC(rs1, rs2, rd))           \
-        _(fmaxs, 0, ENC(rs1, rs2, rd))           \
-        _(fcvtws, 0, ENC(rs1, rs2, rd))          \
-        _(fcvtwus, 0, ENC(rs1, rs2, rd))         \
-        _(fmvxw, 0, ENC(rs1, rs2, rd))           \
-        _(feqs, 0, ENC(rs1, rs2, rd))            \
-        _(flts, 0, ENC(rs1, rs2, rd))            \
-        _(fles, 0, ENC(rs1, rs2, rd))            \
-        _(fclasss, 0, ENC(rs1, rs2, rd))         \
-        _(fcvtsw, 0, ENC(rs1, rs2, rd))          \
-        _(fcvtswu, 0, ENC(rs1, rs2, rd))         \
-        _(fmvwx, 0, ENC(rs1, rs2, rd))           \
-    )                                            \
-    /* RV32C Standard Extension */               \
-    IIF(RV32_HAS(EXT_C))(                        \
-        _(caddi4spn, 0, ENC(rd))                 \
-        _(clw, 0, ENC(rs1, rd))                  \
-        _(csw, 0, ENC(rs1, rs2))                 \
-        /* cnop is mapped to nop */              \
-        _(caddi, 0, ENC(rd))                     \
-        _(cjal, 1, ENC())                        \
-        _(cli, 0, ENC(rd))                       \
-        _(caddi16sp, 0, ENC())                   \
-        _(clui, 0, ENC(rd))                      \
-        _(csrli, 0, ENC(rs1))                    \
-        _(csrai, 0, ENC(rs1))                    \
-        _(candi, 0, ENC(rs1))                    \
-        _(csub, 0, ENC(rs1, rs2, rd))            \
-        _(cxor, 0, ENC(rs1, rs2, rd))            \
-        _(cor, 0, ENC(rs1, rs2, rd))             \
-        _(cand, 0, ENC(rs1, rs2, rd))            \
-        _(cj, 1, ENC())                          \
-        _(cbeqz, 1, ENC(rs1))                    \
-        _(cbnez, 1, ENC(rs1))                    \
-        _(cslli, 0, ENC(rd))                     \
-        _(clwsp, 0, ENC(rd))                     \
-        _(cjr, 1, ENC(rs1, rs2, rd))             \
-        _(cmv, 0, ENC(rs1, rs2, rd))             \
-        _(cebreak, 1, ENC(rs1, rs2, rd))         \
-        _(cjalr, 1, ENC(rs1, rs2, rd))           \
-        _(cadd, 0, ENC(rs1, rs2, rd))            \
-        _(cswsp, 0, ENC(rs2))                    \
+#define RV_INSN_LIST                                \
+    _(nop, 0, 4, ENC(rs1, rd))                      \
+    /* RV32I Base Instruction Set */                \
+    _(lui, 0, 4, ENC(rd))                           \
+    _(auipc, 0, 4, ENC(rd))                         \
+    _(jal, 1, 4, ENC(rd))                           \
+    _(jalr, 1, 4, ENC(rs1, rd))                     \
+    _(beq, 1, 4, ENC(rs1, rs2))                     \
+    _(bne, 1, 4, ENC(rs1, rs2))                     \
+    _(blt, 1, 4, ENC(rs1, rs2))                     \
+    _(bge, 1, 4, ENC(rs1, rs2))                     \
+    _(bltu, 1, 4, ENC(rs1, rs2))                    \
+    _(bgeu, 1, 4, ENC(rs1, rs2))                    \
+    _(lb, 0, 4, ENC(rs1, rd))                       \
+    _(lh, 0, 4, ENC(rs1, rd))                       \
+    _(lw, 0, 4, ENC(rs1, rd))                       \
+    _(lbu, 0, 4, ENC(rs1, rd))                      \
+    _(lhu, 0, 4, ENC(rs1, rd))                      \
+    _(sb, 0, 4, ENC(rs1, rs2))                      \
+    _(sh, 0, 4, ENC(rs1, rs2))                      \
+    _(sw, 0, 4, ENC(rs1, rs2))                      \
+    _(addi, 0, 4, ENC(rs1, rd))                     \
+    _(slti, 0, 4, ENC(rs1, rd))                     \
+    _(sltiu, 0, 4, ENC(rs1, rd))                    \
+    _(xori, 0, 4, ENC(rs1, rd))                     \
+    _(ori, 0, 4, ENC(rs1, rd))                      \
+    _(andi, 0, 4, ENC(rs1, rd))                     \
+    _(slli, 0, 4, ENC(rs1, rd))                     \
+    _(srli, 0, 4, ENC(rs1, rd))                     \
+    _(srai, 0, 4, ENC(rs1, rd))                     \
+    _(add, 0, 4, ENC(rs1, rs2, rd))                 \
+    _(sub, 0, 4, ENC(rs1, rs2, rd))                 \
+    _(sll, 0, 4, ENC(rs1, rs2, rd))                 \
+    _(slt, 0, 4, ENC(rs1, rs2, rd))                 \
+    _(sltu, 0, 4, ENC(rs1, rs2, rd))                \
+    _(xor, 0, 4, ENC(rs1, rs2, rd))                 \
+    _(srl, 0, 4, ENC(rs1, rs2, rd))                 \
+    _(sra, 0, 4, ENC(rs1, rs2, rd))                 \
+    _(or, 0, 4, ENC(rs1, rs2, rd))                  \
+    _(and, 0, 4, ENC(rs1, rs2, rd))                 \
+    _(ecall, 1, 4, ENC(rs1, rd))                    \
+    _(ebreak, 1, 4, ENC(rs1, rd))                   \
+    /* RISC-V Privileged Instruction */             \
+    _(wfi, 0, 4, ENC(rs1, rd))                      \
+    _(uret, 0, 4, ENC(rs1, rd))                     \
+    _(sret, 0, 4, ENC(rs1, rd))                     \
+    _(hret, 0, 4, ENC(rs1, rd))                     \
+    _(mret, 1, 4, ENC(rs1, rd))                     \
+    /* RV32 Zifencei Standard Extension */          \
+    IIF(RV32_HAS(Zifencei))(                        \
+        _(fencei, 1, 4, ENC(rs1, rd))               \
+    )                                               \
+    /* RV32 Zicsr Standard Extension */             \
+    IIF(RV32_HAS(Zicsr))(                           \
+        _(csrrw, 0, 4, ENC(rs1, rd))                \
+        _(csrrs, 0, 4, ENC(rs1, rd))                \
+        _(csrrc, 0, 4, ENC(rs1, rd))                \
+        _(csrrwi, 0, 4, ENC(rs1, rd))               \
+        _(csrrsi, 0, 4, ENC(rs1, rd))               \
+        _(csrrci, 0, 4, ENC(rs1, rd))               \
+    )                                               \
+    /* RV32M Standard Extension */                  \
+    IIF(RV32_HAS(EXT_M))(                           \
+        _(mul, 0, 4, ENC(rs1, rs2, rd))             \
+        _(mulh, 0, 4, ENC(rs1, rs2, rd))            \
+        _(mulhsu, 0, 4, ENC(rs1, rs2, rd))          \
+        _(mulhu, 0, 4, ENC(rs1, rs2, rd))           \
+        _(div, 0, 4, ENC(rs1, rs2, rd))             \
+        _(divu, 0, 4, ENC(rs1, rs2, rd))            \
+        _(rem, 0, 4, ENC(rs1, rs2, rd))             \
+        _(remu, 0, 4, ENC(rs1, rs2, rd))            \
+    )                                               \
+    /* RV32A Standard Extension */                  \
+    IIF(RV32_HAS(EXT_A))(                           \
+        _(lrw, 0, 4, ENC(rs1, rs2, rd))             \
+        _(scw, 0, 4, ENC(rs1, rs2, rd))             \
+        _(amoswapw, 0, 4, ENC(rs1, rs2, rd))        \
+        _(amoaddw, 0, 4, ENC(rs1, rs2, rd))         \
+        _(amoxorw, 0, 4, ENC(rs1, rs2, rd))         \
+        _(amoandw, 0, 4, ENC(rs1, rs2, rd))         \
+        _(amoorw, 0, 4, ENC(rs1, rs2, rd))          \
+        _(amominw, 0, 4, ENC(rs1, rs2, rd))         \
+        _(amomaxw, 0, 4, ENC(rs1, rs2, rd))         \
+        _(amominuw, 0, 4, ENC(rs1, rs2, rd))        \
+        _(amomaxuw, 0, 4, ENC(rs1, rs2, rd))        \
+    )                                               \
+    /* RV32F Standard Extension */                  \
+    IIF(RV32_HAS(EXT_F))(                           \
+        _(flw, 0, 4, ENC(rs1, rd))                  \
+        _(fsw, 0, 4, ENC(rs1, rs2))                 \
+        _(fmadds, 0, 4, ENC(rs1, rs2, rs3, rd))     \
+        _(fmsubs, 0, 4, ENC(rs1, rs2, rs3, rd))     \
+        _(fnmsubs, 0, 4, ENC(rs1, rs2, rs3, rd))    \
+        _(fnmadds, 0, 4, ENC(rs1, rs2, rs3, rd))    \
+        _(fadds, 0, 4, ENC(rs1, rs2, rd))           \
+        _(fsubs, 0, 4, ENC(rs1, rs2, rd))           \
+        _(fmuls, 0, 4, ENC(rs1, rs2, rd))           \
+        _(fdivs, 0, 4, ENC(rs1, rs2, rd))           \
+        _(fsqrts, 0, 4, ENC(rs1, rs2, rd))          \
+        _(fsgnjs, 0, 4, ENC(rs1, rs2, rd))          \
+        _(fsgnjns, 0, 4, ENC(rs1, rs2, rd))         \
+        _(fsgnjxs, 0, 4, ENC(rs1, rs2, rd))         \
+        _(fmins, 0, 4, ENC(rs1, rs2, rd))           \
+        _(fmaxs, 0, 4, ENC(rs1, rs2, rd))           \
+        _(fcvtws, 0, 4, ENC(rs1, rs2, rd))          \
+        _(fcvtwus, 0, 4, ENC(rs1, rs2, rd))         \
+        _(fmvxw, 0, 4, ENC(rs1, rs2, rd))           \
+        _(feqs, 0, 4, ENC(rs1, rs2, rd))            \
+        _(flts, 0, 4, ENC(rs1, rs2, rd))            \
+        _(fles, 0, 4, ENC(rs1, rs2, rd))            \
+        _(fclasss, 0, 4, ENC(rs1, rs2, rd))         \
+        _(fcvtsw, 0, 4, ENC(rs1, rs2, rd))          \
+        _(fcvtswu, 0, 4, ENC(rs1, rs2, rd))         \
+        _(fmvwx, 0, 4, ENC(rs1, rs2, rd))           \
+    )                                               \
+    /* RV32C Standard Extension */                  \
+    IIF(RV32_HAS(EXT_C))(                           \
+        _(caddi4spn, 0, 2, ENC(rd))                 \
+        _(clw, 0, 2, ENC(rs1, rd))                  \
+        _(csw, 0, 2, ENC(rs1, rs2))                 \
+        /* cnop is mapped to nop */                 \
+        _(caddi, 0, 2, ENC(rd))                     \
+        _(cjal, 1, 2, ENC())                        \
+        _(cli, 0, 2, ENC(rd))                       \
+        _(caddi16sp, 0, 2, ENC())                   \
+        _(clui, 0, 2, ENC(rd))                      \
+        _(csrli, 0, 2, ENC(rs1))                    \
+        _(csrai, 0, 2, ENC(rs1))                    \
+        _(candi, 0, 2, ENC(rs1))                    \
+        _(csub, 0, 2, ENC(rs1, rs2, rd))            \
+        _(cxor, 0, 2, ENC(rs1, rs2, rd))            \
+        _(cor, 0, 2, ENC(rs1, rs2, rd))             \
+        _(cand, 0, 2, ENC(rs1, rs2, rd))            \
+        _(cj, 1, 2, ENC())                          \
+        _(cbeqz, 1, 2, ENC(rs1))                    \
+        _(cbnez, 1, 2, ENC(rs1))                    \
+        _(cslli, 0, 2, ENC(rd))                     \
+        _(clwsp, 0, 2, ENC(rd))                     \
+        _(cjr, 1, 2, ENC(rs1, rs2, rd))             \
+        _(cmv, 0, 2, ENC(rs1, rs2, rd))             \
+        _(cebreak, 1, 2, ENC(rs1, rs2, rd))         \
+        _(cjalr, 1, 2, ENC(rs1, rs2, rd))           \
+        _(cadd, 0, 2, ENC(rs1, rs2, rd))            \
+        _(cswsp, 0, 2, ENC(rs2))                    \
     )
 /* clang-format on */
 
 /* clang-format off */
 /* IR list */
 enum {
-#define _(inst, can_branch, reg_mask) rv_insn_##inst,
+#define _(inst, can_branch, insn_len, reg_mask) rv_insn_##inst,
     RV_INSN_LIST
 #undef _
     N_RV_INSNS
@@ -291,7 +292,7 @@ typedef struct rv_insn {
      * self-recursive version, enabling the compiler to leverage TCO.
      */
     struct rv_insn *next;
-    bool (*impl)(riscv_t *, const struct rv_insn *);
+    bool (*impl)(riscv_t *, const struct rv_insn *, uint64_t, uint32_t);
 
     /* Two pointers, 'branch_taken' and 'branch_untaken', are employed to
      * avoid the overhead associated with aggressive memory copying. Instead

--- a/src/decode.h
+++ b/src/decode.h
@@ -246,11 +246,6 @@ enum {
 };
 /* clang-format on */
 
-enum {
-    INSN_16 = 2,
-    INSN_32 = 4,
-};
-
 typedef struct {
     int32_t imm;
     uint8_t rd, rs1, rs2;
@@ -274,9 +269,6 @@ typedef struct rv_insn {
     opcode_fuse_t *fuse;
 
     uint32_t pc;
-
-    /* instruction length */
-    uint8_t insn_len;
 
     /* Tail-call optimization (TCO) allows a C function to replace a function
      * call to another function or itself, followed by a simple return of the

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -61,7 +61,7 @@ enum {
 
 static void rv_exception_default_handler(riscv_t *rv)
 {
-    rv->csr_mepc += rv->compressed ? INSN_16 : INSN_32;
+    rv->csr_mepc += rv->compressed ? 2 : 4;
     rv->PC = rv->csr_mepc; /* mret */
 }
 
@@ -628,14 +628,14 @@ static void block_translate(riscv_t *rv, block_map_t *map, block_t *block)
 
         /* decode the instruction */
         if (!rv_decode(ir, insn)) {
-            rv->compressed = (ir->insn_len == INSN_16);
+            rv->compressed = is_compressed(insn);
             rv_except_illegal_insn(rv, insn);
             break;
         }
         ir->impl = dispatch_table[ir->opcode];
         ir->pc = block->pc_end;
         /* compute the end of pc */
-        block->pc_end += ir->insn_len;
+        block->pc_end += is_compressed(insn) ? 2 : 4;
         block->n_insn++;
         prev_ir = ir;
         /* stop on branch */

--- a/src/riscv_private.h
+++ b/src/riscv_private.h
@@ -139,3 +139,9 @@ FORCE_INLINE uint32_t sign_extend_b(const uint32_t x)
 {
     return (int32_t) ((int8_t) x);
 }
+
+/* Detect the instruction is RV32C or not */
+FORCE_INLINE bool is_compressed(uint32_t insn)
+{
+    return (insn & FC_OPCODE) != 3;
+}

--- a/src/rv32_constopt.c
+++ b/src/rv32_constopt.c
@@ -33,7 +33,7 @@ CONSTOPT(auipc, {
 CONSTOPT(jal, {
     if (ir->rd) {
         info->is_constant[ir->rd] = true;
-        info->const_val[ir->rd] = ir->pc + ir->insn_len;
+        info->const_val[ir->rd] = ir->pc + 4;
     }
 })
 
@@ -47,7 +47,7 @@ CONSTOPT(jal, {
 CONSTOPT(jalr, {
     if (ir->rd) {
         info->is_constant[ir->rd] = true;
-        info->const_val[ir->rd] = ir->pc + ir->insn_len;
+        info->const_val[ir->rd] = ir->pc + 4;
     }
 })
 
@@ -56,7 +56,7 @@ CONSTOPT(jalr, {
     if (info->is_constant[ir->rs1] && info->is_constant[ir->rs2]) { \
         if ((type) info->const_val[ir->rs1] cond                    \
             (type) info->const_val[ir->rs2])                        \
-            ir->imm = ir->insn_len;                                 \
+            ir->imm = 4;                                            \
         ir->opcode = rv_insn_jal;                                   \
         ir->impl = dispatch_table[ir->opcode];                      \
     }
@@ -737,7 +737,7 @@ CONSTOPT(caddi, {
 /* C.JAL */
 CONSTOPT(cjal, {
     info->is_constant[rv_reg_ra] = true;
-    info->const_val[rv_reg_ra] = ir->pc + ir->insn_len;
+    info->const_val[rv_reg_ra] = ir->pc + 2;
 })
 
 /* C.LI loads the sign-extended 6-bit immediate, imm, into register rd.
@@ -881,7 +881,7 @@ CONSTOPT(cj, {})
 CONSTOPT(cbeqz, {
     if (info->is_constant[ir->rs1]) {
         if (info->const_val[ir->rs1])
-            ir->imm = ir->insn_len;
+            ir->imm = 2;
         ir->opcode = rv_insn_cj;
         ir->impl = dispatch_table[ir->opcode];
     }
@@ -891,7 +891,7 @@ CONSTOPT(cbeqz, {
 CONSTOPT(cbnez, {
     if (info->is_constant[ir->rs1]) {
         if (!info->const_val[ir->rs1])
-            ir->imm = ir->insn_len;
+            ir->imm = 2;
         ir->opcode = rv_insn_cj;
         ir->impl = dispatch_table[ir->opcode];
     }
@@ -933,7 +933,7 @@ CONSTOPT(cebreak, {})
 /* C.JALR */
 CONSTOPT(cjalr, {
     info->is_constant[rv_reg_ra] = true;
-    info->const_val[ir->rd] = ir->pc + ir->insn_len;
+    info->const_val[ir->rd] = ir->pc + 2;
 })
 
 /* C.ADD adds the values in registers rd and rs2 and writes the result to

--- a/src/rv32_constopt.c
+++ b/src/rv32_constopt.c
@@ -717,7 +717,8 @@ CONSTOPT(clw, { info->is_constant[ir->rd] = false; })
  */
 CONSTOPT(csw, {})
 
-/* C.NOP is mapped to NOP */
+/* C.NOP */
+CONSTOPT(cnop, {})
 
 /* C.ADDI adds the non-zero sign-extended 6-bit immediate to the value in
  * register rd then writes the result to rd. C.ADDI expands into

--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -807,7 +807,8 @@ RVOP(csw, {
     rv->io.mem_write_w(addr, rv->X[ir->rs2]);
 })
 
-/* C.NOP is mapped to NOP */
+/* C.NOP */
+RVOP(cnop, {/* no operation */})
 
 /* C.ADDI adds the non-zero sign-extended 6-bit immediate to the value in
  * register rd then writes the result to rd. C.ADDI expands into

--- a/tools/rv_histogram.c
+++ b/tools/rv_histogram.c
@@ -39,8 +39,8 @@ typedef struct {
 } rv_hist_t;
 
 static rv_hist_t rv_insn_stats[] = {
-#define _(inst, can_branch, reg_mask) {#inst, 0, reg_mask},
-    RV_INSN_LIST _(unknown, 0, 0)
+#define _(inst, can_branch, insn_len, reg_mask) {#inst, 0, reg_mask},
+    RV_INSN_LIST _(unknown, 0, 0, 0)
 #undef _
 };
 


### PR DESCRIPTION
To eliminate the overhead of memory operation on frequently used rv
fields and ir fields, we pass csr_cycle and PC as parameter and assigin
insn_len as constant value.

* Before
```
000000000000b1f0 <do_nop>:
    b1f0: addq $0x1,0x1a8(%rdi)
    b1f8: movl $0x0,0x58(%rdi)
    b1ff: movzbl 0x1c(%rsi),%eax
    b203: add %eax,0xd8(%rdi)
    b209: movzbl 0x1d(%rsi),%eax
    b20d: or 0x110(%rdi),%al
    b213: jne b220 <do_nop+0x30>
    b215: mov 0x38(%rsi),%rsi
    b219: jmpq *0x20(%rsi)
    b21c: nopl 0x0(%rax)
    b220: retq
    b221: nopw %cs:0x0(%rax,%rax,1)
    b22c: nopl 0x0(%rax)
```
* After
```
000000000000a6d0 <do_nop>:
    a6d0: movl $0x0,0x58(%rdi)
    a6d7: movzbl 0x1d(%rsi),%eax
    a6db: add $0x1,%rdx
    a6df: add $0x4,%ecx
    a6e2: or 0x110(%rdi),%al
    a6e8: jne a6f8 <do_nop+0x28>
    a6ea: mov 0x38(%rsi),%rsi
    a6ee: jmp *0x20(%rsi)
    a6f1: nopl 0x0(%rax)
    a6f8: mov %rdx,0x1a8(%rdi)
    a6ff: mov %ecx,0xd8(%rdi)
    a705: ret
    a706: cs nopw 0x0(%rax,%rax,1)
```
The operands of two x86 add instructions for csr_cycle, PC and insn_len
are all registers, instead of memory location.

Close: #241