### PR TITLE
Apply branch prediction for indirect jump

### DIFF
--- a/src/decode.h
+++ b/src/decode.h
@@ -252,6 +252,12 @@ typedef struct {
     uint8_t opcode;
 } opcode_fuse_t;
 
+#define HISTORY_SIZE 16
+typedef struct {
+    uint32_t PC;
+    struct rv_insn *branch_target;
+} branch_history_entry_t;
+
 typedef struct rv_insn {
     union {
         int32_t imm;
@@ -294,7 +300,8 @@ typedef struct rv_insn {
      * specific IR array without the need for additional copying.
      */
     struct rv_insn *branch_taken, *branch_untaken;
-
+    uint8_t branch_table_count;
+    branch_history_entry_t *branch_table;
 } rv_insn_t;
 
 /* decode the RISC-V instruction */

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -34,6 +34,7 @@ void block_map_clear(riscv_t *rv)
         for (idx = 0, ir = block->ir_head; idx < block->n_insn;
              idx++, ir = next) {
             free(ir->fuse);
+            free(ir->branch_table);
             next = ir->next;
             mpool_free(rv->block_ir_mp, ir);
         }


### PR DESCRIPTION
Previously, it was necessary to perform a block cache lookup at the end of an indirect jump emulation; however, the associated overhead of this operation proved to be substantial. To mitigate this overhead, we have introduced a branch history table that captures the historical data of indirect jump targets. Given the limited number of entries in the branch history table, the lookup overhead is significantly reduced.

As shown in the performance analysis provided below, the branch history table has demonstrably enhanced the overall performance.

|  Metric   |   original   |   proposed   |
|-----------|--------------|--------------|
| Dhrystone | 2932.3 DMIPS | 2985.2 DMIPS |
| CoreMark  | 2231 iter/s  | 2236 iter/s  |
| Stream    | 76.04 sec    | 75.299 sec   |
| Nqueens   | 4.069 sec    | 3.933 sec    |

See: #268 