### PR TITLE
Drop memory_read_str function

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -61,16 +61,6 @@ void memory_read(const memory_t *mem,
     memcpy(dst, mem->mem_base + addr, size);
 }
 
-uint32_t memory_read_str(const memory_t *mem,
-                         uint8_t *dst,
-                         uint32_t addr,
-                         uint32_t max)
-{
-    char *d = (char *) dst;
-    char *s = (char *) mem->mem_base + addr;
-    return strlen(strncpy(d, s, max));
-}
-
 uint32_t memory_ifetch(uint32_t addr)
 {
     return *(const uint32_t *) (data_memory_base + addr);

--- a/src/io.h
+++ b/src/io.h
@@ -20,12 +20,6 @@ typedef struct {
 memory_t *memory_new(uint32_t size);
 void memory_delete(memory_t *m);
 
-/* read a C-style string from memory */
-uint32_t memory_read_str(const memory_t *m,
-                         uint8_t *dst,
-                         uint32_t addr,
-                         uint32_t max);
-
 /* read an instruction from memory */
 uint32_t memory_ifetch(uint32_t addr);
 


### PR DESCRIPTION
The memory_read_str function tends to terminate the string with '\0'
character but the string is only terminated with '\0' character if src is
less than max characters long according to "man 3 strncpy". As a result,
there is a chance to make the dst is not terminated with '\0' character,
e.g., the length of filename equals 256 characters long. It can simply
solved by passing "sizeof(name_str) - 1" to memory_read_str function
instead of "sizeof(name_str)" when calling memory_read_str function.
But, to deal with the filename >= 256 characters long, malloc the desired
length of filename during runtime is a better way.