### PR TITLE
Fix RV32A error

### DIFF
--- a/src/rv32_constopt.c
+++ b/src/rv32_constopt.c
@@ -554,37 +554,67 @@ CONSTOPT(remu, {
 #if RV32_HAS(EXT_A)
 
 /* LR.W: Load Reserved */
-CONSTOPT(lrw, {})
+CONSTOPT(lrw, {
+    if (ir->rd)
+        info->is_constant[ir->rd] = false;
+})
 
 /* SC.W: Store Conditional */
 CONSTOPT(scw, {})
 
 /* AMOSWAP.W: Atomic Swap */
-CONSTOPT(amoswapw, {})
+CONSTOPT(amoswapw, {
+    if (ir->rd)
+        info->is_constant[ir->rd] = false;
+})
 
 /* AMOADD.W: Atomic ADD */
-CONSTOPT(amoaddw, {})
+CONSTOPT(amoaddw, {
+    if (ir->rd)
+        info->is_constant[ir->rd] = false;
+})
 
 /* AMOXOR.W: Atomic XOR */
-CONSTOPT(amoxorw, {})
+CONSTOPT(amoxorw, {
+    if (ir->rd)
+        info->is_constant[ir->rd] = false;
+})
 
 /* AMOAND.W: Atomic AND */
-CONSTOPT(amoandw, {})
+CONSTOPT(amoandw, {
+    if (ir->rd)
+        info->is_constant[ir->rd] = false;
+})
 
 /* AMOOR.W: Atomic OR */
-CONSTOPT(amoorw, {})
+CONSTOPT(amoorw, {
+    if (ir->rd)
+        info->is_constant[ir->rd] = false;
+})
 
 /* AMOMIN.W: Atomic MIN */
-CONSTOPT(amominw, {})
+CONSTOPT(amominw, {
+    if (ir->rd)
+        info->is_constant[ir->rd] = false;
+})
 
 /* AMOMAX.W: Atomic MAX */
-CONSTOPT(amomaxw, {})
+CONSTOPT(amomaxw, {
+    if (ir->rd)
+        info->is_constant[ir->rd] = false;
+})
 
 /* AMOMINU.W */
-CONSTOPT(amominuw, {})
+CONSTOPT(amominuw, {
+    if (ir->rd)
+        info->is_constant[ir->rd] = false;
+})
 
 /* AMOMAXU.W */
-CONSTOPT(amomaxuw, {})
+CONSTOPT(amomaxuw, {
+    if (ir->rd)
+        info->is_constant[ir->rd] = false;
+})
 #endif /* RV32_HAS(EXT_A) */
 
 /* RV32F Standard Extension */

--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -1320,7 +1320,8 @@ GEN({
 RVOP(
     lrw,
     {
-        rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
+        if (ir->rd)
+            rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
         /* skip registration of the 'reservation set'
          * FIXME: uimplemented
          */
@@ -1347,7 +1348,8 @@ RVOP(
 RVOP(
     amoswapw,
     {
-        rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
+        if (ir->rd)
+            rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
         rv->io.mem_write_s(ir->rs1, rv->X[ir->rs2]);
     },
     GEN({
@@ -1358,7 +1360,8 @@ RVOP(
 RVOP(
     amoaddw,
     {
-        rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
+        if (ir->rd)
+            rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
         const int32_t res = (int32_t) rv->X[ir->rd] + (int32_t) rv->X[ir->rs2];
         rv->io.mem_write_s(ir->rs1, res);
     },
@@ -1370,7 +1373,8 @@ RVOP(
 RVOP(
     amoxorw,
     {
-        rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
+        if (ir->rd)
+            rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
         const int32_t res = rv->X[ir->rd] ^ rv->X[ir->rs2];
         rv->io.mem_write_s(ir->rs1, res);
     },
@@ -1382,7 +1386,8 @@ RVOP(
 RVOP(
     amoandw,
     {
-        rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
+        if (ir->rd)
+            rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
         const int32_t res = rv->X[ir->rd] & rv->X[ir->rs2];
         rv->io.mem_write_s(ir->rs1, res);
     },
@@ -1394,7 +1399,8 @@ RVOP(
 RVOP(
     amoorw,
     {
-        rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
+        if (ir->rd)
+            rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
         const int32_t res = rv->X[ir->rd] | rv->X[ir->rs2];
         rv->io.mem_write_s(ir->rs1, res);
     },
@@ -1406,7 +1412,8 @@ RVOP(
 RVOP(
     amominw,
     {
-        rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
+        if (ir->rd)
+            rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
         const int32_t a = rv->X[ir->rd];
         const int32_t b = rv->X[ir->rs2];
         const uint32_t res = a < b ? rv->X[ir->rd] : rv->X[ir->rs2];
@@ -1420,7 +1427,8 @@ RVOP(
 RVOP(
     amomaxw,
     {
-        rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
+        if (ir->rd)
+            rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
         const int32_t a = rv->X[ir->rd];
         const int32_t b = rv->X[ir->rs2];
         const uint32_t res = a > b ? rv->X[ir->rd] : rv->X[ir->rs2];
@@ -1434,7 +1442,8 @@ RVOP(
 RVOP(
     amominuw,
     {
-        rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
+        if (ir->rd)
+            rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
         const uint32_t ures =
             rv->X[ir->rd] < rv->X[ir->rs2] ? rv->X[ir->rd] : rv->X[ir->rs2];
         rv->io.mem_write_s(ir->rs1, ures);
@@ -1447,7 +1456,8 @@ RVOP(
 RVOP(
     amomaxuw,
     {
-        rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
+        if (ir->rd)
+            rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
         const uint32_t ures =
             rv->X[ir->rd] > rv->X[ir->rs2] ? rv->X[ir->rd] : rv->X[ir->rs2];
         rv->io.mem_write_s(ir->rs1, ures);


### PR DESCRIPTION
Fix a potential issue where A extension instructions could inadvertently write to the x0 register, ensuring that such instructions do not modify the x0 register. Additionally, address a requirement to handle RV32A instructions that may perform register writes during constant optimization. Given the possibility of these instructions modifying registers, it's crucial to incorporate appropriate handling for such cases within constant optimization routines.