### PR TITLE
Fix a bug where a file descriptor isn't closed after allocation

### DIFF
--- a/src/emulate.c
+++ b/src/emulate.c
@@ -1210,4 +1210,7 @@ void dump_registers(riscv_t *rv, char *out_file_path)
         fprintf(f, "  \"x%d\": %u%s\n", i, rv->X[i], comma);
     }
     fprintf(f, "}\n");
+
+    if (out_file_path[0] != '-')
+        fclose(f);
 }


### PR DESCRIPTION
Add missing `fclose(f);`