### PR TITLE
Fix signed integer overflow in RV32IM

### DIFF
--- a/src/rv32_constopt.c
+++ b/src/rv32_constopt.c
@@ -408,8 +408,9 @@ CONSTOPT(csrrci, { info->is_constant[ir->rd] = false; })
 CONSTOPT(mul, {
     if (info->is_constant[ir->rs1] && info->is_constant[ir->rs2]) {
         info->is_constant[ir->rd] = true;
-        ir->imm = (int32_t) info->const_val[ir->rs1] *
-                  (int32_t) info->const_val[ir->rs2];
+        const int64_t multiplicand = (int32_t) info->const_val[ir->rs1];
+        const int64_t multiplier = (int32_t) info->const_val[ir->rs2];
+        ir->imm = ((uint64_t) (multiplicand * multiplier)) & ((1ULL << 32) - 1);
         info->const_val[ir->rd] = ir->imm;
         ir->opcode = rv_insn_lui;
         ir->impl = dispatch_table[ir->opcode];

--- a/src/rv32_constopt.c
+++ b/src/rv32_constopt.c
@@ -233,8 +233,7 @@ CONSTOPT(srai, {
 CONSTOPT(add, {
     if (info->is_constant[ir->rs1] && info->is_constant[ir->rs2]) {
         info->is_constant[ir->rd] = true;
-        ir->imm = (int32_t) info->const_val[ir->rs1] +
-                  (int32_t) info->const_val[ir->rs2];
+        ir->imm = info->const_val[ir->rs1] + info->const_val[ir->rs2];
         info->const_val[ir->rd] = ir->imm;
         ir->opcode = rv_insn_lui;
         ir->impl = dispatch_table[ir->opcode];
@@ -246,8 +245,7 @@ CONSTOPT(add, {
 CONSTOPT(sub, {
     if (info->is_constant[ir->rs1] && info->is_constant[ir->rs2]) {
         info->is_constant[ir->rd] = true;
-        ir->imm = (int32_t) info->const_val[ir->rs1] -
-                  (int32_t) info->const_val[ir->rs2];
+        ir->imm = info->const_val[ir->rs1] - info->const_val[ir->rs2];
         info->const_val[ir->rd] = ir->imm;
         ir->opcode = rv_insn_lui;
         ir->impl = dispatch_table[ir->opcode];

--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -603,7 +603,7 @@ RVOP(
  */
 RVOP(
     addi,
-    { rv->X[ir->rd] = (int32_t) (rv->X[ir->rs1]) + ir->imm; },
+    { rv->X[ir->rd] = rv->X[ir->rs1] + ir->imm; },
     GEN({
         ld, S32, TMP0, X, rs1;
         alu32_imm, 32, 0x81, 0, TMP0, imm;
@@ -732,9 +732,7 @@ RVOP(
 /* ADD */
 RVOP(
     add,
-    {
-        rv->X[ir->rd] = (int32_t) (rv->X[ir->rs1]) + (int32_t) (rv->X[ir->rs2]);
-    },
+    { rv->X[ir->rd] = rv->X[ir->rs1] + rv->X[ir->rs2]; },
     GEN({
         ld, S32, TMP0, X, rs1;
         ld, S32, TMP1, X, rs2;
@@ -745,9 +743,7 @@ RVOP(
 /* SUB: Substract */
 RVOP(
     sub,
-    {
-        rv->X[ir->rd] = (int32_t) (rv->X[ir->rs1]) - (int32_t) (rv->X[ir->rs2]);
-    },
+    { rv->X[ir->rd] = rv->X[ir->rs1] - rv->X[ir->rs2]; },
     GEN({
         ld, S32, TMP0, X, rs1;
         ld, S32, TMP1, X, rs2;

--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -1047,7 +1047,12 @@ RVOP(
 /* MUL: Multiply */
 RVOP(
     mul,
-    { rv->X[ir->rd] = (int32_t) rv->X[ir->rs1] * (int32_t) rv->X[ir->rs2]; },
+    {
+        const int64_t multiplicand = (int32_t) rv->X[ir->rs1];
+        const int64_t multiplier = (int32_t) rv->X[ir->rs2];
+        rv->X[ir->rd] =
+            ((uint64_t) (multiplicand * multiplier)) & ((1ULL << 32) - 1);
+    },
     GEN({
         ld, S32, TMP0, X, rs1;
         ld, S32, TMP1, X, rs2;


### PR DESCRIPTION
UBSAN has identified several signed integer overflow issues in the RV32IM implementation, including incorrect type conversions to int32_t for add/sub operations and a lack of prevention for overflow in multiplication.

Address these issues by ensuring proper type handling and preventing integer overflow in the RV32IM implementation.