### PR TITLE
Fix rb_remove() key comparison

### DIFF
--- a/src/map.c
+++ b/src/map.c
@@ -221,7 +221,7 @@ static void rb_remove(map_t rb, map_node_t *node)
     pathp = path;
     while (pathp->node) {
         map_cmp_t cmp = pathp->cmp =
-            (rb->comparator)(node->data, pathp->node->data);
+            (rb->comparator)(node->key, pathp->node->key);
         if (cmp == _CMP_LESS) {
             pathp[1].node = rb_node_get_left(pathp->node);
         } else {

--- a/tests/map/test-map.c
+++ b/tests/map/test-map.c
@@ -29,7 +29,7 @@ static int test_map_mixed_operations()
      */
     for (int i = 0; i < N_NODES; i++) {
         key[i] = i;
-        val[i] = i + 1;
+        val[i] = mt19937_extract();
     }
 
     for (int i = 0; i < N_NODES; i++) {


### PR DESCRIPTION
The origin code was erroneously comparing ```node->data``` when searching
for the node to remove, instead of using the ```node->key```. This PR
corrects the comparison to use the ```node->key```, ensuring the proper
removal of nodes. Also, to ensure that the map functions do not rely on
node data values when comparing and performing operations, this PR
modifies the unit tests for map. It replaces the sequential data values
with random values obtained from ```mt19937_extract()```.

Close: #168 