### PR TITLE
CI: Specify safe.directory for Arm64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,11 +47,15 @@ jobs:
       with:
         arch: aarch64
         distro: ubuntu22.04
+        # No 'sudo' is available
         install: |
           apt-get update -q -y
           apt-get install -q -y git build-essential libsdl2-dev libsdl2-mixer-dev
+          git config --global --add safe.directory ${{ github.workspace }}
+          git config --global --add safe.directory ${{ github.workspace }}/src/softfloat
+          git config --global --add safe.directory ${{ github.workspace }}/src/mini-gdbstub
+        # Append custom commands here
         run: |
-          git config --global --add safe.directory /home/runner/work/rv32emu/rv32emu
           make
           make check
 


### PR DESCRIPTION
Beginning with version 2.35.3 of Git, it is now possible to turn off safe directory checks. This change eliminates the "unsafe repository" error messages. The update resolves unintentional errors that occurred while using git in an emulated Arm64 environment.

It appears that this update is connected to a vulnerability announced: https://github.blog/2022-04-12-git-security-vulnerability-announced/