### PR TITLE
Fix pushing images automatically to DockerHub

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -155,6 +155,7 @@ jobs:
         if: ${{ github.event_name == 'push'}}
         uses: docker/build-push-action@v5
         with:
+          push: true
           context: .
           platforms: linux/amd64,linux/arm64/v8
           tags: sysprog21/rv32emu:latest, sysprog21/rv32emu:${{ env.short_hash }}


### PR DESCRIPTION
Addresses the problem where docker images aren't pushed to DockerHub automatically by GithubCI