### PR TITLE
Improves scripts and add docker image 

### DIFF
--- a/.ci/check-format.sh
+++ b/.ci/check-format.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e -u -o pipefail
+
 SOURCES=$(find $(git rev-parse --show-toplevel) | egrep "\.(c|cxx|cpp|h|hpp)\$")
 
 set -x

--- a/.ci/check-newline.sh
+++ b/.ci/check-newline.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e -u -o pipefail
+
 ret=0
 show=0
 # Reference: https://medium.com/@alexey.inkin/how-to-force-newline-at-end-of-files-and-why-you-should-do-it-fdf76d1d090e

--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -3,11 +3,11 @@ check_platform()
 {
     MACHINE_TYPE=`uname -m`
     if [ ${MACHINE_TYPE} != 'x86_64' ]; then
-        exit
+        exit 1
     fi
 
     OS_TYPE=`uname -s`
     if [ ${OS_TYPE} != 'Linux' ]; then
-        exit
+        exit 1
     fi
 }

--- a/.ci/gdbstub-test.sh
+++ b/.ci/gdbstub-test.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e -u -o pipefail
+
 export PATH=`pwd`/toolchain/riscv/bin:$PATH
 
 GDB=

--- a/.ci/gdbstub-test.sh
+++ b/.ci/gdbstub-test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e -u -o pipefail
+# set -e -u -o pipefail
 
 export PATH=`pwd`/toolchain/riscv/bin:$PATH
 

--- a/.ci/riscv-tests.sh
+++ b/.ci/riscv-tests.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e -u -o pipefail
+
 # Install RISCOF
 python3 -m pip install git+https://github.com/riscv/riscof
 

--- a/.ci/riscv-toolchain-install.sh
+++ b/.ci/riscv-toolchain-install.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e -u -o pipefail
+
 . .ci/common.sh
 
 check_platform

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ quakesw-1.0.6.zip*
 build/id1/
 build/gfx.wad
 build/doomrc
+toolchain/
 
 # built objects
 build/.config

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+FROM ubuntu:22.04
+LABEL maintainer="henrybear327@gmail.com"
+
+# Install packages required for the emulator to compile and execute correctly
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    libsdl2-dev libsdl2-mixer-dev python3-pip git 
+
+RUN python3 -m pip install git+https://github.com/riscv/riscof 
+
+# set up the timezone
+ENV TZ=Asia/Taipei
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# when using apt install gcc-riscv64-unknown-elf, this will cause "unsupported ISA subset 'z'" during compilation
+# thus, we are building from scratch, following the version here -> https://github.com/sysprog21/rv32emu/blob/master/.ci/riscv-toolchain-install.sh
+# for x86, we can optimize this part and take the nightly build directly, but not for aarch64 
+ENV RISCV=/opt/riscv
+ENV PATH=$RISCV/bin:$PATH
+WORKDIR $RISCV
+RUN apt install -y autoconf automake autotools-dev curl libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev
+RUN git clone --recursive https://github.com/riscv/riscv-gnu-toolchain
+RUN cd riscv-gnu-toolchain && \
+    git checkout tags/2023.10.06 && \
+    ./configure --prefix=/opt/riscv --with-arch=rv32gc --with-abi=ilp32d && \
+    make -j$(nproc) && \
+    make clean
+
+# the default reference emulator is x86-based
+# we need to build it ourselves if we are using it on aarch64
+# https://riscof.readthedocs.io/en/stable/installation.html#install-plugin-models
+# the above commands are modified to match the current build flow as indicated in the Github CI -> https://github.com/riscv/sail-riscv/blob/master/.github/workflows/compile.yml
+WORKDIR /home/root/
+RUN apt install -y opam zlib1g-dev pkg-config libgmp-dev z3 device-tree-compiler
+RUN opam init --disable-sandboxing -y
+RUN opam install -y sail
+RUN git clone https://github.com/riscv/sail-riscv.git
+# based on this commit https://github.com/sysprog21/rv32emu/commit/01b00b6f175f57ef39ffd1f4fa6a611891e36df3#diff-3b436c5e32c40ecca4095bdacc1fb69c0759096f86e029238ce34bbe73c6e68f
+# we infer that the sail-riscv binary was taken from commit 9547a30bf84572c458476591b569a95f5232c1c7
+RUN cd sail-riscv && \
+    git checkout 9547a30bf84572c458476591b569a95f5232c1c7 && \
+    eval $(opam env) && \
+    make && \
+    ARCH=RV32 make 
+
+# copy in the source code
+WORKDIR /home/root/rv32emu
+COPY . .
+
+# replace the emulator (riscv_sim_RV32) with the arch that the container can execute 
+RUN rm /home/root/rv32emu/tests/arch-test-target/sail_cSim/riscv_sim_RV32
+RUN cp /home/root/sail-riscv/c_emulator/riscv_sim_RV32 /home/root/rv32emu/tests/arch-test-target/sail_cSim/riscv_sim_RV32
+
+# clean up apt cache
+RUN rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ $ make quake
 
 The usage and limitations of Doom and Quake demo are listed in [docs/demo.md](docs/demo.md).
 
+### Docker image
+
+The image containing all the necessary tools for development and testing can be built by executing `docker build -t rv32emu .`. 
+
+This image works for both x86 and aarch64 (Apple's M1 chip) machines. Note that the image building time will be long since it will perform builds of the toolchain and the reference emulator from source. Also, it will take up about 16GB of disk space.
+
+After the image is built, you can create a docker container by executing `docker run -it rv32emu` at the project root. This will give you can interactive bash shell where you can experiment with the current codebase.
+
 ### Customization
 
 `rv32emu` is configurable, and you can override the below variable(s) to fit your expectations:


### PR DESCRIPTION
This commit adds a docker image that provides the pre-configured environment, which is capable of executing the rv32emu tests, to the users. It can also reduce hassles when working on the M1 machines for development. 

Figuring out the `dockerfile` actually took longer than expected, and here are the 2 main issues (there are also copious of comments in the `dockerfile`):
- The `gcc-riscv64-unknown-elf` compiler installed from `apt` will cause `make arch-test` to fail with error `unsupported ISA subset 'z'`, thus, we build from scratch using the version [here].(ttps://github.com/sysprog21/rv32emu/blob/master/.ci/riscv-toolchain-install.sh).
- The reference emulator in the repo is of x86 architecture, so for the aarch64 (M1 machine), we need to build from `sail-riscv` source. Interestingly, it's a [known issue](https://github.com/riscv/sail-riscv/issues/333#issuecomment-1800172163) that the recent commits will fail to compile. But in any case, for this dockerfile, I am using the commit from `sail-riscv` which is around the time that the commit of the reference emulator happened on [rv32emu](https://github.com/sysprog21/rv32emu), which has no problem building and completing tests.

Reference:
- https://github.com/sysprog21/rv32emu/pull/40