### PR TITLE
Remove the backward jump from the T1C condition

### DIFF
--- a/src/riscv.c
+++ b/src/riscv.c
@@ -507,7 +507,6 @@ static void profile(block_t *block, uint32_t freq, FILE *output_file)
     fprintf(output_file, "%#-8x|", block->pc_end);
     fprintf(output_file, " %-10u|", freq);
     fprintf(output_file, " %-5s |", block->hot ? "true" : "false");
-    fprintf(output_file, " %-8s |", block->backward ? "true" : "false");
     fprintf(output_file, " %-6s |", block->has_loops ? "true" : "false");
     rv_insn_t *taken = block->ir_tail->branch_taken,
               *untaken = block->ir_tail->branch_untaken;
@@ -545,10 +544,8 @@ void rv_profile(riscv_t *rv, char *out_file_path)
     }
 #if RV32_HAS(JIT)
     fprintf(f,
-            "PC start |PC end  | frequency |  hot  | backward |  loop  | "
-            "untaken | taken  "
-            "| IR "
-            "list \n");
+            "PC start |PC end  | frequency |  hot  | loop  | untaken | taken | "
+            "IR list \n");
     cache_profile(rv->block_cache, f, (prof_func_t) profile);
 #else
     fprintf(f, "PC start |PC end  | untaken | taken  | IR list \n");

--- a/src/riscv_private.h
+++ b/src/riscv_private.h
@@ -65,8 +65,7 @@ typedef struct block {
 
     rv_insn_t *ir_head, *ir_tail; /**< the first and last ir for this block */
 #if RV32_HAS(JIT)
-    bool backward; /**< Determine the block has backward jump or not */
-    bool hot;      /**< Determine the block is hotspot or not */
+    bool hot; /**< Determine the block is hotspot or not */
     uint32_t offset;
     bool
         translatable; /**< Determine the block has RV32AF insturctions or not */


### PR DESCRIPTION
According to our performance analysis, backward jumps notably impact the performance of T1C, particularly in the case of qsort and FP emulation. While backward jumps assist in identifying chained blocks with loops, they also encompass blocks without loops. Upon implementing alternative mechanisms for loop detection, we were able to eliminate the need for backward jumps.

|   Metric   | w/ backward | w/o backward | Speedup |
|------------|------------|--------------|---------|
|qsort       |       1.865|         1.588|  +14.85%|
|FP emulation|       3.622|         2.761|  +23.77%|
|bitfield    |       1.596|         1.610|   -0.88%|