### PR TITLE
Fix csrrc instruction behavior when rs1 is 0

### DIFF
--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -992,7 +992,7 @@ RVOP(
     csrrc,
     {
         uint32_t tmp = csr_csrrc(
-            rv, ir->imm, (ir->rs1 == rv_reg_zero) ? ~0U : rv->X[ir->rs1]);
+            rv, ir->imm, (ir->rs1 == rv_reg_zero) ? 0U : rv->X[ir->rs1]);
         rv->X[ir->rd] = ir->rd ? tmp : rv->X[ir->rd];
     },
     GEN({


### PR DESCRIPTION
According to the RISC-V specification, no write operation should occur when rs1 is equal to 0. The current implementation incorrectly clears all bits in the specified CSR.

Introduces a fix that ensures the csrrc instruction refrains from performing any write operation when rs1 is 0.