### PR TITLE
Eliminate redundant register swapping in JIT

### DIFF
--- a/src/jit.h
+++ b/src/jit.h
@@ -36,6 +36,11 @@ struct jit_state {
     int n_jumps;
 };
 
+struct host_reg {
+    uint8_t reg_idx : 5; /* index to the host's register file */
+    bool dirty : 1;
+};
+
 struct jit_state *jit_state_init(size_t size);
 void jit_state_exit(struct jit_state *state);
 uint32_t jit_translate(riscv_t *rv, block_t *block);

--- a/tools/gen-jit-template.py
+++ b/tools/gen-jit-template.py
@@ -200,7 +200,7 @@ for i in range(len(op)):
             elif items[0] == "rald2s":
                 asm = "ra_load2_sext(state, {}, {}, {}, {});".format(items[1], items[2], items[3], items[4])
             elif items[0] == "map":
-                asm = "{} = map_reg(state, {});".format(items[1], items[2])
+                asm = "{} = map_vm_reg(state, {});".format(items[1], items[2])
             elif items[0] == "ld":
                 if (items[3] == "X"):
                     asm = "emit_load(state, {}, parameter_reg[0], {}, offsetof(riscv_t, X) + 4 * {});".format(


### PR DESCRIPTION
In the current register allocation of JIT, we save the host registers before using to keep the consistency of the content between the vm and the host register, even it had not been changed by any other operation after loaded from the stack. This generates lots of redundant `store` related instructions on the host and reduces the performance of vm.

In this patch, we introduce the `dirty` flag to record the status of the host register. Once the content of the host register is changed by an operation, the flag is set to 1. The register swapping will only be invoked when the register is dirty in next allocation.

The performance improvement after this patch is shown below:

* x86-64

| Metric    | Original | Improved | SpeedUp |
| --------- | -------- | -------- | ------- |
| dhrystone |  0.623 s |  0.463 s |  +25.6% |
| miniz     |  3.437 s |  2.837 s |  +17.5% |
| primes    |  4.435 s |  3.205 s |  +27.7% |
| sha512    |  3.212 s |  3.024 s |   +5.9% |
| aes       |  1.708 s |  1.545 s |   +9.5% |
| qsort     |  5.236 s |  5.219 s |   +0.3% |

* aarch64

| Metric    | Original | Improved | SpeedUp |
| --------- | -------- | -------- | ------- |
| dhrystone |  1.003 s |  0.897 s |  +10.6% |
| miniz     |  4.312 s |  4.107 s |   +4.8% |
| primes    |  9.605 s |  8.879 s |   +7.6% |
| sha512    |  5.902 s |  5.796 s |   +1.8% |
| aes       |  2.932 s |  2.891 s |   +1.4% |
| qsort     |  6.123 s |  5.988 s |   +2.2% |