### PR TITLE
Enable build rv32emu using Emscripten

### DIFF
--- a/mk/toolchain.mk
+++ b/mk/toolchain.mk
@@ -1,6 +1,9 @@
 CC_IS_CLANG :=
 CC_IS_GCC :=
-ifneq ($(shell $(CC) --version | head -n 1 | grep clang),)
+CC_IS_EMCC :=
+ifneq ($(shell $(CC) --version | head -n 1 | grep emcc),)
+    CC_IS_EMCC := 1
+else ifneq ($(shell $(CC) --version | head -n 1 | grep clang),)
     CC_IS_CLANG := 1
 else
     ifneq ($(shell $(CC) --version | grep "Free Software Foundation"),)


### PR DESCRIPTION
- Tail-call and link-time optimization can be enabled during the build
- SoftFloat archive object file needs to be built using appropriate $(CC) and $(AR) in order to make linking phase of rv32emu successful

The output of `fcalc.elf`(running in Chrome) is error-free, indicating that linking with the compiled softfloat archive object is OK.
```
Performed 12 tests, 0 failures, 100% success rate.
inferior exit code 0
```

Afterwards, rv32emu's core can be used as the backend of the simulator (see #75)