### PR TITLE
Check if a pointer is NULL before dereferencing

### DIFF
--- a/src/jit.c
+++ b/src/jit.c
@@ -1481,6 +1481,7 @@ out:
 struct jit_state *jit_state_init(size_t size)
 {
     struct jit_state *state = malloc(sizeof(struct jit_state));
+    assert(state);
     state->offset = 0;
     state->size = size;
     state->buf = mmap(0, size, PROT_READ | PROT_WRITE | PROT_EXEC,


### PR DESCRIPTION
Fix a bug where the pointer returned by `malloc()` is dereferenced before checking if it's `NULL`.