### PR TITLE
Remove unused 'isnanf' and 'isinff' functions

### DIFF
--- a/src/emulate.c
+++ b/src/emulate.c
@@ -13,17 +13,6 @@
 #if RV32_HAS(EXT_F)
 #include <math.h>
 #include "softfloat.h"
-
-#if defined(__APPLE__)
-static inline int isinff(float x)
-{
-    return __builtin_fabsf(x) == __builtin_inff();
-}
-static inline int isnanf(float x)
-{
-    return x != x;
-}
-#endif
 #endif /* RV32_HAS(EXT_F) */
 
 #if RV32_HAS(GDBSTUB)


### PR DESCRIPTION
The introduction of SoftFloat for F extension implementation renders 'isnanf' and 'isinff' functions unnecessary. These functions were causing compilation warnings due to being unused.

The commit addresses the following warnings:
```
src/emulate.c:18:19: warning: unused function 'isinff' [-Wunused-function] static inline int isinff(float x)
^
src/emulate.c:22:19: warning: unused function 'isnanf' [-Wunused-function] static inline int isnanf(float x)
^
2 warnings generated.
```

This removal eliminates the redundant functions, ensuring a cleaner codebase and resolving the compilation warnings.

Close: #87 