### PR TITLE
Fix cache_free fucntion

### DIFF
--- a/src/cache.h
+++ b/src/cache.h
@@ -37,4 +37,4 @@ void *cache_put(struct cache *cache, uint32_t key, void *value);
  * @cache: a pointer points to target cache
  * @callback: a function for freeing cache entry completely
  */
-void cache_free(struct cache *cache, void (*callback)(void *));
+void cache_free(struct cache *cache);

--- a/tests/cache/test-cache.c
+++ b/tests/cache/test-cache.c
@@ -62,7 +62,7 @@ int main(int argc, char *argv[])
             assert(cache);
             printf("NEW CACHE\n");
         } else if (!strcmp(arr[0], "FREE\n")) {
-            cache_free(cache, free);
+            cache_free(cache);
             printf("FREE CACHE\n");
         }
     }


### PR DESCRIPTION
After we introduced the memory pool for blocks and IRs, we don't need to free the memory of blocks and IRs by cache.