### PR TITLE
Add specialized instruction to rv32emu

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -449,10 +449,10 @@ static inline bool op_op_imm(rv_insn_t *ir, const uint32_t insn)
 
     /* decode I-type */
     decode_itype(ir, insn);
-    int a0,a1,a2;
-    a0 = ir->rd;
-    a1 = ir->rs1;
-    a2 = ir->imm;
+    int rd,rs1,imm;
+    rd = ir->rd;
+    rs1 = ir->rs1;
+    imm = ir->imm;
     /* nop can be implemented as "addi x0, x0, 0".
      * Any integer computational instruction writing into "x0" is NOP.
      */
@@ -465,24 +465,24 @@ static inline bool op_op_imm(rv_insn_t *ir, const uint32_t insn)
     switch (decode_funct3(insn)) {
     case 0: /* ADDI: Add Immediate */
         ir->opcode = rv_insn_addi;
-        if(a0==10 && a1==10){ir->opcode = rv_insn_addi010010;}
-        else if(a0==10 && a1==2){ir->opcode = rv_insn_addi01002;}
-        else if(a0==11 && a1==10){ir->opcode = rv_insn_addi011010;}
-        else if(a0==11 && a1==11){ir->opcode = rv_insn_addi011011;}
-        else if(a0==11 && a1==2){ir->opcode = rv_insn_addi01102;}
-        else if(a0==14 && a1==11){ir->opcode = rv_insn_addi014011;}
-        else if(a0==19 && a1==19){ir->opcode = rv_insn_addi019019;}
-        else if(a0==2 && a1==2){ir->opcode = rv_insn_addi0202;}
-        else if(a0==12 && a1==12){ir->opcode = rv_insn_addi012012;}
-        else if(a0==13 && a1==13){ir->opcode = rv_insn_addi013013;}
-        else if(a0==13 && a1==8){ir->opcode = rv_insn_addi01308;}
-        else if(a0==14 && a1==14){ir->opcode = rv_insn_addi014014;}
-        else if(a0==15 && a1==15){ir->opcode = rv_insn_addi015015;}
-        else if(a0==8 && a1==14){ir->opcode = rv_insn_addi08014;}
-        else if(a2==0){ir->opcode = rv_insn_mv;}
-        else if(a1==0){ir->opcode = rv_insn_li;}
-        else if(a0==a1 && a2==1){ir->opcode = rv_insn_inc;}
-        else if(a0==a1 && a2==-1){ir->opcode = rv_insn_dec;}
+        if(rd==10 && rs1==10){ir->opcode = rv_insn_addi010010;}
+        else if(rd==10 && rs1==2){ir->opcode = rv_insn_addi01002;}
+        else if(rd==11 && rs1==10){ir->opcode = rv_insn_addi011010;}
+        else if(rd==11 && rs1==11){ir->opcode = rv_insn_addi011011;}
+        else if(rd==11 && rs1==2){ir->opcode = rv_insn_addi01102;}
+        else if(rd==14 && rs1==11){ir->opcode = rv_insn_addi014011;}
+        else if(rd==19 && rs1==19){ir->opcode = rv_insn_addi019019;}
+        else if(rd==2 && rs1==2){ir->opcode = rv_insn_addi0202;}
+        else if(rd==12 && rs1==12){ir->opcode = rv_insn_addi012012;}
+        else if(rd==13 && rs1==13){ir->opcode = rv_insn_addi013013;}
+        else if(rd==13 && rs1==8){ir->opcode = rv_insn_addi01308;}
+        else if(rd==14 && rs1==14){ir->opcode = rv_insn_addi014014;}
+        else if(rd==15 && rs1==15){ir->opcode = rv_insn_addi015015;}
+        else if(rd==8 && rs1==14){ir->opcode = rv_insn_addi08014;}
+        else if(imm==0){ir->opcode = rv_insn_mv;}
+        else if(rs1==0){ir->opcode = rv_insn_li;}
+        else if(rd==rs1 && imm==1){ir->opcode = rv_insn_inc;}
+        else if(rd==rs1 && imm==-1){ir->opcode = rv_insn_dec;}
         break;
     case 1: /* SLLI: Shift Left Logical */
         ir->opcode = rv_insn_slli;

--- a/src/decode.c
+++ b/src/decode.c
@@ -465,11 +465,18 @@ static inline bool op_op_imm(rv_insn_t *ir, const uint32_t insn)
     switch (decode_funct3(insn)) {
     case 0: /* ADDI: Add Immediate */
         ir->opcode = rv_insn_addi;
-        if(a0==12 && a1==12){ir->opcode = rv_insn_addi012012;}
+        if(a0==10 && a1==10){ir->opcode = rv_insn_addi010010;}
+        else if(a0==10 && a1==2){ir->opcode = rv_insn_addi01002;}
+        else if(a0==11 && a1==10){ir->opcode = rv_insn_addi011010;}
+        else if(a0==11 && a1==11){ir->opcode = rv_insn_addi011011;}
+        else if(a0==11 && a1==2){ir->opcode = rv_insn_addi01102;}
+        else if(a0==14 && a1==11){ir->opcode = rv_insn_addi014011;}
+        else if(a0==19 && a1==19){ir->opcode = rv_insn_addi019019;}
+        else if(a0==2 && a1==2){ir->opcode = rv_insn_addi0202;}
+        else if(a0==12 && a1==12){ir->opcode = rv_insn_addi012012;}
         else if(a0==13 && a1==13){ir->opcode = rv_insn_addi013013;}
         else if(a0==13 && a1==8){ir->opcode = rv_insn_addi01308;}
         else if(a0==14 && a1==14){ir->opcode = rv_insn_addi014014;}
-        else if(a0==15 && a1==12){ir->opcode = rv_insn_addi015012;}
         else if(a0==15 && a1==15){ir->opcode = rv_insn_addi015015;}
         else if(a0==8 && a1==14){ir->opcode = rv_insn_addi08014;}
         else if(a2==0){ir->opcode = rv_insn_mv;}
@@ -735,28 +742,14 @@ static inline bool op_branch(rv_insn_t *ir, const uint32_t insn)
 
     /* decode B-type */
     decode_btype(ir, insn);
-    int a1,a2;
-    a1 = ir->rs1;
-    a2 = ir->rs2;
 
     /* dispatch from funct3 field */
     switch (decode_funct3(insn)) {
     case 0: /* BEQ: Branch if Equal */
         ir->opcode = rv_insn_beq;
-        if(a1==14 && a2==0){ir->opcode = rv_insn_beq01400;}
-        else if(a1==14 && a2==10){ir->opcode = rv_insn_beq014010;}
-        else if(a1==14 && a2==13){ir->opcode = rv_insn_beq014013;}
-        else if(a1==15 && a2==0){ir->opcode = rv_insn_beq01500;}
-        else if(a1==15 && a2==14){ir->opcode = rv_insn_beq015014;}
-        else if(a1==8 && a2==0){ir->opcode = rv_insn_beq0800;}
         break;
     case 1: /* BNE: Branch if Not Equal */
-        ir->opcode = rv_insn_bne;
-        if(a1==14 && a2==0){ir->opcode = rv_insn_bne01400;}
-        else if(a1==14 && a2==13){ir->opcode = rv_insn_bne014013;}
-        else if(a1==14 && a2==23){ir->opcode = rv_insn_bne014023;}
-        else if(a1==15 && a2==13){ir->opcode = rv_insn_bne015013;}
-        else if(a1==25 && a2==14){ir->opcode = rv_insn_bne025014;}  
+        ir->opcode = rv_insn_bne;  
         break;
     case 4: /* BLT: Branch if Less Than */
         ir->opcode = rv_insn_blt;

--- a/src/decode.c
+++ b/src/decode.c
@@ -449,10 +449,10 @@ static inline bool op_op_imm(rv_insn_t *ir, const uint32_t insn)
 
     /* decode I-type */
     decode_itype(ir, insn);
-    int rd,rs1,imm;
-    rd = ir->rd;
-    rs1 = ir->rs1;
-    imm = ir->imm;
+    int a0,a1,a2;
+    a0 = ir->rd;
+    a1 = ir->rs1;
+    a2 = ir->imm;
     /* nop can be implemented as "addi x0, x0, 0".
      * Any integer computational instruction writing into "x0" is NOP.
      */
@@ -465,24 +465,24 @@ static inline bool op_op_imm(rv_insn_t *ir, const uint32_t insn)
     switch (decode_funct3(insn)) {
     case 0: /* ADDI: Add Immediate */
         ir->opcode = rv_insn_addi;
-        if(rd==10 && rs1==10){ir->opcode = rv_insn_addi010010;}
-        else if(rd==10 && rs1==2){ir->opcode = rv_insn_addi01002;}
-        else if(rd==11 && rs1==10){ir->opcode = rv_insn_addi011010;}
-        else if(rd==11 && rs1==11){ir->opcode = rv_insn_addi011011;}
-        else if(rd==11 && rs1==2){ir->opcode = rv_insn_addi01102;}
-        else if(rd==14 && rs1==11){ir->opcode = rv_insn_addi014011;}
-        else if(rd==19 && rs1==19){ir->opcode = rv_insn_addi019019;}
-        else if(rd==2 && rs1==2){ir->opcode = rv_insn_addi0202;}
-        else if(rd==12 && rs1==12){ir->opcode = rv_insn_addi012012;}
-        else if(rd==13 && rs1==13){ir->opcode = rv_insn_addi013013;}
-        else if(rd==13 && rs1==8){ir->opcode = rv_insn_addi01308;}
-        else if(rd==14 && rs1==14){ir->opcode = rv_insn_addi014014;}
-        else if(rd==15 && rs1==15){ir->opcode = rv_insn_addi015015;}
-        else if(rd==8 && rs1==14){ir->opcode = rv_insn_addi08014;}
-        else if(imm==0){ir->opcode = rv_insn_mv;}
-        else if(rs1==0){ir->opcode = rv_insn_li;}
-        else if(rd==rs1 && imm==1){ir->opcode = rv_insn_inc;}
-        else if(rd==rs1 && imm==-1){ir->opcode = rv_insn_dec;}
+        if(a0==10 && a1==10){ir->opcode = rv_insn_addi010010;}
+        else if(a0==10 && a1==2){ir->opcode = rv_insn_addi01002;}
+        else if(a0==11 && a1==10){ir->opcode = rv_insn_addi011010;}
+        else if(a0==11 && a1==11){ir->opcode = rv_insn_addi011011;}
+        else if(a0==11 && a1==2){ir->opcode = rv_insn_addi01102;}
+        else if(a0==14 && a1==11){ir->opcode = rv_insn_addi014011;}
+        else if(a0==19 && a1==19){ir->opcode = rv_insn_addi019019;}
+        else if(a0==2 && a1==2){ir->opcode = rv_insn_addi0202;}
+        else if(a0==12 && a1==12){ir->opcode = rv_insn_addi012012;}
+        else if(a0==13 && a1==13){ir->opcode = rv_insn_addi013013;}
+        else if(a0==13 && a1==8){ir->opcode = rv_insn_addi01308;}
+        else if(a0==14 && a1==14){ir->opcode = rv_insn_addi014014;}
+        else if(a0==15 && a1==15){ir->opcode = rv_insn_addi015015;}
+        else if(a0==8 && a1==14){ir->opcode = rv_insn_addi08014;}
+        else if(a2==0){ir->opcode = rv_insn_mv;}
+        else if(a1==0){ir->opcode = rv_insn_li;}
+        else if(a0==a1 && a2==1){ir->opcode = rv_insn_inc;}
+        else if(a0==a1 && a2==-1){ir->opcode = rv_insn_dec;}
         break;
     case 1: /* SLLI: Shift Left Logical */
         ir->opcode = rv_insn_slli;

--- a/src/decode.c
+++ b/src/decode.c
@@ -449,7 +449,10 @@ static inline bool op_op_imm(rv_insn_t *ir, const uint32_t insn)
 
     /* decode I-type */
     decode_itype(ir, insn);
-
+    int a0,a1,a2;
+    a0 = ir->rd;
+    a1 = ir->rs1;
+    a2 = ir->imm;
     /* nop can be implemented as "addi x0, x0, 0".
      * Any integer computational instruction writing into "x0" is NOP.
      */
@@ -462,6 +465,17 @@ static inline bool op_op_imm(rv_insn_t *ir, const uint32_t insn)
     switch (decode_funct3(insn)) {
     case 0: /* ADDI: Add Immediate */
         ir->opcode = rv_insn_addi;
+        if(a0==12 && a1==12){ir->opcode = rv_insn_addi012012;}
+        else if(a0==13 && a1==13){ir->opcode = rv_insn_addi013013;}
+        else if(a0==13 && a1==8){ir->opcode = rv_insn_addi01308;}
+        else if(a0==14 && a1==14){ir->opcode = rv_insn_addi014014;}
+        else if(a0==15 && a1==12){ir->opcode = rv_insn_addi015012;}
+        else if(a0==15 && a1==15){ir->opcode = rv_insn_addi015015;}
+        else if(a0==8 && a1==14){ir->opcode = rv_insn_addi08014;}
+        else if(a2==0){ir->opcode = rv_insn_mv;}
+        else if(a1==0){ir->opcode = rv_insn_li;}
+        else if(a0==a1 && a2==1){ir->opcode = rv_insn_inc;}
+        else if(a0==a1 && a2==-1){ir->opcode = rv_insn_dec;}
         break;
     case 1: /* SLLI: Shift Left Logical */
         ir->opcode = rv_insn_slli;
@@ -721,14 +735,28 @@ static inline bool op_branch(rv_insn_t *ir, const uint32_t insn)
 
     /* decode B-type */
     decode_btype(ir, insn);
+    int a1,a2;
+    a1 = ir->rs1;
+    a2 = ir->rs2;
 
     /* dispatch from funct3 field */
     switch (decode_funct3(insn)) {
     case 0: /* BEQ: Branch if Equal */
         ir->opcode = rv_insn_beq;
+        if(a1==14 && a2==0){ir->opcode = rv_insn_beq01400;}
+        else if(a1==14 && a2==10){ir->opcode = rv_insn_beq014010;}
+        else if(a1==14 && a2==13){ir->opcode = rv_insn_beq014013;}
+        else if(a1==15 && a2==0){ir->opcode = rv_insn_beq01500;}
+        else if(a1==15 && a2==14){ir->opcode = rv_insn_beq015014;}
+        else if(a1==8 && a2==0){ir->opcode = rv_insn_beq0800;}
         break;
     case 1: /* BNE: Branch if Not Equal */
         ir->opcode = rv_insn_bne;
+        if(a1==14 && a2==0){ir->opcode = rv_insn_bne01400;}
+        else if(a1==14 && a2==13){ir->opcode = rv_insn_bne014013;}
+        else if(a1==14 && a2==23){ir->opcode = rv_insn_bne014023;}
+        else if(a1==15 && a2==13){ir->opcode = rv_insn_bne015013;}
+        else if(a1==25 && a2==14){ir->opcode = rv_insn_bne025014;}  
         break;
     case 4: /* BLT: Branch if Less Than */
         ir->opcode = rv_insn_blt;

--- a/src/decode.h
+++ b/src/decode.h
@@ -81,28 +81,24 @@ enum op_field {
     _(hret, 0, 4, 0, ENC(rs1, rd))                     \
     _(mret, 1, 4, 0, ENC(rs1, rd))                     \
     /* RISC-V Specialized Instruction */                \
+    _(addi010010, 0, 4, 1, ENC(rs1, rd))                     \
+    _(addi01002, 0, 4, 1, ENC(rs1, rd))                     \
+    _(addi011010, 0, 4, 1, ENC(rs1, rd))                     \
+    _(addi011011, 0, 4, 1, ENC(rs1, rd))                     \
+    _(addi01102, 0, 4, 1, ENC(rs1, rd))                     \
+    _(addi014011, 0, 4, 1, ENC(rs1, rd))                     \
+    _(addi019019, 0, 4, 1, ENC(rs1, rd))                     \
+    _(addi0202, 0, 4, 1, ENC(rs1, rd))                     \
     _(addi012012, 0, 4, 1, ENC(rs1, rd))                     \
     _(addi013013, 0, 4, 1, ENC(rs1, rd))                     \
     _(addi01308, 0, 4, 1, ENC(rs1, rd))                     \
     _(addi014014, 0, 4, 1, ENC(rs1, rd))                     \
-    _(addi015012, 0, 4, 1, ENC(rs1, rd))                     \
     _(addi015015, 0, 4, 1, ENC(rs1, rd))                     \
     _(addi08014, 0, 4, 1, ENC(rs1, rd))                     \
     _(mv, 0, 4, 1, ENC(rs1, rd))                     \
     _(li, 0, 4, 1, ENC(rs1, rd))                     \
     _(inc, 0, 4, 1, ENC(rs1, rd))                     \
     _(dec, 0, 4, 1, ENC(rs1, rd))                     \
-    _(beq01400, 1, 4, 1, ENC(rs1, rs2))                     \
-    _(beq014010, 1, 4, 1, ENC(rs1, rs2))                     \
-    _(beq014013, 1, 4, 1, ENC(rs1, rs2))                     \
-    _(beq01500, 1, 4, 1, ENC(rs1, rs2))                     \
-    _(beq015014, 1, 4, 1, ENC(rs1, rs2))                     \
-    _(beq0800, 1, 4, 1, ENC(rs1, rs2))                     \
-    _(bne01400, 1, 4, 1, ENC(rs1, rs2))                     \
-    _(bne014013, 1, 4, 1, ENC(rs1, rs2))                     \
-    _(bne014023, 1, 4, 1, ENC(rs1, rs2))                     \
-    _(bne015013, 1, 4, 1, ENC(rs1, rs2))                     \
-    _(bne025014, 1, 4, 1, ENC(rs1, rs2))                     \
     /* RV32 Zifencei Standard Extension */             \
     IIF(RV32_HAS(Zifencei))(                           \
         _(fencei, 1, 4, 0, ENC(rs1, rd))               \

--- a/src/decode.h
+++ b/src/decode.h
@@ -80,6 +80,29 @@ enum op_field {
     _(sret, 0, 4, 0, ENC(rs1, rd))                     \
     _(hret, 0, 4, 0, ENC(rs1, rd))                     \
     _(mret, 1, 4, 0, ENC(rs1, rd))                     \
+    /* RISC-V Specialized Instruction */                \
+    _(addi012012, 0, 4, 1, ENC(rs1, rd))                     \
+    _(addi013013, 0, 4, 1, ENC(rs1, rd))                     \
+    _(addi01308, 0, 4, 1, ENC(rs1, rd))                     \
+    _(addi014014, 0, 4, 1, ENC(rs1, rd))                     \
+    _(addi015012, 0, 4, 1, ENC(rs1, rd))                     \
+    _(addi015015, 0, 4, 1, ENC(rs1, rd))                     \
+    _(addi08014, 0, 4, 1, ENC(rs1, rd))                     \
+    _(mv, 0, 4, 1, ENC(rs1, rd))                     \
+    _(li, 0, 4, 1, ENC(rs1, rd))                     \
+    _(inc, 0, 4, 1, ENC(rs1, rd))                     \
+    _(dec, 0, 4, 1, ENC(rs1, rd))                     \
+    _(beq01400, 1, 4, 1, ENC(rs1, rs2))                     \
+    _(beq014010, 1, 4, 1, ENC(rs1, rs2))                     \
+    _(beq014013, 1, 4, 1, ENC(rs1, rs2))                     \
+    _(beq01500, 1, 4, 1, ENC(rs1, rs2))                     \
+    _(beq015014, 1, 4, 1, ENC(rs1, rs2))                     \
+    _(beq0800, 1, 4, 1, ENC(rs1, rs2))                     \
+    _(bne01400, 1, 4, 1, ENC(rs1, rs2))                     \
+    _(bne014013, 1, 4, 1, ENC(rs1, rs2))                     \
+    _(bne014023, 1, 4, 1, ENC(rs1, rs2))                     \
+    _(bne015013, 1, 4, 1, ENC(rs1, rs2))                     \
+    _(bne025014, 1, 4, 1, ENC(rs1, rs2))                     \
     /* RV32 Zifencei Standard Extension */             \
     IIF(RV32_HAS(Zifencei))(                           \
         _(fencei, 1, 4, 0, ENC(rs1, rd))               \

--- a/src/rv32_constopt.c
+++ b/src/rv32_constopt.c
@@ -60,13 +60,36 @@ CONSTOPT(jalr, {
         ir->opcode = rv_insn_jal;                                   \
         ir->impl = dispatch_table[ir->opcode];                      \
     }
+
+#define OPT_BRANCH_FUNC_SPEC(type, cond, rs1, rs2)                                 \
+    if (info->is_constant[rs1] && info->is_constant[rs2]) { \
+        if ((type) info->const_val[rs1] cond                    \
+            (type) info->const_val[rs2])                        \
+            ir->imm = 4;                                            \
+        ir->opcode = rv_insn_jal;                                   \
+        ir->impl = dispatch_table[ir->opcode];                      \
+    }
+
 /* clang-format on */
 
 /* BEQ: Branch if Equal */
 CONSTOPT(beq, { OPT_BRANCH_FUNC(uint32_t, !=); })
 
+CONSTOPT(beq01400, { OPT_BRANCH_FUNC_SPEC(uint32_t, !=, 14, 0); })
+CONSTOPT(beq014010, { OPT_BRANCH_FUNC_SPEC(uint32_t, !=, 14, 10); })
+CONSTOPT(beq014013, { OPT_BRANCH_FUNC_SPEC(uint32_t, !=, 14, 13); })
+CONSTOPT(beq01500, { OPT_BRANCH_FUNC_SPEC(uint32_t, !=, 15, 0); })
+CONSTOPT(beq015014, { OPT_BRANCH_FUNC_SPEC(uint32_t, !=, 15, 14); })
+CONSTOPT(beq0800, { OPT_BRANCH_FUNC_SPEC(uint32_t, !=, 8, 0); })
+
 /* BNE: Branch if Not Equal */
 CONSTOPT(bne, { OPT_BRANCH_FUNC(uint32_t, ==); })
+
+CONSTOPT(bne01400, { OPT_BRANCH_FUNC_SPEC(uint32_t, ==, 14, 0); })
+CONSTOPT(bne014013, { OPT_BRANCH_FUNC_SPEC(uint32_t, ==, 14, 13); })
+CONSTOPT(bne014023, { OPT_BRANCH_FUNC_SPEC(uint32_t, ==, 14, 23); })
+CONSTOPT(bne015013, { OPT_BRANCH_FUNC_SPEC(uint32_t, ==, 15, 13); })
+CONSTOPT(bne025014, { OPT_BRANCH_FUNC_SPEC(uint32_t, ==, 25, 14); })
 
 /* BLT: Branch if Less Than */
 CONSTOPT(blt, { OPT_BRANCH_FUNC(int32_t, >=); })
@@ -119,6 +142,18 @@ CONSTOPT(addi, {
     } else
         info->is_constant[ir->rd] = false;
 })
+
+CONSTOPT(addi012012, {if (info->is_constant[12]) {ir->imm += info->const_val[12];info->is_constant[12] = true;info->const_val[12] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[12] = false;}	})
+CONSTOPT(addi013013, {if (info->is_constant[13]) {ir->imm += info->const_val[13];info->is_constant[13] = true;info->const_val[13] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[13] = false;}	})
+CONSTOPT(addi01308, {if (info->is_constant[8]) {ir->imm += info->const_val[8];info->is_constant[13] = true;info->const_val[13] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[13] = false;}	})
+CONSTOPT(addi014014, {if (info->is_constant[14]) {ir->imm += info->const_val[14];info->is_constant[14] = true;info->const_val[14] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[14] = false;}	})
+CONSTOPT(addi015012, {if (info->is_constant[12]) {ir->imm += info->const_val[12];info->is_constant[15] = true;info->const_val[15] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[15] = false;}	})
+CONSTOPT(addi015015, {if (info->is_constant[15]) {ir->imm += info->const_val[15];info->is_constant[15] = true;info->const_val[15] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[15] = false;}	})
+CONSTOPT(addi08014, {if (info->is_constant[14]) {ir->imm += info->const_val[14];info->is_constant[8] = true;info->const_val[8] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[8] = false;}	})
+CONSTOPT(mv, {if (info->is_constant[ir->rs1]) {ir->imm += info->const_val[ir->rs1];info->is_constant[ir->rd] = true;info->const_val[ir->rd] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[ir->rd] = false;}})
+CONSTOPT(li, {if (info->is_constant[ir->rs1]) {ir->imm += info->const_val[ir->rs1];info->is_constant[ir->rd] = true;info->const_val[ir->rd] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[ir->rd] = false;}})
+CONSTOPT(inc, {if (info->is_constant[ir->rs1]) {ir->imm += info->const_val[ir->rs1];info->is_constant[ir->rd] = true;info->const_val[ir->rd] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[ir->rd] = false;}})
+CONSTOPT(dec, {if (info->is_constant[ir->rs1]) {ir->imm += info->const_val[ir->rs1];info->is_constant[ir->rd] = true;info->const_val[ir->rd] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[ir->rd] = false;}})
 
 /* SLTI place the value 1 in register rd if register rs1 is less than the
  * signextended immediate when both are treated as signed numbers, else 0 is

--- a/src/rv32_constopt.c
+++ b/src/rv32_constopt.c
@@ -129,7 +129,6 @@ CONSTOPT(addi01102, {if (info->is_constant[2]) {ir->imm += info->const_val[2];in
 CONSTOPT(addi014011, {if (info->is_constant[11]) {ir->imm += info->const_val[11];info->is_constant[14] = true;info->const_val[14] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[14] = false;}	})
 CONSTOPT(addi019019, {if (info->is_constant[19]) {ir->imm += info->const_val[19];info->is_constant[19] = true;info->const_val[19] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[19] = false;}	})
 CONSTOPT(addi0202, {if (info->is_constant[2]) {ir->imm += info->const_val[2];info->is_constant[2] = true;info->const_val[2] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[2] = false;}	})
-
 CONSTOPT(addi012012, {if (info->is_constant[12]) {ir->imm += info->const_val[12];info->is_constant[12] = true;info->const_val[12] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[12] = false;}	})
 CONSTOPT(addi013013, {if (info->is_constant[13]) {ir->imm += info->const_val[13];info->is_constant[13] = true;info->const_val[13] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[13] = false;}	})
 CONSTOPT(addi01308, {if (info->is_constant[8]) {ir->imm += info->const_val[8];info->is_constant[13] = true;info->const_val[13] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[13] = false;}	})

--- a/src/rv32_constopt.c
+++ b/src/rv32_constopt.c
@@ -129,6 +129,7 @@ CONSTOPT(addi01102, {if (info->is_constant[2]) {ir->imm += info->const_val[2];in
 CONSTOPT(addi014011, {if (info->is_constant[11]) {ir->imm += info->const_val[11];info->is_constant[14] = true;info->const_val[14] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[14] = false;}	})
 CONSTOPT(addi019019, {if (info->is_constant[19]) {ir->imm += info->const_val[19];info->is_constant[19] = true;info->const_val[19] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[19] = false;}	})
 CONSTOPT(addi0202, {if (info->is_constant[2]) {ir->imm += info->const_val[2];info->is_constant[2] = true;info->const_val[2] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[2] = false;}	})
+
 CONSTOPT(addi012012, {if (info->is_constant[12]) {ir->imm += info->const_val[12];info->is_constant[12] = true;info->const_val[12] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[12] = false;}	})
 CONSTOPT(addi013013, {if (info->is_constant[13]) {ir->imm += info->const_val[13];info->is_constant[13] = true;info->const_val[13] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[13] = false;}	})
 CONSTOPT(addi01308, {if (info->is_constant[8]) {ir->imm += info->const_val[8];info->is_constant[13] = true;info->const_val[13] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[13] = false;}	})

--- a/src/rv32_constopt.c
+++ b/src/rv32_constopt.c
@@ -61,35 +61,13 @@ CONSTOPT(jalr, {
         ir->impl = dispatch_table[ir->opcode];                      \
     }
 
-#define OPT_BRANCH_FUNC_SPEC(type, cond, rs1, rs2)                                 \
-    if (info->is_constant[rs1] && info->is_constant[rs2]) { \
-        if ((type) info->const_val[rs1] cond                    \
-            (type) info->const_val[rs2])                        \
-            ir->imm = 4;                                            \
-        ir->opcode = rv_insn_jal;                                   \
-        ir->impl = dispatch_table[ir->opcode];                      \
-    }
-
 /* clang-format on */
 
 /* BEQ: Branch if Equal */
 CONSTOPT(beq, { OPT_BRANCH_FUNC(uint32_t, !=); })
 
-CONSTOPT(beq01400, { OPT_BRANCH_FUNC_SPEC(uint32_t, !=, 14, 0); })
-CONSTOPT(beq014010, { OPT_BRANCH_FUNC_SPEC(uint32_t, !=, 14, 10); })
-CONSTOPT(beq014013, { OPT_BRANCH_FUNC_SPEC(uint32_t, !=, 14, 13); })
-CONSTOPT(beq01500, { OPT_BRANCH_FUNC_SPEC(uint32_t, !=, 15, 0); })
-CONSTOPT(beq015014, { OPT_BRANCH_FUNC_SPEC(uint32_t, !=, 15, 14); })
-CONSTOPT(beq0800, { OPT_BRANCH_FUNC_SPEC(uint32_t, !=, 8, 0); })
-
 /* BNE: Branch if Not Equal */
 CONSTOPT(bne, { OPT_BRANCH_FUNC(uint32_t, ==); })
-
-CONSTOPT(bne01400, { OPT_BRANCH_FUNC_SPEC(uint32_t, ==, 14, 0); })
-CONSTOPT(bne014013, { OPT_BRANCH_FUNC_SPEC(uint32_t, ==, 14, 13); })
-CONSTOPT(bne014023, { OPT_BRANCH_FUNC_SPEC(uint32_t, ==, 14, 23); })
-CONSTOPT(bne015013, { OPT_BRANCH_FUNC_SPEC(uint32_t, ==, 15, 13); })
-CONSTOPT(bne025014, { OPT_BRANCH_FUNC_SPEC(uint32_t, ==, 25, 14); })
 
 /* BLT: Branch if Less Than */
 CONSTOPT(blt, { OPT_BRANCH_FUNC(int32_t, >=); })
@@ -143,11 +121,19 @@ CONSTOPT(addi, {
         info->is_constant[ir->rd] = false;
 })
 
+CONSTOPT(addi010010, {if (info->is_constant[10]) {ir->imm += info->const_val[10];info->is_constant[10] = true;info->const_val[10] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[10] = false;}	})
+CONSTOPT(addi01002, {if (info->is_constant[2]) {ir->imm += info->const_val[2];info->is_constant[10] = true;info->const_val[10] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[10] = false;}	})
+CONSTOPT(addi011010, {if (info->is_constant[10]) {ir->imm += info->const_val[10];info->is_constant[11] = true;info->const_val[11] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[11] = false;}	})
+CONSTOPT(addi011011, {if (info->is_constant[11]) {ir->imm += info->const_val[11];info->is_constant[11] = true;info->const_val[11] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[11] = false;}	})
+CONSTOPT(addi01102, {if (info->is_constant[2]) {ir->imm += info->const_val[2];info->is_constant[11] = true;info->const_val[11] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[11] = false;}	})
+CONSTOPT(addi014011, {if (info->is_constant[11]) {ir->imm += info->const_val[11];info->is_constant[14] = true;info->const_val[14] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[14] = false;}	})
+CONSTOPT(addi019019, {if (info->is_constant[19]) {ir->imm += info->const_val[19];info->is_constant[19] = true;info->const_val[19] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[19] = false;}	})
+CONSTOPT(addi0202, {if (info->is_constant[2]) {ir->imm += info->const_val[2];info->is_constant[2] = true;info->const_val[2] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[2] = false;}	})
+
 CONSTOPT(addi012012, {if (info->is_constant[12]) {ir->imm += info->const_val[12];info->is_constant[12] = true;info->const_val[12] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[12] = false;}	})
 CONSTOPT(addi013013, {if (info->is_constant[13]) {ir->imm += info->const_val[13];info->is_constant[13] = true;info->const_val[13] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[13] = false;}	})
 CONSTOPT(addi01308, {if (info->is_constant[8]) {ir->imm += info->const_val[8];info->is_constant[13] = true;info->const_val[13] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[13] = false;}	})
 CONSTOPT(addi014014, {if (info->is_constant[14]) {ir->imm += info->const_val[14];info->is_constant[14] = true;info->const_val[14] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[14] = false;}	})
-CONSTOPT(addi015012, {if (info->is_constant[12]) {ir->imm += info->const_val[12];info->is_constant[15] = true;info->const_val[15] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[15] = false;}	})
 CONSTOPT(addi015015, {if (info->is_constant[15]) {ir->imm += info->const_val[15];info->is_constant[15] = true;info->const_val[15] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[15] = false;}	})
 CONSTOPT(addi08014, {if (info->is_constant[14]) {ir->imm += info->const_val[14];info->is_constant[8] = true;info->const_val[8] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[8] = false;}	})
 CONSTOPT(mv, {if (info->is_constant[ir->rs1]) {ir->imm += info->const_val[ir->rs1];info->is_constant[ir->rd] = true;info->const_val[ir->rd] = ir->imm;ir->opcode = rv_insn_lui;ir->impl = dispatch_table[ir->opcode];} else{info->is_constant[ir->rd] = false;}})

--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -614,7 +614,6 @@ RVOP(addi01102,{rv->X[11] = (int32_t) (rv->X[2]) + ir->imm;},X64({ld, S32, RAX, 
 RVOP(addi014011,{rv->X[14] = (int32_t) (rv->X[11]) + ir->imm;},X64({ld, S32, RAX, X, rs1;alu32_imm, 32, 0x81, 0, RAX, imm;st, S32, RAX, X, rd;}))
 RVOP(addi019019,{rv->X[19] = (int32_t) (rv->X[19]) + ir->imm;},X64({ld, S32, RAX, X, rs1;alu32_imm, 32, 0x81, 0, RAX, imm;st, S32, RAX, X, rd;}))
 RVOP(addi0202,{rv->X[2] = (int32_t) (rv->X[2]) + ir->imm;},X64({ld, S32, RAX, X, rs1;alu32_imm, 32, 0x81, 0, RAX, imm;st, S32, RAX, X, rd;}))
-
 RVOP(addi012012,{rv->X[12] = (int32_t) (rv->X[12]) + ir->imm;},X64({ld, S32, RAX, X, rs1;alu32_imm, 32, 0x81, 0, RAX, imm;st, S32, RAX, X, rd;}))
 RVOP(addi013013,{rv->X[13] = (int32_t) (rv->X[13]) + ir->imm;},X64({ld, S32, RAX, X, rs1;alu32_imm, 32, 0x81, 0, RAX, imm;st, S32, RAX, X, rd;}))
 RVOP(addi01308,{rv->X[13] = (int32_t) (rv->X[8]) + ir->imm;},X64({ld, S32, RAX, X, rs1;alu32_imm, 32, 0x81, 0, RAX, imm;st, S32, RAX, X, rd;}))

--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -614,6 +614,7 @@ RVOP(addi01102,{rv->X[11] = (int32_t) (rv->X[2]) + ir->imm;},X64({ld, S32, RAX, 
 RVOP(addi014011,{rv->X[14] = (int32_t) (rv->X[11]) + ir->imm;},X64({ld, S32, RAX, X, rs1;alu32_imm, 32, 0x81, 0, RAX, imm;st, S32, RAX, X, rd;}))
 RVOP(addi019019,{rv->X[19] = (int32_t) (rv->X[19]) + ir->imm;},X64({ld, S32, RAX, X, rs1;alu32_imm, 32, 0x81, 0, RAX, imm;st, S32, RAX, X, rd;}))
 RVOP(addi0202,{rv->X[2] = (int32_t) (rv->X[2]) + ir->imm;},X64({ld, S32, RAX, X, rs1;alu32_imm, 32, 0x81, 0, RAX, imm;st, S32, RAX, X, rd;}))
+
 RVOP(addi012012,{rv->X[12] = (int32_t) (rv->X[12]) + ir->imm;},X64({ld, S32, RAX, X, rs1;alu32_imm, 32, 0x81, 0, RAX, imm;st, S32, RAX, X, rd;}))
 RVOP(addi013013,{rv->X[13] = (int32_t) (rv->X[13]) + ir->imm;},X64({ld, S32, RAX, X, rs1;alu32_imm, 32, 0x81, 0, RAX, imm;st, S32, RAX, X, rd;}))
 RVOP(addi01308,{rv->X[13] = (int32_t) (rv->X[8]) + ir->imm;},X64({ld, S32, RAX, X, rs1;alu32_imm, 32, 0x81, 0, RAX, imm;st, S32, RAX, X, rd;}))

--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -286,54 +286,6 @@ RVOP(
     return true;
 
 
-#define BRANCH_FUNC_SPEC(type, cond, rs1, rs2)                                              \
-    IIF(RV32_HAS(EXT_C))(, const uint32_t pc = PC;);                         \
-    if (BRANCH_COND(type, rv->X[rs1], rv->X[rs2], cond)) {           \
-        is_branch_taken = false;                                             \
-        struct rv_insn *untaken = ir->branch_untaken;                        \
-        if (!untaken)                                                        \
-            goto nextop;                                                     \
-        IIF(RV32_HAS(JIT))                                                   \
-        ({                                                                   \
-            block_t *block = cache_get(rv->block_cache, PC + 4);             \
-            if (!block) {                                                    \
-                ir->branch_untaken = NULL;                                   \
-                goto nextop;                                                 \
-            }                                                                \
-            untaken = ir->branch_untaken = block->ir_head;                   \
-            if (cache_hot(rv->block_cache, PC + 4))                          \
-                goto nextop;                                                 \
-        }, );                                                                \
-        PC += 4;                                                             \
-        last_pc = PC;                                                        \
-        MUST_TAIL return untaken->impl(rv, untaken, cycle, PC);              \
-    }                                                                        \
-    is_branch_taken = true;                                                  \
-    PC += ir->imm;                                                           \
-    /* check instruction misaligned */                                       \
-    IIF(RV32_HAS(EXT_C))                                                     \
-    (, RV_EXC_MISALIGN_HANDLER(pc, insn, false, 0);) struct rv_insn *taken = \
-        ir->branch_taken;                                                    \
-    if (taken) {                                                             \
-        IIF(RV32_HAS(JIT))                                                   \
-        ({                                                                   \
-            block_t *block = cache_get(rv->block_cache, PC);                 \
-            if (!block) {                                                    \
-                ir->branch_taken = NULL;                                     \
-                goto end_insn;                                               \
-            }                                                                \
-            taken = ir->branch_taken = block->ir_head;                       \
-            if (cache_hot(rv->block_cache, PC))                              \
-                goto end_insn;                                               \
-        }, );                                                                \
-        last_pc = PC;                                                        \
-        MUST_TAIL return taken->impl(rv, taken, cycle, PC);                  \
-    }                                                                        \
-    end_insn:                                                                \
-    rv->csr_cycle = cycle;                                                   \
-    rv->PC = PC;                                                             \
-    return true;
-
 /* In RV32I and RV64I, if the branch is taken, set pc = pc + offset, where
  * offset is a multiple of two; else do nothing. The offset is 13 bits long.
  *
@@ -375,13 +327,6 @@ RVOP(
         exit;
     }))
 
-RVOP(beq01400,{ BRANCH_FUNC_SPEC(uint32_t, !=, 14 ,0); },GEN({ld, S32, TMP0, X, rs1;ld, S32, TMP1, X, rs2;cmp, TMP1, TMP0;set_jmp_off;jcc, 0x84;cond, branch_untaken;jmp, pc, 4;end;ld_imm, TMP0, pc, 4;st, S32, TMP0, PC;exit;jmp_off;cond, branch_taken;jmp, pc, imm;end;ld_imm, TMP0, pc, imm;st, S32, TMP0, PC;exit;}))
-RVOP(beq014010,{ BRANCH_FUNC_SPEC(uint32_t, !=, 14 ,10); },GEN({ld, S32, TMP0, X, rs1;ld, S32, TMP1, X, rs2;cmp, TMP1, TMP0;set_jmp_off;jcc, 0x84;cond, branch_untaken;jmp, pc, 4;end;ld_imm, TMP0, pc, 4;st, S32, TMP0, PC;exit;jmp_off;cond, branch_taken;jmp, pc, imm;end;ld_imm, TMP0, pc, imm;st, S32, TMP0, PC;exit;}))
-RVOP(beq014013,{ BRANCH_FUNC_SPEC(uint32_t, !=, 14 ,13); },GEN({ld, S32, TMP0, X, rs1;ld, S32, TMP1, X, rs2;cmp, TMP1, TMP0;set_jmp_off;jcc, 0x84;cond, branch_untaken;jmp, pc, 4;end;ld_imm, TMP0, pc, 4;st, S32, TMP0, PC;exit;jmp_off;cond, branch_taken;jmp, pc, imm;end;ld_imm, TMP0, pc, imm;st, S32, TMP0, PC;exit;}))
-RVOP(beq01500,{ BRANCH_FUNC_SPEC(uint32_t, !=, 15 ,0); },GEN({ld, S32, TMP0, X, rs1;ld, S32, TMP1, X, rs2;cmp, TMP1, TMP0;set_jmp_off;jcc, 0x84;cond, branch_untaken;jmp, pc, 4;end;ld_imm, TMP0, pc, 4;st, S32, TMP0, PC;exit;jmp_off;cond, branch_taken;jmp, pc, imm;end;ld_imm, TMP0, pc, imm;st, S32, TMP0, PC;exit;}))
-RVOP(beq015014,{ BRANCH_FUNC_SPEC(uint32_t, !=, 15 ,14); },GEN({ld, S32, TMP0, X, rs1;ld, S32, TMP1, X, rs2;cmp, TMP1, TMP0;set_jmp_off;jcc, 0x84;cond, branch_untaken;jmp, pc, 4;end;ld_imm, TMP0, pc, 4;st, S32, TMP0, PC;exit;jmp_off;cond, branch_taken;jmp, pc, imm;end;ld_imm, TMP0, pc, imm;st, S32, TMP0, PC;exit;}))
-RVOP(beq0800,{ BRANCH_FUNC_SPEC(uint32_t, !=, 8 ,0); },GEN({ld, S32, TMP0, X, rs1;ld, S32, TMP1, X, rs2;cmp, TMP1, TMP0;set_jmp_off;jcc, 0x84;cond, branch_untaken;jmp, pc, 4;end;ld_imm, TMP0, pc, 4;st, S32, TMP0, PC;exit;jmp_off;cond, branch_taken;jmp, pc, imm;end;ld_imm, TMP0, pc, imm;st, S32, TMP0, PC;exit;}))
-
 /* BNE: Branch if Not Equal */
 RVOP(
     bne,
@@ -406,12 +351,6 @@ RVOP(
         st, S32, TMP0, PC;
         exit;
     }))
-
-RVOP(bne01400,{ BRANCH_FUNC_SPEC(uint32_t, ==, 14 ,0); },GEN({ld, S32, TMP0, X, rs1;ld, S32, TMP1, X, rs2;cmp, TMP1, TMP0;set_jmp_off;jcc, 0x84;cond, branch_untaken;jmp, pc, 4;end;ld_imm, TMP0, pc, 4;st, S32, TMP0, PC;exit;jmp_off;cond, branch_taken;jmp, pc, imm;end;ld_imm, TMP0, pc, imm;st, S32, TMP0, PC;exit;}))
-RVOP(bne014013,{ BRANCH_FUNC_SPEC(uint32_t, ==, 14 ,13); },GEN({ld, S32, TMP0, X, rs1;ld, S32, TMP1, X, rs2;cmp, TMP1, TMP0;set_jmp_off;jcc, 0x84;cond, branch_untaken;jmp, pc, 4;end;ld_imm, TMP0, pc, 4;st, S32, TMP0, PC;exit;jmp_off;cond, branch_taken;jmp, pc, imm;end;ld_imm, TMP0, pc, imm;st, S32, TMP0, PC;exit;}))
-RVOP(bne014023,{ BRANCH_FUNC_SPEC(uint32_t, ==, 14 ,23); },GEN({ld, S32, TMP0, X, rs1;ld, S32, TMP1, X, rs2;cmp, TMP1, TMP0;set_jmp_off;jcc, 0x84;cond, branch_untaken;jmp, pc, 4;end;ld_imm, TMP0, pc, 4;st, S32, TMP0, PC;exit;jmp_off;cond, branch_taken;jmp, pc, imm;end;ld_imm, TMP0, pc, imm;st, S32, TMP0, PC;exit;}))
-RVOP(bne015013,{ BRANCH_FUNC_SPEC(uint32_t, ==, 15 ,13); },GEN({ld, S32, TMP0, X, rs1;ld, S32, TMP1, X, rs2;cmp, TMP1, TMP0;set_jmp_off;jcc, 0x84;cond, branch_untaken;jmp, pc, 4;end;ld_imm, TMP0, pc, 4;st, S32, TMP0, PC;exit;jmp_off;cond, branch_taken;jmp, pc, imm;end;ld_imm, TMP0, pc, imm;st, S32, TMP0, PC;exit;}))
-RVOP(bne025014,{ BRANCH_FUNC_SPEC(uint32_t, ==, 25 ,14); },GEN({ld, S32, TMP0, X, rs1;ld, S32, TMP1, X, rs2;cmp, TMP1, TMP0;set_jmp_off;jcc, 0x84;cond, branch_untaken;jmp, pc, 4;end;ld_imm, TMP0, pc, 4;st, S32, TMP0, PC;exit;jmp_off;cond, branch_taken;jmp, pc, imm;end;ld_imm, TMP0, pc, imm;st, S32, TMP0, PC;exit;}))
 
 /* BLT: Branch if Less Than */
 RVOP(
@@ -667,11 +606,19 @@ RVOP(
         st, S32, TMP0, X, rd;
     }))
 
+RVOP(addi010010,{rv->X[10] = (int32_t) (rv->X[10]) + ir->imm;},X64({ld, S32, RAX, X, rs1;alu32_imm, 32, 0x81, 0, RAX, imm;st, S32, RAX, X, rd;}))
+RVOP(addi01002,{rv->X[10] = (int32_t) (rv->X[2]) + ir->imm;},X64({ld, S32, RAX, X, rs1;alu32_imm, 32, 0x81, 0, RAX, imm;st, S32, RAX, X, rd;}))
+RVOP(addi011010,{rv->X[11] = (int32_t) (rv->X[10]) + ir->imm;},X64({ld, S32, RAX, X, rs1;alu32_imm, 32, 0x81, 0, RAX, imm;st, S32, RAX, X, rd;}))
+RVOP(addi011011,{rv->X[11] = (int32_t) (rv->X[11]) + ir->imm;},X64({ld, S32, RAX, X, rs1;alu32_imm, 32, 0x81, 0, RAX, imm;st, S32, RAX, X, rd;}))
+RVOP(addi01102,{rv->X[11] = (int32_t) (rv->X[2]) + ir->imm;},X64({ld, S32, RAX, X, rs1;alu32_imm, 32, 0x81, 0, RAX, imm;st, S32, RAX, X, rd;}))
+RVOP(addi014011,{rv->X[14] = (int32_t) (rv->X[11]) + ir->imm;},X64({ld, S32, RAX, X, rs1;alu32_imm, 32, 0x81, 0, RAX, imm;st, S32, RAX, X, rd;}))
+RVOP(addi019019,{rv->X[19] = (int32_t) (rv->X[19]) + ir->imm;},X64({ld, S32, RAX, X, rs1;alu32_imm, 32, 0x81, 0, RAX, imm;st, S32, RAX, X, rd;}))
+RVOP(addi0202,{rv->X[2] = (int32_t) (rv->X[2]) + ir->imm;},X64({ld, S32, RAX, X, rs1;alu32_imm, 32, 0x81, 0, RAX, imm;st, S32, RAX, X, rd;}))
+
 RVOP(addi012012,{rv->X[12] = (int32_t) (rv->X[12]) + ir->imm;},X64({ld, S32, RAX, X, rs1;alu32_imm, 32, 0x81, 0, RAX, imm;st, S32, RAX, X, rd;}))
 RVOP(addi013013,{rv->X[13] = (int32_t) (rv->X[13]) + ir->imm;},X64({ld, S32, RAX, X, rs1;alu32_imm, 32, 0x81, 0, RAX, imm;st, S32, RAX, X, rd;}))
 RVOP(addi01308,{rv->X[13] = (int32_t) (rv->X[8]) + ir->imm;},X64({ld, S32, RAX, X, rs1;alu32_imm, 32, 0x81, 0, RAX, imm;st, S32, RAX, X, rd;}))
 RVOP(addi014014,{rv->X[14] = (int32_t) (rv->X[14]) + ir->imm;},X64({ld, S32, RAX, X, rs1;alu32_imm, 32, 0x81, 0, RAX, imm;st, S32, RAX, X, rd;}))
-RVOP(addi015012,{rv->X[15] = (int32_t) (rv->X[12]) + ir->imm;},X64({ld, S32, RAX, X, rs1;alu32_imm, 32, 0x81, 0, RAX, imm;st, S32, RAX, X, rd;}))
 RVOP(addi015015,{rv->X[15] = (int32_t) (rv->X[15]) + ir->imm;},X64({ld, S32, RAX, X, rs1;alu32_imm, 32, 0x81, 0, RAX, imm;st, S32, RAX, X, rd;}))
 RVOP(addi08014,{rv->X[8] = (int32_t) (rv->X[14]) + ir->imm;},X64({ld, S32, RAX, X, rs1;alu32_imm, 32, 0x81, 0, RAX, imm;st, S32, RAX, X, rd;}))
 RVOP(li,{rv->X[ir->rd] = (ir->imm);},X64({ld, S32, RAX, X, rs1;alu32_imm, 32, 0x81, 0, RAX, imm;st, S32, RAX, X, rd;}))


### PR DESCRIPTION
## Overview
In order to optimize the performance of the **interpreter** for frequently occurring instructions during runtime, I specialized the **addi** instruction by introducing several specialized methods at runtime to accelerate the execution speed.

## Modified Files

* decode.[ch]
* rv32_template.c
* rv32_constopt.c

## Description of Changes 

The changed of  **decode.[ch]**  is responsible for adding specialized instructions to the instruction table and, during the decode phase, determining if the addi instruction is specialized. As for **rv32_template.c** and **rv32_constopt.c**, they will include instruction methods for **emulate.c**  , and I have also added specialized instructions for them here.

## Test Results

The modification has been confirmed to bring improvements to **coremark.elf**, **stream.elf**, and **nqueens.elf** .
