### PR TITLE
Fix missing dirty flag in `cmv` instruction

### DIFF
--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -2337,6 +2337,8 @@ RVOP(
         map, VR1, rd;
         cond, regneq;
         mov, VR0, VR1;
+        else;
+        pollute, VR1;
         end;
     }))
 

--- a/tools/gen-jit-template.py
+++ b/tools/gen-jit-template.py
@@ -256,8 +256,12 @@ for i in range(len(op)):
                 if items[1] == "regneq":
                     items[1] = "vm_reg[0] != vm_reg[1]"
                 asm = "if({})".format(items[1]) + "{"
+            elif items[0] == "else":
+                asm = "} else {"
             elif items[0] == "end":
                 asm = "}"
+            elif items[0] == "pollute":
+                asm = "set_dirty({}, true);".format(items[1])
             elif items[0] == "break":
                 asm = "store_back(state);"
             elif items[0] == "assert":


### PR DESCRIPTION
In the `cmv` instruction, we ignore the data movement of the same destination register, and the `set_dirty()` function is skipped. We need to explicitly set the flag in the `src/rv_template.c` to make sure the context of the register file is correct.

After the changes, the `do_cmv()` becomes:
```c
vm_reg[0] = ra_load(state, ir->rs2);
vm_reg[1] = map_vm_reg(state, ir->rd);

if (vm_reg[0] != vm_reg[1]) {
    emit_mov(state, vm_reg[0], vm_reg[1]);
} else {
    set_dirty(vm_reg[1], true);
}
```