### PR TITLE
Fix softfloat build failure

### DIFF
--- a/src/riscv.h
+++ b/src/riscv.h
@@ -7,7 +7,15 @@
 #include <stdbool.h>
 #include <stdint.h>
 #if RV32_HAS(EXT_F)
+#define float16_t softfloat_float16_t
+#define bfloat16_t softfloat_bfloat16_t
+#define float32_t softfloat_float32_t
+#define float64_t softfloat_float64_t
 #include "softfloat/softfloat.h"
+#undef float16_t
+#undef bfloat16_t
+#undef float32_t
+#undef float64_t
 #endif
 
 #ifdef __cplusplus
@@ -93,7 +101,7 @@ typedef uint16_t riscv_half_t;
 typedef uint8_t riscv_byte_t;
 typedef uint32_t riscv_exception_t;
 #if RV32_HAS(EXT_F)
-typedef float32_t riscv_float_t;
+typedef softfloat_float32_t riscv_float_t;
 #endif
 
 /* memory read handlers */

--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -627,7 +627,7 @@ RVOP(fmadds, {
 /* FMSUB.S */
 RVOP(fmsubs, {
     set_rounding_mode(rv);
-    float32_t tmp = rv->F[ir->rs3];
+    riscv_float_t tmp = rv->F[ir->rs3];
     tmp.v ^= FMASK_SIGN;
     rv->F[ir->rd] = f32_mulAdd(rv->F[ir->rs1], rv->F[ir->rs2], tmp);
     set_fflag(rv);
@@ -636,7 +636,7 @@ RVOP(fmsubs, {
 /* FNMSUB.S */
 RVOP(fnmsubs, {
     set_rounding_mode(rv);
-    float32_t tmp = rv->F[ir->rs1];
+    riscv_float_t tmp = rv->F[ir->rs1];
     tmp.v ^= FMASK_SIGN;
     rv->F[ir->rd] = f32_mulAdd(tmp, rv->F[ir->rs2], rv->F[ir->rs3]);
     set_fflag(rv);
@@ -645,8 +645,8 @@ RVOP(fnmsubs, {
 /* FNMADD.S */
 RVOP(fnmadds, {
     set_rounding_mode(rv);
-    float32_t tmp1 = rv->F[ir->rs1];
-    float32_t tmp2 = rv->F[ir->rs3];
+    riscv_float_t tmp1 = rv->F[ir->rs1];
+    riscv_float_t tmp2 = rv->F[ir->rs3];
     tmp1.v ^= FMASK_SIGN;
     tmp2.v ^= FMASK_SIGN;
     rv->F[ir->rd] = f32_mulAdd(tmp1, rv->F[ir->rs2], tmp2);


### PR DESCRIPTION
Addressed compilation errors on macOS/Arm64 arising from conflicts between SoftFloat and SDL headers. The solution involves explicitly defining the conflicting types in SoftFloat to avoid clashes.

Close: #261 