### PR TITLE
Fix cmv constant optimization bug

### DIFF
--- a/src/rv32_constopt.c
+++ b/src/rv32_constopt.c
@@ -946,6 +946,8 @@ CONSTOPT(cmv, {
         info->const_val[ir->rd] = ir->imm;
         ir->opcode = rv_insn_clui;
         ir->impl = dispatch_table[ir->opcode];
+    } else {
+        info->is_constant[ir->rd] = false;
     }
 })
 


### PR DESCRIPTION
Missing to set `info->is_constant[ir->rd]` to false when C.MV does not enter the optimization block.