### PR TITLE
Fix incorrect mcycle csr address

### DIFF
--- a/src/riscv_private.h
+++ b/src/riscv_private.h
@@ -40,7 +40,7 @@ enum {
     CSR_MIP = 0x344,      /* Machine interrupt pending */
 
     /* low words */
-    CSR_CYCLE = 0xC00, /* Cycle counter for RDCYCLE instruction */
+    CSR_CYCLE = 0xB00, /* Cycle counter for RDCYCLE instruction */
     CSR_TIME = 0xC01,  /* Timer for RDTIME instruction */
     CSR_INSTRET = 0xC02,
 


### PR DESCRIPTION
According to [RISC-V Specifications](https://riscv.org/technical/specifications/) Volume 2, Privileged Specification, the correct CSR address for the mcycle is 0xB00.