### PR TITLE
Fix compile warning in JIT without RV32F/C

### DIFF
--- a/tools/gen-jit-template.py
+++ b/tools/gen-jit-template.py
@@ -95,6 +95,12 @@ INSN = {
         "cadd",
         "cswsp",
     ],
+    "EXT_FC": [
+        "cflwsp",
+        "cfswsp",
+        "cflw",
+        "cfsw",
+    ],
 }
 EXT_LIST = ["Zifencei", "Zicsr", "EXT_M", "EXT_A", "EXT_F", "EXT_C"]
 SKIP_LIST = []
@@ -109,6 +115,8 @@ def parse_argv(EXT_LIST, SKIP_LIST):
                 EXT_LIST.remove(ext)
     for ext in EXT_LIST:
         SKIP_LIST += INSN[ext]
+    if "EXT_F" in EXT_LIST or "EXT_C" in EXT_LIST:
+        SKIP_LIST += INSN["EXT_FC"]
 
 parse_argv(EXT_LIST, SKIP_LIST)
 # prepare PROLOGUE


### PR DESCRIPTION
Fix warnings in JIT compiler caused by unused functions 'do_cfsw', 'do_cflw', 'do_cfswsp', and 'do_cflwsp' when JIT compiler is enabled without F or C extensions.