### PR TITLE
Bind I/O handlers during emulator initialization

### DIFF
--- a/src/riscv.c
+++ b/src/riscv.c
@@ -155,15 +155,37 @@ void rv_remap_stdstream(riscv_t *rv, fd_stream_pair_t *fsp, uint32_t fsp_size)
     }
 }
 
-riscv_t *rv_create(const riscv_io_t *io, riscv_user_t rv_attr)
+#define MEMIO(op) on_mem_##op
+#define IO_HANDLER_IMPL(type, op, RW)                                     \
+    static IIF(RW)(                                                       \
+        /* W */ void MEMIO(op)(riscv_word_t addr, riscv_##type##_t data), \
+        /* R */ riscv_##type##_t MEMIO(op)(riscv_word_t addr))            \
+    {                                                                     \
+        IIF(RW)                                                           \
+        (memory_##op(addr, (uint8_t *) &data), return memory_##op(addr)); \
+    }
+
+#define R 0
+#define W 1
+
+IO_HANDLER_IMPL(word, ifetch, R)
+IO_HANDLER_IMPL(word, read_w, R)
+IO_HANDLER_IMPL(half, read_s, R)
+IO_HANDLER_IMPL(byte, read_b, R)
+
+IO_HANDLER_IMPL(word, write_w, W)
+IO_HANDLER_IMPL(half, write_s, W)
+IO_HANDLER_IMPL(byte, write_b, W)
+
+#undef R
+#undef W
+
+riscv_t *rv_create(riscv_user_t rv_attr)
 {
-    assert(io && rv_attr);
+    assert(rv_attr);
 
     riscv_t *rv = calloc(1, sizeof(riscv_t));
     assert(rv);
-
-    /* copy over the IO interface */
-    memcpy(&rv->io, io, sizeof(riscv_io_t));
 
     /* copy over the attr */
     rv->data = rv_attr;
@@ -190,6 +212,27 @@ riscv_t *rv_create(const riscv_io_t *io, riscv_user_t rv_attr)
         assert(rv_set_pc(rv, hdr->e_entry));
 
         elf_delete(elf);
+
+        /* install the I/O handlers */
+        const riscv_io_t io = {
+            /* memory read interface */
+            .mem_ifetch = MEMIO(ifetch),
+            .mem_read_w = MEMIO(read_w),
+            .mem_read_s = MEMIO(read_s),
+            .mem_read_b = MEMIO(read_b),
+
+            /* memory write interface */
+            .mem_write_w = MEMIO(write_w),
+            .mem_write_s = MEMIO(write_s),
+            .mem_write_b = MEMIO(write_b),
+
+            /* system services or essential routines */
+            .on_ecall = ecall_handler,
+            .on_ebreak = ebreak_handler,
+            .on_memcpy = memcpy_handler,
+            .on_memset = memset_handler,
+        };
+        memcpy(&rv->io, &io, sizeof(riscv_io_t));
     } else {
         /* TODO: system emulator */
     }

--- a/src/riscv.h
+++ b/src/riscv.h
@@ -139,6 +139,8 @@ typedef struct {
     riscv_mem_write_s mem_write_s;
     riscv_mem_write_b mem_write_b;
 
+    /* TODO: add peripheral I/O interfaces */
+
     /* system */
     riscv_on_ecall on_ecall;
     riscv_on_ebreak on_ebreak;
@@ -150,7 +152,7 @@ typedef struct {
 void rv_run(riscv_t *rv);
 
 /* create a RISC-V emulator */
-riscv_t *rv_create(const riscv_io_t *io, riscv_user_t attr);
+riscv_t *rv_create(riscv_user_t attr);
 
 /* delete a RISC-V emulator */
 void rv_delete(riscv_t *rv);


### PR DESCRIPTION
It is not required to give an application the opportunity to bind I/O handlers because I/O handlers are rarely altered during the creation of an emulator.

With this commit, the application can now build a emulator much more easier by only taking the emulator's attribute (vm_attr_t) into consideration.

In order to facilitate further integration with the RISC-V system emulator (semu), I have included a TODO inside the I/O interface.

Related: #310