### PR TITLE
Fix the microsecond-to-nanosecond conversion in rv_clock_gettime()

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -69,7 +69,7 @@ void rv_clock_gettime(struct timespec *tp)
     int32_t tv_sec, tv_usec;
     get_time_info(&tv_sec, &tv_usec);
     tp->tv_sec = tv_sec;
-    tp->tv_nsec = tv_usec / 1000; /* Transfer to microseconds */
+    tp->tv_nsec = tv_usec * 1000; /* Transfer to microseconds */
 }
 
 char *sanitize_path(const char *input)


### PR DESCRIPTION
A microsecond is 1000 times bigger than a nanosecond (10<sup>-6</sup> vs 10<sup>-9</sup> seconds). This commit corrects the conversion of microseconds to nanoseconds in `rv_clock_gettime()` by multiplying `tv_usec` by 1000 instead of dividing it.