### PR TITLE
Improve the performance of indirect jump for T1C

### DIFF
--- a/src/decode.h
+++ b/src/decode.h
@@ -278,9 +278,13 @@ typedef struct {
 
 #define HISTORY_SIZE 16
 typedef struct {
-    uint8_t idx;
     uint32_t PC[HISTORY_SIZE];
+#if !RV32_HAS(JIT)
+    uint8_t idx;
     struct rv_insn *target[HISTORY_SIZE];
+#else
+    uint32_t times[HISTORY_SIZE];
+#endif
 } branch_history_table_t;
 
 typedef struct rv_insn {

--- a/tools/gen-jit-template.py
+++ b/tools/gen-jit-template.py
@@ -254,6 +254,8 @@ for i in range(len(op)):
                 asm = "store_back(state);"
             elif items[0] == "assert":
                 asm = "assert(NULL);"
+            elif items[0] == "predict":
+                asm = "parse_branch_history_table(state, ir);"
             output += asm + "\n"
         output += "})\n"
 


### PR DESCRIPTION
Considering the T1C ends with the indirect jump, our interpreter mode now records the target of the indirect jump, identifying the most  frequent jump target for T1C. The T1 generated code for the indirect jump compares the selected jump target and executes the jump if the comparison results in equality. With this enhancement, T1C and T2C which are integrated later can proceed with an indirect jump if the target PC matches the selected jump target.

Based on the performance analysis, the benchmarks with significant number of indirect jump effectively improve the performance.

| Metric   | N_in_jmp  | Original | Propused | Speedup |
|----------|-----------|----------|----------|---------|
|miniz	   |    2098313|   1.266 s|   1.225 s|   +3.35%|
|sha512    |   10500727|   1.905 s|   1.861 s|   +2.36%|
|dhrystone |   20000618|   0.325 s|   0.253 s|  +28.46%|
|nqueens   |   44658722|   1.051 s|    0.79 s|  +33.04%|
|qsort	   |  275000250|   1.978 s|   1.517 s|  +30.39%|