### PR TITLE
Fix NULL pointer dereference in remove_next_nth_ir()

### DIFF
--- a/src/emulate.c
+++ b/src/emulate.c
@@ -729,6 +729,10 @@ static inline void remove_next_nth_ir(const riscv_t *rv,
 {
     for (uint8_t i = 0; i < n; i++) {
         rv_insn_t *next = ir->next;
+        if (!next) {
+            n = i;
+            break;
+        }
         ir->next = ir->next->next;
         mpool_free(rv->block_ir_mp, next);
     }

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -138,7 +138,7 @@ RV_EXCEPTION_LIST
         return false;                                                 \
     }
 
-/* get current time in microsecnds and update csr_time register */
+/* get current time in microseconds and update csr_time register */
 static inline void update_time(riscv_t *rv)
 {
     struct timeval tv;


### PR DESCRIPTION
During the execution of Doom in rv32emu, a null pointer dereference issue was observed. After a thorough investigation, it was determined that this problem was introduced by the commit [ac05003](https://github.com/sysprog21/rv32emu/commit/ac050039e10637fe702300cd8790106fdde8051a), which added the 'remove_next_nth_ir()' function. The issue arose when attempting to remove more ir than were actually present in the linked list. To address this, we now check for the existence of the next ir in the loop. If there is no next ir, we terminate the loop early. This change ensures that we do not attempt to remove non-existent ir.