### PR TITLE
Introduce Infer static analyzer to the CI pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,12 +127,23 @@ jobs:
     - name: set up scan-build  
       run: |
             sudo apt-get update -q -y
-            sudo apt-get install -q -y clang clang-tools libsdl2-dev libsdl2-mixer-dev
+            sudo apt-get install -q -y clang clang-tools
       shell: bash
     - name: run scan-build without JIT
       run: make clean && make distclean && scan-build -v -o ~/scan-build --status-bugs --use-cc=clang --force-analyze-debug-code --show-description -analyzer-config stable-report-filename=true -enable-checker valist,nullability make ENABLE_EXT_F=0 ENABLE_SDL=0 ENABLE_JIT=0
     - name: run scan-build with JIT
       run: make clean && make distclean && scan-build -v -o ~/scan-build --status-bugs --use-cc=clang --force-analyze-debug-code --show-description -analyzer-config stable-report-filename=true -enable-checker valist,nullability make ENABLE_EXT_F=0 ENABLE_SDL=0 ENABLE_JIT=1
+  
+  static-analysis-infer:
+    needs: [detect-code-related-file-changes]
+    if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
+    runs-on: sysprog21/infer:latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: run infer without JIT
+      run: infer --fail-on-issue -- make ENABLE_SDL=0 ENABLE_LTO=0 ENABLE_EXT_F=0 ENABLE_JIT=0
+    - name: run infer with JIT
+      run: infer --fail-on-issue -- make ENABLE_SDL=0 ENABLE_LTO=0 ENABLE_EXT_F=0 ENABLE_JIT=1
 
   compliance-test:
     needs: [detect-code-related-file-changes]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,13 +137,16 @@ jobs:
   static-analysis-infer:
     needs: [detect-code-related-file-changes]
     if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
-    runs-on: sysprog21/infer:latest
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: run infer without JIT
-      run: infer --fail-on-issue -- make ENABLE_SDL=0 ENABLE_LTO=0 ENABLE_EXT_F=0 ENABLE_JIT=0
-    - name: run infer with JIT
-      run: infer --fail-on-issue -- make ENABLE_SDL=0 ENABLE_LTO=0 ENABLE_EXT_F=0 ENABLE_JIT=1
+    - name: Obtain source code
+      uses: actions/checkout@v4
+    - name: Use Docker Hub Infer image
+      uses: docker://sysprog21/infer:latest
+      with:
+        run: |
+          make clean && make distclean && infer --fail-on-issue -- make ENABLE_SDL=0 ENABLE_LTO=0 ENABLE_EXT_F=0 ENABLE_JIT=0
+          make clean && make distclean && infer --fail-on-issue -- make ENABLE_SDL=0 ENABLE_LTO=0 ENABLE_EXT_F=0 ENABLE_JIT=1
 
   compliance-test:
     needs: [detect-code-related-file-changes]

--- a/src/jit.c
+++ b/src/jit.c
@@ -1238,11 +1238,10 @@ FORCE_INLINE void store_back_target(struct jit_state *state, int target_reg)
 
 static int map_reg(struct jit_state *state, int reg_number)
 {
-    int target_reg = -1;
     if (reg_table[reg_number] != -1)
         return reg_table[reg_number];
     count = (count + 1) % n_reg;
-    target_reg = register_map[count];
+    int target_reg = register_map[count];
     store_back_target(state, target_reg);
     reg_table[reg_number] = target_reg;
     return target_reg;


### PR DESCRIPTION
The [Infer Docker Image](https://hub.docker.com/repository/docker/sysprog21/infer/general) in use is hosted on Docker Hub, which was [built and pushed to sysprog21 by us](https://henrybear327.github.io/notes/posts/container/infer/) since [Infer's latest upstream release](https://github.com/facebook/infer/releases/tag/v1.1.0) is very outdated at the time of writing.

The docker image size is around 470 MB, after numerous attempts to reduce its size from 3GB.

This PR also fixes issues reported by Infer. (The value written to `&target_reg` is never used.)