### PR TITLE
Fix several critical errors in RV32A implementations

### DIFF
--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -1351,7 +1351,7 @@ RVOP(
     {
         if (ir->rd)
             rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
-        rv->io.mem_write_s(rv->X[ir->rs1], rv->X[ir->rs2]);
+        rv->io.mem_write_w(rv->X[ir->rs1], rv->X[ir->rs2]);
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1364,7 +1364,7 @@ RVOP(
         if (ir->rd)
             rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
         const int32_t res = (int32_t) rv->X[ir->rd] + (int32_t) rv->X[ir->rs2];
-        rv->io.mem_write_s(rv->X[ir->rs1], res);
+        rv->io.mem_write_w(rv->X[ir->rs1], res);
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1377,7 +1377,7 @@ RVOP(
         if (ir->rd)
             rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
         const int32_t res = rv->X[ir->rd] ^ rv->X[ir->rs2];
-        rv->io.mem_write_s(rv->X[ir->rs1], res);
+        rv->io.mem_write_w(rv->X[ir->rs1], res);
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1390,7 +1390,7 @@ RVOP(
         if (ir->rd)
             rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
         const int32_t res = rv->X[ir->rd] & rv->X[ir->rs2];
-        rv->io.mem_write_s(rv->X[ir->rs1], res);
+        rv->io.mem_write_w(rv->X[ir->rs1], res);
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1403,7 +1403,7 @@ RVOP(
         if (ir->rd)
             rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
         const int32_t res = rv->X[ir->rd] | rv->X[ir->rs2];
-        rv->io.mem_write_s(rv->X[ir->rs1], res);
+        rv->io.mem_write_w(rv->X[ir->rs1], res);
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1418,7 +1418,7 @@ RVOP(
         const int32_t a = rv->X[ir->rd];
         const int32_t b = rv->X[ir->rs2];
         const uint32_t res = a < b ? rv->X[ir->rd] : rv->X[ir->rs2];
-        rv->io.mem_write_s(rv->X[ir->rs1], res);
+        rv->io.mem_write_w(rv->X[ir->rs1], res);
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1433,7 +1433,7 @@ RVOP(
         const int32_t a = rv->X[ir->rd];
         const int32_t b = rv->X[ir->rs2];
         const uint32_t res = a > b ? rv->X[ir->rd] : rv->X[ir->rs2];
-        rv->io.mem_write_s(rv->X[ir->rs1], res);
+        rv->io.mem_write_w(rv->X[ir->rs1], res);
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1447,7 +1447,7 @@ RVOP(
             rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
         const uint32_t ures =
             rv->X[ir->rd] < rv->X[ir->rs2] ? rv->X[ir->rd] : rv->X[ir->rs2];
-        rv->io.mem_write_s(rv->X[ir->rs1], ures);
+        rv->io.mem_write_w(rv->X[ir->rs1], ures);
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1461,7 +1461,7 @@ RVOP(
             rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
         const uint32_t ures =
             rv->X[ir->rd] > rv->X[ir->rs2] ? rv->X[ir->rd] : rv->X[ir->rs2];
-        rv->io.mem_write_s(rv->X[ir->rs1], ures);
+        rv->io.mem_write_w(rv->X[ir->rs1], ures);
     },
     GEN({
         assert; /* FIXME: Implement */

--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -1349,9 +1349,12 @@ RVOP(
 RVOP(
     amoswapw,
     {
+        const uint32_t addr = rv->X[ir->rs1];
+        const uint32_t value1 = rv->io.mem_read_w(rv->X[ir->rs1]);
+        const uint32_t value2 = rv->X[ir->rs2];
         if (ir->rd)
-            rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
-        rv->io.mem_write_w(rv->X[ir->rs1], rv->X[ir->rs2]);
+            rv->X[ir->rd] = value1;
+        rv->io.mem_write_w(addr, value2);
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1361,10 +1364,13 @@ RVOP(
 RVOP(
     amoaddw,
     {
+        const uint32_t addr = rv->X[ir->rs1];
+        const uint32_t value1 = rv->io.mem_read_w(rv->X[ir->rs1]);
+        const uint32_t value2 = rv->X[ir->rs2];
         if (ir->rd)
-            rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
-        const uint32_t res = rv->X[ir->rd] + rv->X[ir->rs2];
-        rv->io.mem_write_w(rv->X[ir->rs1], res);
+            rv->X[ir->rd] = value1;
+        const uint32_t res = value1 + value2;
+        rv->io.mem_write_w(addr, res);
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1374,10 +1380,13 @@ RVOP(
 RVOP(
     amoxorw,
     {
+        const uint32_t addr = rv->X[ir->rs1];
+        const uint32_t value1 = rv->io.mem_read_w(rv->X[ir->rs1]);
+        const uint32_t value2 = rv->X[ir->rs2];
         if (ir->rd)
-            rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
-        const uint32_t res = rv->X[ir->rd] ^ rv->X[ir->rs2];
-        rv->io.mem_write_w(rv->X[ir->rs1], res);
+            rv->X[ir->rd] = value1;
+        const uint32_t res = value1 ^ value2;
+        rv->io.mem_write_w(addr, res);
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1387,10 +1396,13 @@ RVOP(
 RVOP(
     amoandw,
     {
+        const uint32_t addr = rv->X[ir->rs1];
+        const uint32_t value1 = rv->io.mem_read_w(rv->X[ir->rs1]);
+        const uint32_t value2 = rv->X[ir->rs2];
         if (ir->rd)
-            rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
-        const uint32_t res = rv->X[ir->rd] & rv->X[ir->rs2];
-        rv->io.mem_write_w(rv->X[ir->rs1], res);
+            rv->X[ir->rd] = value1;
+        const uint32_t res = value1 & value2;
+        rv->io.mem_write_w(addr, res);
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1400,10 +1412,13 @@ RVOP(
 RVOP(
     amoorw,
     {
+        const uint32_t addr = rv->X[ir->rs1];
+        const uint32_t value1 = rv->io.mem_read_w(rv->X[ir->rs1]);
+        const uint32_t value2 = rv->X[ir->rs2];
         if (ir->rd)
-            rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
-        const uint32_t res = rv->X[ir->rd] | rv->X[ir->rs2];
-        rv->io.mem_write_w(rv->X[ir->rs1], res);
+            rv->X[ir->rd] = value1;
+        const uint32_t res = value1 | value2;
+        rv->io.mem_write_w(addr, res);
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1413,12 +1428,15 @@ RVOP(
 RVOP(
     amominw,
     {
+        const uint32_t addr = rv->X[ir->rs1];
+        const uint32_t value1 = rv->io.mem_read_w(rv->X[ir->rs1]);
+        const uint32_t value2 = rv->X[ir->rs2];
         if (ir->rd)
-            rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
-        const int32_t a = rv->X[ir->rd];
-        const int32_t b = rv->X[ir->rs2];
-        const uint32_t res = a < b ? rv->X[ir->rd] : rv->X[ir->rs2];
-        rv->io.mem_write_w(rv->X[ir->rs1], res);
+            rv->X[ir->rd] = value1;
+        const int32_t a = value1;
+        const int32_t b = value2;
+        const uint32_t res = a < b ? value1 : value2;
+        rv->io.mem_write_w(addr, res);
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1428,12 +1446,15 @@ RVOP(
 RVOP(
     amomaxw,
     {
+        const uint32_t addr = rv->X[ir->rs1];
+        const uint32_t value1 = rv->io.mem_read_w(rv->X[ir->rs1]);
+        const uint32_t value2 = rv->X[ir->rs2];
         if (ir->rd)
-            rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
-        const int32_t a = rv->X[ir->rd];
-        const int32_t b = rv->X[ir->rs2];
-        const uint32_t res = a > b ? rv->X[ir->rd] : rv->X[ir->rs2];
-        rv->io.mem_write_w(rv->X[ir->rs1], res);
+            rv->X[ir->rd] = value1;
+        const int32_t a = value1;
+        const int32_t b = value2;
+        const uint32_t res = a > b ? value1 : value2;
+        rv->io.mem_write_w(addr, res);
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1443,11 +1464,13 @@ RVOP(
 RVOP(
     amominuw,
     {
+        const uint32_t addr = rv->X[ir->rs1];
+        const uint32_t value1 = rv->io.mem_read_w(rv->X[ir->rs1]);
+        const uint32_t value2 = rv->X[ir->rs2];
         if (ir->rd)
-            rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
-        const uint32_t ures =
-            rv->X[ir->rd] < rv->X[ir->rs2] ? rv->X[ir->rd] : rv->X[ir->rs2];
-        rv->io.mem_write_w(rv->X[ir->rs1], ures);
+            rv->X[ir->rd] = value1;
+        const uint32_t ures = value1 < value2 ? value1 : value2;
+        rv->io.mem_write_w(addr, ures);
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1457,11 +1480,13 @@ RVOP(
 RVOP(
     amomaxuw,
     {
+        const uint32_t addr = rv->X[ir->rs1];
+        const uint32_t value1 = rv->io.mem_read_w(rv->X[ir->rs1]);
+        const uint32_t value2 = rv->X[ir->rs2];
         if (ir->rd)
-            rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
-        const uint32_t ures =
-            rv->X[ir->rd] > rv->X[ir->rs2] ? rv->X[ir->rd] : rv->X[ir->rs2];
-        rv->io.mem_write_w(rv->X[ir->rs1], ures);
+            rv->X[ir->rd] = value1;
+        const uint32_t ures = value1 > value2 ? value1 : value2;
+        rv->io.mem_write_w(addr, ures);
     },
     GEN({
         assert; /* FIXME: Implement */

--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -1350,8 +1350,8 @@ RVOP(
     amoswapw,
     {
         if (ir->rd)
-            rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
-        rv->io.mem_write_s(ir->rs1, rv->X[ir->rs2]);
+            rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
+        rv->io.mem_write_s(rv->X[ir->rs1], rv->X[ir->rs2]);
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1362,9 +1362,9 @@ RVOP(
     amoaddw,
     {
         if (ir->rd)
-            rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
+            rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
         const int32_t res = (int32_t) rv->X[ir->rd] + (int32_t) rv->X[ir->rs2];
-        rv->io.mem_write_s(ir->rs1, res);
+        rv->io.mem_write_s(rv->X[ir->rs1], res);
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1375,9 +1375,9 @@ RVOP(
     amoxorw,
     {
         if (ir->rd)
-            rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
+            rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
         const int32_t res = rv->X[ir->rd] ^ rv->X[ir->rs2];
-        rv->io.mem_write_s(ir->rs1, res);
+        rv->io.mem_write_s(rv->X[ir->rs1], res);
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1388,9 +1388,9 @@ RVOP(
     amoandw,
     {
         if (ir->rd)
-            rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
+            rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
         const int32_t res = rv->X[ir->rd] & rv->X[ir->rs2];
-        rv->io.mem_write_s(ir->rs1, res);
+        rv->io.mem_write_s(rv->X[ir->rs1], res);
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1401,9 +1401,9 @@ RVOP(
     amoorw,
     {
         if (ir->rd)
-            rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
+            rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
         const int32_t res = rv->X[ir->rd] | rv->X[ir->rs2];
-        rv->io.mem_write_s(ir->rs1, res);
+        rv->io.mem_write_s(rv->X[ir->rs1], res);
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1414,11 +1414,11 @@ RVOP(
     amominw,
     {
         if (ir->rd)
-            rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
+            rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
         const int32_t a = rv->X[ir->rd];
         const int32_t b = rv->X[ir->rs2];
         const uint32_t res = a < b ? rv->X[ir->rd] : rv->X[ir->rs2];
-        rv->io.mem_write_s(ir->rs1, res);
+        rv->io.mem_write_s(rv->X[ir->rs1], res);
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1429,11 +1429,11 @@ RVOP(
     amomaxw,
     {
         if (ir->rd)
-            rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
+            rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
         const int32_t a = rv->X[ir->rd];
         const int32_t b = rv->X[ir->rs2];
         const uint32_t res = a > b ? rv->X[ir->rd] : rv->X[ir->rs2];
-        rv->io.mem_write_s(ir->rs1, res);
+        rv->io.mem_write_s(rv->X[ir->rs1], res);
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1444,10 +1444,10 @@ RVOP(
     amominuw,
     {
         if (ir->rd)
-            rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
+            rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
         const uint32_t ures =
             rv->X[ir->rd] < rv->X[ir->rs2] ? rv->X[ir->rd] : rv->X[ir->rs2];
-        rv->io.mem_write_s(ir->rs1, ures);
+        rv->io.mem_write_s(rv->X[ir->rs1], ures);
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1458,10 +1458,10 @@ RVOP(
     amomaxuw,
     {
         if (ir->rd)
-            rv->X[ir->rd] = rv->io.mem_read_w(ir->rs1);
+            rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
         const uint32_t ures =
             rv->X[ir->rd] > rv->X[ir->rs2] ? rv->X[ir->rd] : rv->X[ir->rs2];
-        rv->io.mem_write_s(ir->rs1, ures);
+        rv->io.mem_write_s(rv->X[ir->rs1], ures);
     },
     GEN({
         assert; /* FIXME: Implement */

--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -1363,7 +1363,7 @@ RVOP(
     {
         if (ir->rd)
             rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
-        const int32_t res = (int32_t) rv->X[ir->rd] + (int32_t) rv->X[ir->rs2];
+        const uint32_t res = rv->X[ir->rd] + rv->X[ir->rs2];
         rv->io.mem_write_w(rv->X[ir->rs1], res);
     },
     GEN({
@@ -1376,7 +1376,7 @@ RVOP(
     {
         if (ir->rd)
             rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
-        const int32_t res = rv->X[ir->rd] ^ rv->X[ir->rs2];
+        const uint32_t res = rv->X[ir->rd] ^ rv->X[ir->rs2];
         rv->io.mem_write_w(rv->X[ir->rs1], res);
     },
     GEN({
@@ -1389,7 +1389,7 @@ RVOP(
     {
         if (ir->rd)
             rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
-        const int32_t res = rv->X[ir->rd] & rv->X[ir->rs2];
+        const uint32_t res = rv->X[ir->rd] & rv->X[ir->rs2];
         rv->io.mem_write_w(rv->X[ir->rs1], res);
     },
     GEN({
@@ -1402,7 +1402,7 @@ RVOP(
     {
         if (ir->rd)
             rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
-        const int32_t res = rv->X[ir->rd] | rv->X[ir->rs2];
+        const uint32_t res = rv->X[ir->rd] | rv->X[ir->rs2];
         rv->io.mem_write_w(rv->X[ir->rs1], res);
     },
     GEN({

--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -1321,8 +1321,10 @@ GEN({
 RVOP(
     lrw,
     {
+        const uint32_t addr = rv->X[ir->rs1];
+        RV_EXC_MISALIGN_HANDLER(3, load, false, 1);
         if (ir->rd)
-            rv->X[ir->rd] = rv->io.mem_read_w(rv->X[ir->rs1]);
+            rv->X[ir->rd] = rv->io.mem_read_w(addr);
         /* skip registration of the 'reservation set'
          * FIXME: uimplemented
          */
@@ -1338,7 +1340,9 @@ RVOP(
         /* assume the 'reservation set' is valid
          * FIXME: unimplemented
          */
-        rv->io.mem_write_w(rv->X[ir->rs1], rv->X[ir->rs2]);
+        const uint32_t addr = rv->X[ir->rs1];
+        RV_EXC_MISALIGN_HANDLER(3, store, false, 1);
+        rv->io.mem_write_w(addr, rv->X[ir->rs2]);
         rv->X[ir->rd] = 0;
     },
     GEN({
@@ -1350,6 +1354,7 @@ RVOP(
     amoswapw,
     {
         const uint32_t addr = rv->X[ir->rs1];
+        RV_EXC_MISALIGN_HANDLER(3, load, false, 1);
         const uint32_t value1 = rv->io.mem_read_w(rv->X[ir->rs1]);
         const uint32_t value2 = rv->X[ir->rs2];
         if (ir->rd)
@@ -1365,6 +1370,7 @@ RVOP(
     amoaddw,
     {
         const uint32_t addr = rv->X[ir->rs1];
+        RV_EXC_MISALIGN_HANDLER(3, load, false, 1);
         const uint32_t value1 = rv->io.mem_read_w(rv->X[ir->rs1]);
         const uint32_t value2 = rv->X[ir->rs2];
         if (ir->rd)
@@ -1381,6 +1387,7 @@ RVOP(
     amoxorw,
     {
         const uint32_t addr = rv->X[ir->rs1];
+        RV_EXC_MISALIGN_HANDLER(3, load, false, 1);
         const uint32_t value1 = rv->io.mem_read_w(rv->X[ir->rs1]);
         const uint32_t value2 = rv->X[ir->rs2];
         if (ir->rd)
@@ -1397,6 +1404,7 @@ RVOP(
     amoandw,
     {
         const uint32_t addr = rv->X[ir->rs1];
+        RV_EXC_MISALIGN_HANDLER(3, load, false, 1);
         const uint32_t value1 = rv->io.mem_read_w(rv->X[ir->rs1]);
         const uint32_t value2 = rv->X[ir->rs2];
         if (ir->rd)
@@ -1413,6 +1421,7 @@ RVOP(
     amoorw,
     {
         const uint32_t addr = rv->X[ir->rs1];
+        RV_EXC_MISALIGN_HANDLER(3, load, false, 1);
         const uint32_t value1 = rv->io.mem_read_w(rv->X[ir->rs1]);
         const uint32_t value2 = rv->X[ir->rs2];
         if (ir->rd)
@@ -1429,6 +1438,7 @@ RVOP(
     amominw,
     {
         const uint32_t addr = rv->X[ir->rs1];
+        RV_EXC_MISALIGN_HANDLER(3, load, false, 1);
         const uint32_t value1 = rv->io.mem_read_w(rv->X[ir->rs1]);
         const uint32_t value2 = rv->X[ir->rs2];
         if (ir->rd)
@@ -1447,6 +1457,7 @@ RVOP(
     amomaxw,
     {
         const uint32_t addr = rv->X[ir->rs1];
+        RV_EXC_MISALIGN_HANDLER(3, load, false, 1);
         const uint32_t value1 = rv->io.mem_read_w(rv->X[ir->rs1]);
         const uint32_t value2 = rv->X[ir->rs2];
         if (ir->rd)
@@ -1465,6 +1476,7 @@ RVOP(
     amominuw,
     {
         const uint32_t addr = rv->X[ir->rs1];
+        RV_EXC_MISALIGN_HANDLER(3, load, false, 1);
         const uint32_t value1 = rv->io.mem_read_w(rv->X[ir->rs1]);
         const uint32_t value2 = rv->X[ir->rs2];
         if (ir->rd)
@@ -1481,6 +1493,7 @@ RVOP(
     amomaxuw,
     {
         const uint32_t addr = rv->X[ir->rs1];
+        RV_EXC_MISALIGN_HANDLER(3, load, false, 1);
         const uint32_t value1 = rv->io.mem_read_w(rv->X[ir->rs1]);
         const uint32_t value2 = rv->X[ir->rs2];
         if (ir->rd)


### PR DESCRIPTION
Addressed multiple critical issues in RV32A instruction implementations, including fixing memory address fetching errors, ensuring correct byte writing to memory (instead of half bytes), resolving arithmetic operation overflow problems, fixing incorrect values written to memory, and implementing memory address alignment checks.