### PR TITLE
Refine the API in the public header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,6 @@ CFLAGS = -std=gnu99 -O2 -Wall -Wextra
 CFLAGS += -Wno-unused-label
 CFLAGS += -include src/common.h
 
-# Set the default stack pointer
-CFLAGS += -D DEFAULT_STACK_ADDR=0xFFFFE000
-# Set the default args starting address
-CFLAGS += -D DEFAULT_ARGS_ADDR=0xFFFFF000
-
 # Enable link-time optimization (LTO)
 ENABLE_LTO ?= 1
 ifeq ($(call has, LTO), 1)
@@ -121,7 +116,7 @@ endif
 ENABLE_JIT ?= 0
 $(call set-feature, JIT)
 ifeq ($(call has, JIT), 1)
-OBJS_EXT += jit.o 
+OBJS_EXT += jit.o
 ifneq ($(processor),$(filter $(processor),x86_64 aarch64 arm64))
 $(error JIT mode only supports for x64 and arm64 target currently.)
 endif

--- a/src/elf.c
+++ b/src/elf.c
@@ -259,12 +259,8 @@ bool elf_get_data_section_range(elf_t *e, uint32_t *start, uint32_t *end)
  * Finding data for section headers:
  *   File start + section_header.offset -> section Data
  */
-bool elf_load(elf_t *e, riscv_t *rv, memory_t *mem)
+bool elf_load(elf_t *e, memory_t *mem)
 {
-    /* set the entry point */
-    if (!rv_set_pc(rv, e->hdr->e_entry))
-        return false;
-
     /* loop over all of the program headers */
     for (int p = 0; p < e->hdr->e_phnum; ++p) {
         /* find next program header */

--- a/src/elf.h
+++ b/src/elf.h
@@ -145,7 +145,7 @@ const char *elf_find_symbol(elf_t *e, uint32_t addr);
 bool elf_get_data_section_range(elf_t *e, uint32_t *start, uint32_t *end);
 
 /* Load the ELF file into a memory abstraction */
-bool elf_load(elf_t *e, riscv_t *rv, memory_t *mem);
+bool elf_load(elf_t *e, memory_t *mem);
 
 /* get the ELF header */
 struct Elf32_Ehdr *get_elf_header(elf_t *e);

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -125,7 +125,7 @@ RV_EXCEPTION_LIST
  */
 #define RV_EXC_MISALIGN_HANDLER(mask_or_pc, type, compress, IO)       \
     IIF(IO)                                                           \
-    (if (!rv->io.allow_misalign && unlikely(addr & (mask_or_pc))),    \
+    (if (!PRIV(rv)->allow_misalign && unlikely(addr & (mask_or_pc))), \
      if (unlikely(insn_is_misaligned(PC))))                           \
     {                                                                 \
         rv->compressed = compress;                                    \
@@ -1182,7 +1182,7 @@ void ecall_handler(riscv_t *rv)
 
 void memset_handler(riscv_t *rv)
 {
-    memory_t *m = ((state_t *) rv->userdata)->mem;
+    memory_t *m = PRIV(rv)->mem;
     memset((char *) m->mem_base + rv->X[rv_reg_a0], rv->X[rv_reg_a1],
            rv->X[rv_reg_a2]);
     rv->PC = rv->X[rv_reg_ra] & ~1U;
@@ -1190,7 +1190,7 @@ void memset_handler(riscv_t *rv)
 
 void memcpy_handler(riscv_t *rv)
 {
-    memory_t *m = ((state_t *) rv->userdata)->mem;
+    memory_t *m = PRIV(rv)->mem;
     memcpy((char *) m->mem_base + rv->X[rv_reg_a0],
            (char *) m->mem_base + rv->X[rv_reg_a1], rv->X[rv_reg_a2]);
     rv->PC = rv->X[rv_reg_ra] & ~1U;

--- a/src/io.c
+++ b/src/io.c
@@ -17,44 +17,36 @@
 
 static uint8_t *data_memory_base;
 
-/*
- * set memory size to 2^32 - 1 bytes
- *
- * The memory size is set to 2^32 - 1 bytes in order to make this emulator
- * portable for both 32-bit and 64-bit platforms. As a result, it can access
- * any segment of the memory on either platform. Furthermore, it is safe
- * because most of the test cases' data memory usage will not exceed this
- * memory size.
- */
-#define MEM_SIZE 0xFFFFFFFFULL
-
-memory_t *memory_new(void)
+memory_t *memory_new(uint32_t size)
 {
+    if (!size)
+        return NULL;
+
     memory_t *mem = malloc(sizeof(memory_t));
     assert(mem);
 #if HAVE_MMAP
-    data_memory_base = mmap(NULL, MEM_SIZE, PROT_READ | PROT_WRITE,
+    data_memory_base = mmap(NULL, size, PROT_READ | PROT_WRITE,
                             MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
     if (data_memory_base == MAP_FAILED) {
         free(mem);
         return NULL;
     }
 #else
-    data_memory_base = malloc(MEM_SIZE);
+    data_memory_base = malloc(size);
     if (!data_memory_base) {
         free(mem);
         return NULL;
     }
 #endif
     mem->mem_base = data_memory_base;
-    mem->mem_size = MEM_SIZE;
+    mem->mem_size = size;
     return mem;
 }
 
 void memory_delete(memory_t *mem)
 {
 #if HAVE_MMAP
-    munmap(mem->mem_base, MEM_SIZE);
+    munmap(mem->mem_base, mem->mem_size);
 #else
     free(mem->mem_base);
 #endif

--- a/src/io.h
+++ b/src/io.h
@@ -17,7 +17,7 @@ typedef struct {
     uint64_t mem_size;
 } memory_t;
 
-memory_t *memory_new(void);
+memory_t *memory_new(uint32_t size);
 void memory_delete(memory_t *m);
 
 /* read a C-style string from memory */

--- a/src/jit.c
+++ b/src/jit.c
@@ -39,6 +39,7 @@
 #include "io.h"
 #include "jit.h"
 #include "riscv.h"
+#include "riscv_private.h"
 #include "utils.h"
 
 #define JIT_CLS_MASK 0x07
@@ -1284,7 +1285,7 @@ static void do_fuse2(struct jit_state *state, riscv_t *rv UNUSED, rv_insn_t *ir)
 
 static void do_fuse3(struct jit_state *state, riscv_t *rv, rv_insn_t *ir)
 {
-    memory_t *m = ((state_t *) rv->userdata)->mem;
+    memory_t *m = PRIV(rv)->mem;
     opcode_fuse_t *fuse = ir->fuse;
     for (int i = 0; i < ir->imm2; i++) {
         emit_load(state, S32, parameter_reg[0], temp_reg[0],
@@ -1300,7 +1301,7 @@ static void do_fuse3(struct jit_state *state, riscv_t *rv, rv_insn_t *ir)
 
 static void do_fuse4(struct jit_state *state, riscv_t *rv, rv_insn_t *ir)
 {
-    memory_t *m = ((state_t *) rv->userdata)->mem;
+    memory_t *m = PRIV(rv)->mem;
     opcode_fuse_t *fuse = ir->fuse;
     for (int i = 0; i < ir->imm2; i++) {
         emit_load(state, S32, parameter_reg[0], temp_reg[0],

--- a/src/riscv_private.h
+++ b/src/riscv_private.h
@@ -17,6 +17,8 @@
 #include "cache.h"
 #endif
 
+#define PRIV(x) ((vm_attr_t *) x->data)
+
 /* CSRs */
 enum {
     /* floating point */
@@ -100,7 +102,7 @@ struct riscv_internal {
     riscv_word_t PC;
 
     /* user provided data */
-    riscv_user_t userdata;
+    riscv_user_t data;
 
 #if RV32_HAS(EXT_F)
     /* float registers */
@@ -129,8 +131,7 @@ struct riscv_internal {
     struct mpool *chain_entry_mp;
 #endif
     struct mpool *block_mp, *block_ir_mp;
-    /* print exit code on syscall_exit */
-    bool output_exit_code;
+
     void *jit_state;
 #if RV32_HAS(GDBSTUB)
     /* gdbstub instance */

--- a/tools/gen-jit-template.py
+++ b/tools/gen-jit-template.py
@@ -219,7 +219,7 @@ for i in range(len(op)):
             elif items[0] == "jmp_off":
                 asm = "emit_jump_target_offset(state, JUMP_LOC, state->offset);"
             elif items[0] == "mem":
-                asm = "memory_t *m = ((state_t *) rv->userdata)->mem;"
+                asm = "memory_t *m = PRIV(rv)->mem;"
             elif items[0] == "call":
                 asm = "emit_call(state, (intptr_t) rv->io.on_{});".format(
                     items[1])


### PR DESCRIPTION
The following should be included in an emulator's simple and clear public API:
1. create/init core
2. run emulation
3. delete/destroy core

Other components, including as memory, file systems, program data, etc., should be abstracted from the user, as a result, setting a configuration value (`vm_attr_t`) is sufficient. The user should manage about memory (`state_t`) and elf stuff before this PR. The user may just construct a core, run it, and shut it down after this PR, so they won't need to worry about them anymore.

For stdio remapping, `rv_remap_stdstream` function is introduced.

The `vm_attr_t` has multiple fields and they are commented clearly in the code.

elf is reopened in `dump_test_signature` because elf is allocated during `rv_create`. It is acceptable to reopen elf since it is only for testing. Print inferior exit code to console inside main instead of `syscall_exit` because the actual usage of exit code depends on applications of using riscv public API.

The `io` interface is not changed in this PR because it could maybe reused with `semu` in some way, still need to be investigated. Also, Logging feature and system emulator integration are not implemented yet.