### PR TITLE
CI: Build executable files during Docker image generation

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,6 +24,9 @@ jobs:
               mk/**
               tests/**
               tools/**
+              docker/**
+              Dockerfile
+              Makefile
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,3 +27,8 @@ COPY --from=base_gcc /opt/riscv/ /opt/riscv/
 # replace the emulator (riscv_sim_RV32) with the arch that the container can execute 
 RUN rm /home/root/rv32emu/tests/arch-test-target/sail_cSim/riscv_sim_RV32
 COPY --from=base_sail /home/root/riscv_sim_RV32 /home/root/rv32emu/tests/arch-test-target/sail_cSim/riscv_sim_RV32
+
+# generate execution file for rv32emu and rv_histogram
+RUN make
+RUN make tool
+ENV PATH=/home/root/rv32emu/build:$PATH


### PR DESCRIPTION
Generate both `rv32emu` and `rv_histogram` execution files, and place then in the `$PATH`.