### PR TITLE
Implement file path sanitation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ build/mini-gdbstub
 build/softfloat
 build/cache/
 build/map/
+build/path/
 *.o
 *.o.d
 tests/**/*.elf

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -6,12 +6,19 @@ MAP_TEST_SRCDIR := tests/map
 MAP_TEST_OUTDIR:= build/map
 MAP_TEST_TARGET := $(MAP_TEST_OUTDIR)/test-map
 
+PATH_TEST_SRCDIR := tests/path
+PATH_TEST_OUTDIR := build/path
+PATH_TEST_TARGET := $(PATH_TEST_OUTDIR)/test-path
+
 CACHE_TEST_OBJS := \
 	test-cache.o
 
 MAP_TEST_OBJS := \
 	test-map.o \
 	mt19937.o
+
+PATH_TEST_OBJS := \
+	test-path.o 
 
 CACHE_TEST_OBJS := $(addprefix $(CACHE_TEST_OUTDIR)/, $(CACHE_TEST_OBJS)) \
 		   $(OUT)/cache.o $(OUT)/mpool.o
@@ -22,6 +29,11 @@ MAP_TEST_OBJS := $(addprefix $(MAP_TEST_OUTDIR)/, $(MAP_TEST_OBJS)) \
 		 $(OUT)/map.o
 OBJS += $(MAP_TEST_OBJS)
 deps += $(MAP_TEST_OBJS:%.o=%.o.d)
+
+PATH_TEST_OBJS := $(addprefix $(PATH_TEST_OUTDIR)/, $(PATH_TEST_OBJS)) \
+		   $(OUT)/utils.o 
+OBJS += $(PATH_TEST_OBJS)
+deps += $(PATH_TEST_OBJS:%.o=%.o.d)
 
 # Check adaptive replacement cache policy is enabled or not, default is LFU
 ifeq ($(ENABLE_ARC), 1)
@@ -43,8 +55,9 @@ endif
 
 CACHE_TEST_OUT = $(addprefix $(CACHE_TEST_OUTDIR)/, $(CACHE_TEST_ACTIONS:%=%.out))
 MAP_TEST_OUT = $(MAP_TEST_TARGET).out
+PATH_TEST_OUT = $(PATH_TEST_TARGET).out
 
-tests : run-test-cache run-test-map
+tests : run-test-cache run-test-map run-test-path
 
 run-test-cache: $(CACHE_TEST_OUT)
 	$(Q)$(foreach e,$(CACHE_TEST_ACTIONS),\
@@ -60,6 +73,15 @@ run-test-cache: $(CACHE_TEST_OUT)
 run-test-map: $(MAP_TEST_OUT)
 	$(Q)$(MAP_TEST_TARGET)
 	$(VECHO) "Running test-map ... "; \
+	if [ $$? -eq 0 ]; then \
+	$(call notice, [OK]); \
+	else \
+	$(PRINTF) "Failed.\n"; \
+	fi;
+
+run-test-path: $(PATH_TEST_OUT)
+	$(Q)$(PATH_TEST_TARGET)
+	$(VECHO) "Running test-path ... "; \
 	if [ $$? -eq 0 ]; then \
 	$(call notice, [OK]); \
 	else \
@@ -88,6 +110,18 @@ $(MAP_TEST_TARGET): $(MAP_TEST_OBJS)
 	$(Q)$(CC) $^ -o $@
 
 $(MAP_TEST_OUTDIR)/%.o: $(MAP_TEST_SRCDIR)/%.c
+	$(VECHO) "  CC\t$@\n"
+	$(Q)mkdir -p $(dir $@)
+	$(Q)$(CC) -o $@ $(CFLAGS) -I./src -c -MMD -MF $@.d $<
+
+$(PATH_TEST_OUT): $(PATH_TEST_TARGET)
+	$(Q)touch $@
+
+$(PATH_TEST_TARGET): $(PATH_TEST_OBJS)
+	$(VECHO) "  CC\t$@\n"
+	$(Q)$(CC) $^ -o $@
+
+$(PATH_TEST_OUTDIR)/%.o: $(PATH_TEST_SRCDIR)/%.c
 	$(VECHO) "  CC\t$@\n"
 	$(Q)mkdir -p $(dir $@)
 	$(Q)$(CC) -o $@ $(CFLAGS) -I./src -c -MMD -MF $@.d $<

--- a/mk/tools.mk
+++ b/mk/tools.mk
@@ -7,6 +7,7 @@ HIST_OBJS := \
 	elf.o \
 	decode.o \
 	mpool.o \
+	utils.o \
 	rv_histogram.o
 
 HIST_OBJS := $(addprefix $(OUT)/, $(HIST_OBJS))

--- a/src/main.c
+++ b/src/main.c
@@ -10,6 +10,7 @@
 
 #include "elf.h"
 #include "state.h"
+#include "utils.h"
 
 /* enable program trace mode */
 static bool opt_trace = false;

--- a/src/utils.h
+++ b/src/utils.h
@@ -21,3 +21,29 @@ void rv_clock_gettime(struct timespec *tp);
         /* 0x61C88647 is 32-bit golden ratio */                         \
         return (val * 0x61C88647 >> (32 - size_bits)) & ((size) - (1)); \
     }
+
+/*
+ * Reference:
+ * https://cs.opensource.google/go/go/+/refs/tags/go1.21.4:src/path/path.go;l=51
+ *
+ * sanitize_path returns the shortest path name equivalent to path
+ * by purely lexical processing. It applies the following rules
+ * iteratively until no further processing can be done:
+ *
+ *  1. Replace multiple slashes with a single slash.
+ *  2. Eliminate each . path name element (the current directory).
+ *  3. Eliminate each inner .. path name element (the parent directory)
+ *     along with the non-.. element that precedes it.
+ *  4. Eliminate .. elements that begin a rooted path:
+ *     that is, replace "/.." by "/" at the beginning of a path.
+ *
+ * The returned path ends in a slash only if it is the root "/".
+ *
+ * If the result of this process is an empty string, Clean
+ * returns the string ".".
+ *
+ * See also Rob Pike, “Lexical File Names in Plan 9 or
+ * Getting Dot-Dot Right,”
+ * https://9p.io/sys/doc/lexnames.html
+ */
+char *sanitize_path(const char *input);

--- a/tests/path/test-path.c
+++ b/tests/path/test-path.c
@@ -1,0 +1,79 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "utils.h"
+
+void compare(char *input, char *expected_output)
+{
+    char *input_sanitized = sanitize_path(input);
+    if (!input_sanitized) {
+        exit(1);
+    }
+
+    if (strcmp(input_sanitized, expected_output)) {
+        printf("\n\nInput =\t\t\t%s\nOutput =\t\t%s\nExpected output =\t%s\n",
+               input, input_sanitized, expected_output);
+
+        exit(1);
+    }
+
+    free(input_sanitized);
+}
+
+void sanitize_path_test()
+{
+    /* Already clean */
+    compare("", ".");
+    compare("abc", "abc");
+    compare("abc/def", "abc/def");
+    compare(".", ".");
+    compare("..", "..");
+    compare("../..", "../..");
+    compare("../../abc", "../../abc");
+    compare("/abc", "/abc");
+    compare("/", "/");
+
+    /* Remove trailing slash */
+    compare("abc/", "abc");
+    compare("abc/def/", "abc/def");
+    compare("a/b/c/", "a/b/c");
+    compare("./", ".");
+    compare("../", "..");
+    compare("../../", "../..");
+    compare("/abc/", "/abc");
+
+    /* Remove doubled slash */
+    compare("abc//def//ghi", "abc/def/ghi");
+    compare("//abc", "/abc");
+    compare("///abc", "/abc");
+    compare("//abc//", "/abc");
+    compare("abc//", "abc");
+
+    /* Remove . elements */
+    compare("abc/./def", "abc/def");
+    compare("/./abc/def", "/abc/def");
+    compare("abc/.", "abc");
+
+    /* Remove .. elements */
+    compare("abc/def/ghi/../jkl", "abc/def/jkl");
+    compare("abc/def/../ghi/../jkl", "abc/jkl");
+    compare("abc/def/..", "abc");
+    compare("abc/def/../..", ".");
+    compare("/abc/def/../..", "/");
+    compare("abc/def/../../..", "..");
+    compare("/abc/def/../../..", "/");
+    compare("abc/def/../../../ghi/jkl/../../../mno", "../../mno");
+
+    /* Combinations */
+    compare("abc/./../def", "def");
+    compare("abc//./../def", "def");
+    compare("abc/../../././../def", "../../def");
+}
+
+int main()
+{
+    sanitize_path_test();
+
+    return 0;
+}


### PR DESCRIPTION
As mentioned in issue #137, the elf path is not sanitized before opening, which might be a security risk. This PR addresses this issue by porting the path sanitation logic from Golang to C.

Reference code: https://cs.opensource.google/go/go/+/refs/tags/go1.21.4:src/path/path.go;l=70

Unit test -> https://github.com/sysprog21/rv32emu/pull/274