### PR TITLE
Fix signed integer comparison in AMOMIN.W and AMOMAX.W

### DIFF
--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -1376,8 +1376,9 @@ RVOP(
     amominw,
     {
         rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
-        const int32_t res =
-            rv->X[ir->rd] < rv->X[ir->rs2] ? rv->X[ir->rd] : rv->X[ir->rs2];
+        const int32_t a = rv->X[ir->rd];
+        const int32_t b = rv->X[ir->rs2];
+        const uint32_t res = a < b ? rv->X[ir->rd] : rv->X[ir->rs2];
         rv->io.mem_write_s(ir->rs1, res);
     },
     GEN({
@@ -1389,8 +1390,9 @@ RVOP(
     amomaxw,
     {
         rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
-        const int32_t res =
-            rv->X[ir->rd] > rv->X[ir->rs2] ? rv->X[ir->rd] : rv->X[ir->rs2];
+        const int32_t a = rv->X[ir->rd];
+        const int32_t b = rv->X[ir->rs2];
+        const uint32_t res = a > b ? rv->X[ir->rd] : rv->X[ir->rs2];
         rv->io.mem_write_s(ir->rs1, res);
     },
     GEN({


### PR DESCRIPTION
The current implementation of the AMOMIN.W and AMOMAX.W instructions incorrectly compares the values of registers rd and rs2 as unsigned integers instead of signed integers. Correct this behavior by properly treating rd and rs2 as signed integers before performing the comparison.