### PR TITLE
End the indirect jump when potential hotspot is detected

### DIFF
--- a/src/emulate.c
+++ b/src/emulate.c
@@ -399,12 +399,14 @@ static bool has_loops = false;
     nextop:                                                           \
         PC += __rv_insn_##inst##_len;                                 \
         if (unlikely(RVOP_NO_NEXT(ir))) {                             \
-            rv->csr_cycle = cycle;                                    \
-            rv->PC = PC;                                              \
-            return true;                                              \
+            goto end_op;                                              \
         }                                                             \
         const rv_insn_t *next = ir->next;                             \
         MUST_TAIL return next->impl(rv, next, cycle, PC);             \
+    end_op:                                                           \
+        rv->csr_cycle = cycle;                                        \
+        rv->PC = PC;                                                  \
+        return true;                                                  \
     }
 
 #include "rv32_template.c"


### PR DESCRIPTION
Currently, the indirect jump does not switch to T1C when potential hotspot is detected, it would make execution stuck in interpreter mode. This modification make execution end when potential hotspot is detected.