### PR TITLE
Refine I/O comments

### DIFF
--- a/src/io.h
+++ b/src/io.h
@@ -8,16 +8,15 @@
 #include <stdint.h>
 #include <string.h>
 
-/* Directly map a memory with a size of 2^32 bytes. All memory read/write
- * operations can access this memory through the memory subsystem.
- */
-
 typedef struct {
     uint8_t *mem_base;
     uint64_t mem_size;
 } memory_t;
 
+/* create a memory instance */
 memory_t *memory_new(uint32_t size);
+
+/* delete a memory instance */
 void memory_delete(memory_t *m);
 
 /* read an instruction from memory */
@@ -35,6 +34,7 @@ uint8_t memory_read_b(uint32_t addr);
 /* read a length of data from memory */
 void memory_read(const memory_t *m, uint8_t *dst, uint32_t addr, uint32_t size);
 
+/* write a length of data to memory */
 static inline void memory_write(memory_t *m,
                                 uint32_t addr,
                                 const uint8_t *src,
@@ -43,12 +43,16 @@ static inline void memory_write(memory_t *m,
     memcpy(m->mem_base + addr, src, size);
 }
 
+/* write a word to memory */
 void memory_write_w(uint32_t addr, const uint8_t *src);
 
+/* write a short to memory */
 void memory_write_s(uint32_t addr, const uint8_t *src);
 
+/* write a byte to memory */
 void memory_write_b(uint32_t addr, const uint8_t *src);
 
+/* write a length of certain value to memory */
 static inline void memory_fill(memory_t *m,
                                uint32_t addr,
                                uint32_t size,


### PR DESCRIPTION
Since commit #340, the size of memory can be changed. As a result, this commit has removed outdated comments. Some comments are added to describe the IO functions in order to increase consistency.