### PR TITLE
Attempt to resolve `Assertion failed: (total_read == rv_get_reg(rv, rv_reg_a2))`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ OUT ?= build
 BIN := $(OUT)/rv32emu
 
 CFLAGS = -std=gnu99 -O2 -Wall -Wextra
-CFLAGS += -Wno-unused-label
+CFLAGS += -Wno-unused-label -g
 CFLAGS += -include src/common.h
 
 # Set the default stack pointer


### PR DESCRIPTION
At the outset, I attempted to replicate the issue reported by qwe661234. However, on my PC, everything appeared normal without any errors. To further investigate, I utilized GDB by specifying the build/rv32emu and setting a breakpoint at src/syscall.c:290. My goal was to observe the values of 'total_read' and 'rv_get_reg (rv, rv_reg_a2)' to ascertain whether any discrepancy in these values might have been the root cause of qwe661234's issue. Upon analysis, I discovered that 'total_read' was equal to 0xC, and 'rv_get_reg(rv, rv_reg_a2)' was also 0xC. Consequently, in the assertion 'assert(total_read == rv_get_reg(rv, rv_reg_a2));', the program didn't halt. [The link](https://hackmd.io/ucXfO5ixSTePjNX_KFR_Vg#Assertion-failed-total_read--rv_get_regrv-rv_reg_a2-function-syscall_read-214) is my debug report.

See #214