### PR TITLE
Add dockerfile that contains the development environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,11 @@ The usage and limitations of Doom and Quake demo are listed in [docs/demo.md](do
 
 ### Docker image
 
-The image containing all the necessary tools for development and testing can be executed by `docker run -it sysprog21/rv32emu:latest`. It works for both x86-64 and aarch64 (Apple's M1 chip) machines.
+The image containing the `rv32emu` binary can be run by executing `docker run -it sysprog21/rv32emu:latest`. 
+
+The image containing all the necessary development toolchains can be built by `docker build -t rv32emu-dev -f docker/Dockerfile-dev .`.
+
+It works for both x86-64 and aarch64 (Apple's M1 chip) machines.
 
 ### Customization
 

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -1,0 +1,47 @@
+FROM sysprog21/rv32emu-gcc as base_gcc
+FROM sysprog21/rv32emu-sail as base_sail
+
+FROM ubuntu:22.04 as final
+
+# https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user#_creating-a-nonroot-user
+# add a non-root user
+ARG USERNAME=sysprog21
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Create the user
+RUN groupadd --gid $USER_GID $USERNAME && \
+    useradd --uid $USER_UID --gid $USER_GID -m $USERNAME && \
+    # Add sudo support
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y sudo && \
+    echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME && \
+    chmod 0440 /etc/sudoers.d/$USERNAME && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set the default user
+USER $USERNAME
+
+# Install extra packages for the emulator to compile and execute with full capabilities correctly
+RUN sudo apt-get update && \
+    DEBIAN_FRONTEND=noninteractive sudo apt-get install -y \
+    python3-pip git clang && \
+    sudo rm -rf /var/lib/apt/lists/*
+
+RUN sudo python3 -m pip install git+https://github.com/riscv/riscof 
+
+# copy in the source code
+WORKDIR /home/$USERNAME/rv32emu
+COPY --chown=$USERNAME:$USERNAME . .
+
+# Copy the GNU Toolchain files
+ENV RISCV=/opt/riscv
+ENV PATH=$RISCV/bin:$PATH
+COPY --chown=$USERNAME:$USERNAME --from=base_gcc /opt/riscv/ /opt/riscv/
+
+# replace the emulator (riscv_sim_RV32) with the arch that the container can execute 
+RUN rm /home/$USERNAME/rv32emu/tests/arch-test-target/sail_cSim/riscv_sim_RV32
+COPY --chown=$USERNAME:$USERNAME --from=base_sail /home/root/riscv_sim_RV32 /home/$USERNAME/rv32emu/tests/arch-test-target/sail_cSim/riscv_sim_RV32
+
+# Set the default directory
+WORKDIR /home/$USERNAME


### PR DESCRIPTION
We currently have a demo image that contains the `rv32emu` binary. 

This PR introduces a new rv32emu development image containing all the toolchains required in the docker directory, providing contributors with an easier way to get on board. 