### PR TITLE
Fix a bug cache_create()

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -153,7 +153,7 @@ free_map:
     free(cache->map);
 free_lists:
     for (int j = 0; j < i; j++)
-        free(cache->lists[i]);
+        free(cache->lists[j]);
 
     free(cache);
     return NULL;


### PR DESCRIPTION
The array index is wrongly written to `i` instead of `j`, which is the wrong logic. 