### PR TITLE
Refine rv_step function prototype

### DIFF
--- a/src/emulate.c
+++ b/src/emulate.c
@@ -1074,9 +1074,11 @@ static bool runtime_profiler(riscv_t *rv, block_t *block)
 typedef void (*exec_block_func_t)(riscv_t *rv, uintptr_t);
 #endif
 
-void rv_step(riscv_t *rv, int32_t cycles)
+void rv_step(riscv_t *rv)
 {
     assert(rv);
+    vm_attr_t *attr = PRIV(rv);
+    uint32_t cycles = attr->cycle_per_step;
 
     /* find or translate a block for starting PC */
     const uint64_t cycles_target = rv->csr_cycle + cycles;

--- a/src/gdbstub.c
+++ b/src/gdbstub.c
@@ -79,13 +79,15 @@ static inline bool rv_is_interrupt(riscv_t *rv)
 static gdb_action_t rv_cont(void *args)
 {
     riscv_t *rv = (riscv_t *) args;
-    const uint32_t cycles_per_step = 1;
+    assert(rv);
+    vm_attr_t *attr = PRIV(rv);
+    attr->cycle_per_step = 1;
 
     for (; !rv_has_halted(rv) && !rv_is_interrupt(rv);) {
         if (breakpoint_map_find(rv->breakpoint_map, rv_get_pc(rv)))
             break;
 
-        rv_step(rv, cycles_per_step);
+        rv_step(rv);
     }
 
     /* Clear the interrupt if it's pending */
@@ -97,7 +99,11 @@ static gdb_action_t rv_cont(void *args)
 static gdb_action_t rv_stepi(void *args)
 {
     riscv_t *rv = (riscv_t *) args;
-    rv_step(rv, 1);
+    assert(rv);
+    vm_attr_t *attr = PRIV(rv);
+    attr->cycle_per_step = 1;
+
+    rv_step(rv);
     return ACT_RESUME;
 }
 

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -276,11 +276,11 @@ static void rv_run_and_trace(riscv_t *rv)
 
     vm_attr_t *attr = PRIV(rv);
     assert(attr && attr->data.user && attr->data.user->elf_program);
+    attr->cycle_per_step = 1;
 
     const char *prog_name = attr->data.user->elf_program;
     elf_t *elf = elf_new();
     assert(elf && elf_open(elf, prog_name));
-    const uint32_t cycles_per_step = 1;
 
     for (; !rv_has_halted(rv);) { /* run until the flag is done */
         /* trace execution */
@@ -288,7 +288,7 @@ static void rv_run_and_trace(riscv_t *rv)
         const char *sym = elf_find_symbol(elf, pc);
         printf("%08x  %s\n", pc, (sym ? sym : ""));
 
-        rv_step(rv, cycles_per_step); /* step instructions */
+        rv_step(rv); /* step instructions */
     }
 
     elf_delete(elf);
@@ -316,8 +316,8 @@ void rv_run(riscv_t *rv)
 #endif
     else {
         /* default main loop */
-        for (; !rv_has_halted(rv);)            /* run until the flag is done */
-            rv_step(rv, attr->cycle_per_step); /* step instructions */
+        for (; !rv_has_halted(rv);) /* run until the flag is done */
+            rv_step(rv);            /* step instructions */
     }
 
     if (attr->run_flag & RV_RUN_PROFILE) {

--- a/src/riscv.h
+++ b/src/riscv.h
@@ -166,7 +166,7 @@ void rv_debug(riscv_t *rv);
 #endif
 
 /* step the RISC-V emulator */
-void rv_step(riscv_t *rv, int32_t cycles);
+void rv_step(riscv_t *rv);
 
 /* set the program counter of a RISC-V emulator */
 bool rv_set_pc(riscv_t *rv, riscv_word_t pc);


### PR DESCRIPTION
After refinement of riscv.[ch] public APIs in commit 820cd9b, cycle_per_step is specified in vm_attr_t, the argument cycles in the function prototype of rv_step is no longer required.