### PR TITLE
Add RV32A architectural tests

### DIFF
--- a/.ci/riscv-tests.sh
+++ b/.ci/riscv-tests.sh
@@ -17,3 +17,4 @@ make arch-test RISCV_DEVICE=FCZicsr || exit 1
 make arch-test RISCV_DEVICE=IZifencei || exit 1
 make arch-test RISCV_DEVICE=IZicsr || exit 1
 make arch-test RISCV_DEVICE=FZicsr || exit 1
+make arch-test RISCV_DEVICE=IMA || exit 1

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ For macOS users, installing `sdiff` might be required:
 $ brew install diffutils
 ```
 
-To run the tests for specific extension, set the environmental variable `RISCV_DEVICE` to one of `I`, `M`, `C`, `Zifencei`, `privilege`.
+To run the tests for specific extension, set the environmental variable `RISCV_DEVICE` to one of `I`, `M`, `A`, `F`, `C`, `Zifencei`, `privilege`.
 ```shell
 $ make arch-test RISCV_DEVICE=I
 ```
@@ -137,10 +137,11 @@ Current progress of this emulator in riscv-arch-test (RV32):
 * Passed Tests
     - `I`: Base Integer Instruction Set
     - `M`: Standard Extension for Integer Multiplication and Division
+    - `A`: Standard Extension for Atomic Instructions
+    - `F` Standard Extension for Single-Precision Floating-Point
     - `C`: Standard Extension for Compressed Instruction
     - `Zifencei`: Instruction-Fetch Fence
     - `privilege`: RISCV Privileged Specification
-    - `F` Standard Extension for Single-Precision Floating-Point
 
 Detail in riscv-arch-test:
 * [RISCOF document](https://riscof.readthedocs.io/en/stable/)

--- a/mk/riscv-arch-test.mk
+++ b/mk/riscv-arch-test.mk
@@ -3,7 +3,7 @@ ARCH_TEST_SUITE ?= $(ARCH_TEST_DIR)/riscv-test-suite
 export RISCV_TARGET := tests/arch-test-target
 export TARGETDIR := $(shell pwd)
 export WORK := $(TARGETDIR)/build/arch-test
-export RISCV_DEVICE ?= IMCZicsrZifencei
+export RISCV_DEVICE ?= IMACFZicsrZifencei
 
 ifeq ($(RISCV_DEVICE),FCZicsr)
 ARCH_TEST_SUITE := tests/rv32fc-test-suite

--- a/tests/arch-test-target/constants.py
+++ b/tests/arch-test-target/constants.py
@@ -6,6 +6,7 @@ refname = 'sail_cSim'
 root = os.path.abspath(os.path.dirname(__file__))
 cwd = os.getcwd()
 
+misa_A = (1 << 0)
 misa_C = (1 << 2)
 misa_F = (1 << 5)
 misa_M = (1 << 12)

--- a/tests/arch-test-target/setup.py
+++ b/tests/arch-test-target/setup.py
@@ -15,6 +15,9 @@ def setup_testlist(riscv_device):
     if 'M' in riscv_device:
         misa |= constants.misa_M
         ISA += 'M'
+    if 'A' in riscv_device:
+        misa |= constants.misa_A
+        ISA += 'A'
     if 'F' in riscv_device:
         misa |= constants.misa_F
         ISA += 'F'
@@ -55,7 +58,7 @@ def setup_config():
 if __name__=="__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--riscv_device', help='the ISA will test',
-                        default='IMCZicsrZifencei')
+                        default='IMACZicsrZifencei')
     args = parser.parse_args()
 
     setup_testlist(args.riscv_device)


### PR DESCRIPTION
Introduce architectural tests for RV32A and integrate them into the CI pipeline. To facilitate RV32A testing, the riscv-arch-test version has been updated to v3.8.9. Additionally, the README has been updated to accurately reflect the inclusion of RV32A tests in the testing suite. This ensures thorough testing coverage and enhances the overall reliability and compatibility of the project.

Note: Depends on #373 to pass the tests.