### PR TITLE
Tweak build rules for WebAssembly

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -168,7 +168,10 @@ static void dump_test_signature(const char *prog_name)
     elf_delete(elf);
 }
 
-#define MEM_SIZE 0xFFFFFFFFULL  /* 2^32 - 1 */
+/* MEM_SIZE shall be defined on different runtime */
+#ifndef MEM_SIZE
+#define MEM_SIZE 0xFFFFFFFFULL /* 2^32 - 1 */
+#endif
 #define STACK_SIZE 0x1000       /* 4096 */
 #define ARGS_OFFSET_SIZE 0x1000 /* 4096 */
 


### PR DESCRIPTION
The "emcc --version" command displays information about the version of emcc, which contains the "gcc" or "clang" string. As a result, the build rule should only match one compiler and stop checking anymore.  If not, the build could be failed by a mix of different compiler's CFLAGS. For example, -flto from clang and -flto=thin from emcc.

After refactoring the riscv.[ch] public APIs in commit 820cd9b, it is now possible to adjust the memory size to accommodate varying runtime requirements. The memory size must align to a 4KB page size for the WASM runtime and I set 1GB as default memory size for WASM runtime.

The LTO is not supported to build emscripten-port SDL library, so disable it when both ENABLE_LTO=1 and ENABLE_SDL=1 are set.

Related to: #75
Close #375