### PR TITLE
Use the canonical order of RISC-V extension names

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,8 +57,8 @@ jobs:
       run: |
             make distclean ENABLE_EXT_M=0 check
             make distclean ENABLE_EXT_A=0 check
-            make distclean ENABLE_EXT_C=0 check
             make distclean ENABLE_EXT_F=0 check
+            make distclean ENABLE_EXT_C=0 check
             make distclean ENABLE_SDL=0 check
     - name: gdbstub test
       run: |
@@ -67,8 +67,8 @@ jobs:
       run: |
             make ENABLE_JIT=1 clean check
             make ENABLE_EXT_A=0 ENABLE_JIT=1 clean check
-            make ENABLE_EXT_C=0 ENABLE_JIT=1 clean check
             make ENABLE_EXT_F=0 ENABLE_JIT=1 clean check
+            make ENABLE_EXT_C=0 ENABLE_JIT=1 clean check
 
   host-arm64:
     needs: [detect-code-related-file-changes]
@@ -97,8 +97,8 @@ jobs:
           make check
           make ENABLE_JIT=1 clean check
           make ENABLE_EXT_A=0 ENABLE_JIT=1 clean check
-          make ENABLE_EXT_C=0 ENABLE_JIT=1 clean check
           make ENABLE_EXT_F=0 ENABLE_JIT=1 clean check
+          make ENABLE_EXT_C=0 ENABLE_JIT=1 clean check
 
   coding-style:
     needs: [detect-code-related-file-changes]

--- a/Makefile
+++ b/Makefile
@@ -35,14 +35,6 @@ CFLAGS += $(CFLAGS_NO_CET)
 
 OBJS_EXT :=
 
-# Control and Status Register (CSR)
-ENABLE_Zicsr ?= 1
-$(call set-feature, Zicsr)
-
-# Instruction-Fetch Fence
-ENABLE_Zifencei ?= 1
-$(call set-feature, Zifencei)
-
 # Integer Multiplication and Division instructions
 ENABLE_EXT_M ?= 1
 $(call set-feature, EXT_M)
@@ -50,10 +42,6 @@ $(call set-feature, EXT_M)
 # Atomic Instructions
 ENABLE_EXT_A ?= 1
 $(call set-feature, EXT_A)
-
-# Compressed extension instructions
-ENABLE_EXT_C ?= 1
-$(call set-feature, EXT_C)
 
 # Single-precision floating point instructions
 ENABLE_EXT_F ?= 1
@@ -73,6 +61,18 @@ $(OUT)/decode.o $(OUT)/riscv.o: $(SOFTFLOAT_LIB)
 LDFLAGS += $(SOFTFLOAT_LIB)
 LDFLAGS += -lm
 endif
+
+# Compressed extension instructions
+ENABLE_EXT_C ?= 1
+$(call set-feature, EXT_C)
+
+# Control and Status Register (CSR)
+ENABLE_Zicsr ?= 1
+$(call set-feature, Zicsr)
+
+# Instruction-Fetch Fence
+ENABLE_Zifencei ?= 1
+$(call set-feature, Zifencei)
 
 # Experimental SDL oriented system calls
 ENABLE_SDL ?= 1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RISC-V RV32I[MACF] emulator
+# RISC-V RV32I[MAFC] emulator
 ![GitHub Actions](https://github.com/sysprog21/rv32emu/actions/workflows/main.yml/badge.svg)
 ```
                        /--===============------\
@@ -24,7 +24,7 @@ a focus on efficiency and readability.
 
 Features:
 * Fast interpreter for executing the RV32 ISA
-* Comprehensive support for RV32I and M, A, C, F extensions
+* Comprehensive support for RV32I and M, A, F, C extensions
 * Memory-efficient design
 * Built-in ELF loader
 * Implementation of commonly used newlib system calls
@@ -75,8 +75,8 @@ The image containing all the necessary tools for development and testing can be 
 `rv32emu` is configurable, and you can override the below variable(s) to fit your expectations:
 * `ENABLE_EXT_M`: Standard Extension for Integer Multiplication and Division
 * `ENABLE_EXT_A`: Standard Extension for Atomic Instructions
-* `ENABLE_EXT_C`: Standard Extension for Compressed Instructions (RV32C.D excluded)
 * `ENABLE_EXT_F`: Standard Extension for Single-Precision Floating Point Instructions
+* `ENABLE_EXT_C`: Standard Extension for Compressed Instructions (RV32C.D excluded)
 * `ENABLE_Zicsr`: Control and Status Register (CSR)
 * `ENABLE_Zifencei`: Instruction-Fetch Fence
 * `ENABLE_GDBSTUB` : GDB remote debugging support

--- a/src/feature.h
+++ b/src/feature.h
@@ -17,14 +17,14 @@
 #define RV32_FEATURE_EXT_A 1
 #endif
 
-/* Standard Extension for Compressed Instructions */
-#ifndef RV32_FEATURE_EXT_C
-#define RV32_FEATURE_EXT_C 1
-#endif
-
 /* Standard Extension for Single-Precision Floating Point Instructions */
 #ifndef RV32_FEATURE_EXT_F
 #define RV32_FEATURE_EXT_F 1
+#endif
+
+/* Standard Extension for Compressed Instructions */
+#ifndef RV32_FEATURE_EXT_C
+#define RV32_FEATURE_EXT_C 1
 #endif
 
 /* Control and Status Register (CSR) */

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -467,9 +467,6 @@ void rv_reset(riscv_t *rv, riscv_word_t pc)
 #if RV32_HAS(EXT_C)
     rv->csr_misa |= MISA_C;
 #endif
-#if RV32_HAS(EXT_M)
-    rv->csr_misa |= MISA_M;
-#endif
 #if RV32_HAS(EXT_F)
     rv->csr_misa |= MISA_F;
     /* reset float registers */
@@ -477,6 +474,10 @@ void rv_reset(riscv_t *rv, riscv_word_t pc)
         rv->F[i].v = 0;
     rv->csr_fcsr = 0;
 #endif
+#if RV32_HAS(EXT_M)
+    rv->csr_misa |= MISA_M;
+#endif
+
 
     rv->halt = false;
 }


### PR DESCRIPTION
The RISC-V Instruction Set Manual Vol. 1 specifies the canonical order in which ISA extension names should appear in architecture name strings in [Table 1.1 of Chapter 27](https://five-embeddev.com/riscv-isa-manual/latest/naming.html#isanametable). However, the repository description and the code state that rv32emu supports `RV32IMACF`, whereas the correct string in canonical order should be `RV32IMAFC`.  This string may cause problems when used in some tools that need the canonical order of extensions, such as the `-march` option of GCC.

Close #359 