### PR TITLE
Enable exit-on-error setting to gdbstub-test.sh

### DIFF
--- a/.ci/gdbstub-test.sh
+++ b/.ci/gdbstub-test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# set -e -u -o pipefail
+set -e -u -o pipefail
 
 export PATH=`pwd`/toolchain/riscv/bin:$PATH
 
@@ -8,10 +8,12 @@ GDB=
 prefixes=("${CROSS_COMPILE}" "riscv32-unknown-elf" "riscv-none-elf")
 for prefix in "${prefixes[@]}"; do
     utility=${prefix}-gdb
+    set +e # temporarily disable exit on error
     command -v "${utility}" &> /dev/null
     if [[ $? == 0 ]]; then
         GDB=${utility}
     fi
+    set -e
 done
 
 # Check if GDB is available


### PR DESCRIPTION
Temporarily disable the exit-on-error setting as `command -v "${utility}" &> /dev/null` will set the error code for the subsequent if condition to check.