### PR TITLE
Introduce Valgrind to the CI pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,7 @@ jobs:
     - name: install-dependencies
       run: |
             sudo apt-get update -q -y
-            sudo apt-get install -q -y libsdl2-dev libsdl2-mixer-dev
+            sudo apt-get install -q -y libsdl2-dev libsdl2-mixer-dev valgrind
             .ci/riscv-toolchain-install.sh
             wget https://apt.llvm.org/llvm.sh
             sudo chmod +x ./llvm.sh
@@ -119,6 +119,16 @@ jobs:
       run: |
             make clean && make ENABLE_UBSAN=1 check -j$(nproc)
             make ENABLE_JIT=1 clean && make ENABLE_JIT=1 ENABLE_UBSAN=1 check -j$(nproc)
+    - name: valgrind check (without JIT)
+      run: |
+            make clean && make ENABLE_SDL=0 ENABLE_JIT=0 ENABLE_VALGRIND=1
+            valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./build/rv32emu ./build/hello.elf 
+            valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./build/rv32emu ./build/aes.elf 
+    - name: valgrind check (with JIT)
+      run: |
+            make clean && make ENABLE_SDL=0 ENABLE_JIT=1 ENABLE_VALGRIND=1
+            valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./build/rv32emu ./build/hello.elf 
+            valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./build/rv32emu ./build/aes.elf 
 
   host-arm64:
     needs: [detect-code-related-file-changes]

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,14 @@ CFLAGS = -std=gnu99 -O2 -Wall -Wextra
 CFLAGS += -Wno-unused-label
 CFLAGS += -include src/common.h
 
+ENABLE_VALGRIND ?= 0
+ifeq ("$(ENABLE_UBSAN)", "1")
+# according to gcc's man page: "If you use multiple -O options, with or without level numbers, the last such option is the one that is effective."
+# In order to use Valgrind, we need to compile with -g
+CFLAGS += -g
+LDFLAGS += -g
+endif
+
 # Enable link-time optimization (LTO)
 ENABLE_LTO ?= 1
 ifeq ($(call has, LTO), 1)


### PR DESCRIPTION
The static analyzer alone can't catch all the runtime issues. In this commit, the dynamic analysis tool Valgrind is added to the CI pipeline.

ENABLE_SDL is set to 0, in order to reduce noise caused by the external
libraries.

Reference:
- https://valgrind.org/docs/manual/quick-start.html
- https://linux.die.net/man/1/gcc