### PR TITLE
Unify the hash function of cache and map

### DIFF
--- a/src/riscv.c
+++ b/src/riscv.c
@@ -11,7 +11,6 @@
 #include "riscv_private.h"
 #include "state.h"
 
-#define BLOCK_MAP_CAPACITY_BITS 10
 #define BLOCK_IR_MAP_CAPACITY_BITS 10
 
 /* initialize the block map */

--- a/src/riscv.h
+++ b/src/riscv.h
@@ -79,6 +79,8 @@ enum {
 #define MSTATUS_MPIE (1 << MSTATUS_MPIE_SHIFT)
 #define MSTATUS_MPP (3 << MSTATUS_MPP_SHIFT)
 
+#define BLOCK_MAP_CAPACITY_BITS 10
+
 /* forward declaration for internal structure */
 typedef struct riscv_internal riscv_t;
 typedef void *riscv_user_t;

--- a/src/utils.h
+++ b/src/utils.h
@@ -10,3 +10,14 @@ void rv_gettimeofday(struct timeval *tv);
 
 /* Retrieve the value used by a clock which is specified by clock_id. */
 void rv_clock_gettime(struct timespec *tp);
+
+/* This hashing routine is adapted from Linux kernel.
+ * See
+ * https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/include/linux/hash.h
+ */
+#define HASH_FUNC_IMPL(name, size_bits, size)                        \
+    FORCE_INLINE uint32_t name(uint32_t val)                         \
+    {                                                                \
+        /* 0x61C88647 is 32-bit golden ratio */                      \
+        return (val * 0x61C88647 >> (32 - size_bits)) & ((size) -1); \
+    }


### PR DESCRIPTION
Based on the below performance analysis, the golden ratio hash is a little bit better than map hash. Therefore, we unify the hash function to golden ratio hash.

|Metric    | map hash |	golden ratio hash |
|----------|----------|-------------------|
|Dhrystone |	2.06 s|            2.07 s |
|Nqueens   |	4.35 s|	           4.25 s |
|Stream	   |    76.7 s|  	  75.59 s |

Close: #149 