### PR TITLE
Remove unused macro

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -12,7 +12,6 @@
 #include "cache.h"
 #include "mpool.h"
 
-#define MIN(a, b) ((a < b) ? a : b)
 #define GOLDEN_RATIO_32 0x61C88647
 #define HASH(val) \
     (((val) * (GOLDEN_RATIO_32)) >> (32 - (cache_size_bits))) & (cache_size - 1)


### PR DESCRIPTION
The 'MIN' macro is no longer used anywhere in the codebase. This PR removes the unused macro to improve code clarity.