### PR TITLE
CI: Add Clang static analyzer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,6 +117,23 @@ jobs:
             .ci/check-format.sh
       shell: bash
   
+  static-analysis:
+    needs: [detect-code-related-file-changes]
+    if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    # LLVM static analysis
+    - name: set up scan-build  
+      run: |
+            sudo apt-get update -q -y
+            sudo apt-get install -q -y clang clang-tools libsdl2-dev libsdl2-mixer-dev
+      shell: bash
+    - name: run scan-build without JIT
+      run: make clean && make distclean && scan-build -v -o ~/scan-build --status-bugs --use-cc=clang --force-analyze-debug-code --show-description -analyzer-config stable-report-filename=true -enable-checker valist,nullability make ENABLE_EXT_F=0 ENABLE_SDL=0 ENABLE_JIT=0
+    - name: run scan-build with JIT
+      run: make clean && make distclean && scan-build -v -o ~/scan-build --status-bugs --use-cc=clang --force-analyze-debug-code --show-description -analyzer-config stable-report-filename=true -enable-checker valist,nullability make ENABLE_EXT_F=0 ENABLE_SDL=0 ENABLE_JIT=1
+
   compliance-test:
     needs: [detect-code-related-file-changes]
     if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -755,6 +755,7 @@ static bool libc_substitute(riscv_t *rv, block_t *block)
          */
         if (IF_imm(ir, 15) && IF_rd(ir, t1) && IF_rs1(ir, zero)) {
             next_ir = ir->next;
+            assert(next_ir);
             if (IF_insn(next_ir, addi) && IF_rd(next_ir, a4) &&
                 IF_rs1(next_ir, a0) && IF_rs2(next_ir, zero)) {
                 next_ir = next_ir->next;
@@ -770,6 +771,7 @@ static bool libc_substitute(riscv_t *rv, block_t *block)
             }
         } else if (IF_imm(ir, 0) && IF_rd(ir, t1) && IF_rs1(ir, a0)) {
             next_ir = ir->next;
+            assert(next_ir);
             if (IF_insn(next_ir, beq) && IF_rs1(next_ir, a2) &&
                 IF_rs2(next_ir, zero)) {
                 if (IF_imm(next_ir, 20) && detect_memset(rv, 1)) {
@@ -795,6 +797,7 @@ static bool libc_substitute(riscv_t *rv, block_t *block)
          */
         if (IF_rd(ir, a5) && IF_rs1(ir, a0) && IF_rs2(ir, a1)) {
             next_ir = ir->next;
+            assert(next_ir);
             if (IF_insn(next_ir, andi) && IF_imm(next_ir, 3) &&
                 IF_rd(next_ir, a5) && IF_rs1(next_ir, a5)) {
                 next_ir = next_ir->next;
@@ -833,6 +836,7 @@ static void match_pattern(riscv_t *rv, block_t *block)
     rv_insn_t *ir;
     for (i = 0, ir = block->ir_head; i < block->n_insn - 1;
          i++, ir = ir->next) {
+        assert(ir);
         rv_insn_t *next_ir = NULL;
         int32_t count = 0;
         switch (ir->opcode) {

--- a/src/main.c
+++ b/src/main.c
@@ -35,7 +35,7 @@ static char *signature_out_file;
 static bool opt_quiet_outputs = false;
 
 /* target executable */
-static char *opt_prog_name = "a.out";
+static char *opt_prog_name;
 
 /* target argc and argv */
 static int prog_argc;

--- a/src/riscv.h
+++ b/src/riscv.h
@@ -228,7 +228,7 @@ typedef struct {
     char *elf_program;
 } vm_user_t;
 
-typedef union {
+typedef struct {
     vm_user_t *user;
     /* TODO: system emulator stuff */
 } vm_data_t;


### PR DESCRIPTION
The clang static analyzer is invoked by executing scan-build. 

If any issues are detected by scan-build, it will halt the pipeline. 
If halting the pipeline is not the desired behavior, remove the flag 
--status-bugs.

The analysis result can be viewed in the GitHub Action execution log.

Ubuntu-latest is used to enable us to utilize the latest version of the 
tool.

References:
- https://gitlab.xfce.org/xfce/xfce4-dev-tools/-/issues/51
- https://gitlab.com/gnuwget/wget2/-/blob/cabedf3847afd3926cbeaa67d4ee9f28f78979d9/.gitlab-ci.yml#L279

If you run scan-build locally, you can see the reports in HTML.
The report index page will look something like the following
<img width="1512" alt="Screenshot 2024-02-26 at 10 26 35 AM" src="https://github.com/sysprog21/rv32emu/assets/9054879/264f69bf-0c52-4570-a049-9eeb48607f68">

For each of the issue, the report will look something like the following
<img width="481" alt="Screenshot 2024-02-26 at 10 26 43 AM" src="https://github.com/sysprog21/rv32emu/assets/9054879/590d77aa-375c-4c9e-b2d6-6df0b8e773ab">