### PR TITLE
CI: Add undefined behavior test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,6 +69,10 @@ jobs:
             make ENABLE_EXT_A=0 ENABLE_JIT=1 clean check
             make ENABLE_EXT_F=0 ENABLE_JIT=1 clean check
             make ENABLE_EXT_C=0 ENABLE_JIT=1 clean check
+    - name: undefined behavior test
+      run: |
+            make ENABLE_UBSAN=1 clean check
+            make ENABLE_JIT=1 ENABLE_UBSAN=1 clean check
 
   host-arm64:
     needs: [detect-code-related-file-changes]

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,12 @@ ifeq ("$(CC_IS_EMCC)", "1")
 CFLAGS += -mtail-call
 endif
 
+ENABLE_UBSAN ?= 0
+ifeq ("$(ENABLE_UBSAN)", "1")
+CFLAGS += -fsanitize=undefined -fno-sanitize=alignment -fno-sanitize-recover=all
+LDFLAGS += -fsanitize=undefined -fno-sanitize=alignment -fno-sanitize-recover=all
+endif
+
 $(OUT)/emulate.o: CFLAGS += -foptimize-sibling-calls -fomit-frame-pointer -fno-stack-check -fno-stack-protector
 
 # Clear the .DEFAULT_GOAL special variable, so that the following turns


### PR DESCRIPTION
Introduce the utilization of UBSan (Undefined Behavior Sanitizer) to identify any instances of undefined behavior within the codebase. The CI pipeline now includes tests specifically designed to catch such behavior. Additionally, slight adjustments have been made to the Makefile for this purpose.

See: #324 