### PR TITLE
CI: Tweak WebAssembly CI event

### DIFF
--- a/.github/workflows/deploy-wasm.yml
+++ b/.github/workflows/deploy-wasm.yml
@@ -1,7 +1,7 @@
 name: WebAssembly
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - master
     types:


### PR DESCRIPTION
To access the secrets variable (or token) in pull request event, it is necessary to use pull_request_target instead of pull_request.

Close: #400