### PR TITLE
Enable link-time optimization by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,28 @@ CFLAGS += -D DEFAULT_STACK_ADDR=0xFFFFE000
 # Set the default args starting address
 CFLAGS += -D DEFAULT_ARGS_ADDR=0xFFFFF000
 
+# Enable link-time optimization (LTO)
+ENABLE_LTO ?= 1
+ifeq ($(call has, LTO), 1)
+ifeq ("$(CC_IS_CLANG)$(CC_IS_GCC)",)
+$(warning LTO is only supported in clang and gcc.)
+override ENABLE_LTO := 0
+endif
+endif
+$(call set-feature, LTO)
+ifeq ($(call has, LTO), 1)
+ifeq ("$(CC_IS_GCC)", "1")
+CFLAGS += -flto
+endif
+ifeq ("$(CC_IS_CLANG)", "1")
+CFLAGS += -flto=thin -fsplit-lto-unit
+LDFLAGS += -flto=thin
+endif
+endif
+
+# Disable Intel's Control-flow Enforcement Technology (CET)
+CFLAGS += $(CFLAGS_NO_CET)
+
 OBJS_EXT :=
 
 # Control and Status Register (CSR)
@@ -90,7 +112,7 @@ endif
 
 # For tail-call elimination, we need a specific set of build flags applied.
 # FIXME: On macOS + Apple Silicon, -fno-stack-protector might have a negative impact.
-$(OUT)/emulate.o: CFLAGS += $(CFLAGS_NO_CET) -foptimize-sibling-calls -fomit-frame-pointer -fno-stack-check -fno-stack-protector
+$(OUT)/emulate.o: CFLAGS += -foptimize-sibling-calls -fomit-frame-pointer -fno-stack-check -fno-stack-protector
 
 # Clear the .DEFAULT_GOAL special variable, so that the following turns
 # to the first target after .DEFAULT_GOAL is not set.


### PR DESCRIPTION
Compilers have the ability to transform our code and reorganize instructions, as long as the program retains the same observable behavior. This becomes particularly relevant with the growing adoption of optimization techniques like Link-Time Optimization (LTO).

This commit enables LTO by default to leverage the advantages of compiler optimizations.