### PR TITLE
Fix reading uninitialized variable right_red in map.c (#349)

### DIFF
--- a/src/map.c
+++ b/src/map.c
@@ -548,7 +548,7 @@ static map_node_t *map_create_node(void *key,
                                    size_t ksize,
                                    size_t vsize)
 {
-    map_node_t *node = malloc(sizeof(map_node_t));
+    map_node_t *node = calloc(1, sizeof(map_node_t));
     assert(node);
 
     /* allocate memory for the keys and data */


### PR DESCRIPTION
The struct member right_red is used in several functions, such as  rb_node_set_right(). It has been reported by infer and LLVM static analyzer that right_red isn't initialized before being used.

By tracing the node initialization function calls (starting from `map_create_node`), it can be seen that `rb_node_set_right` is the function where `right_red` is attempted to be initialized, but we are indeed performing `&1` on an uninitialized value. 

In this commit, a change to using `calloc` guarantees the struct members will be zeroed out during allocation, which in terms serves as initialization.