### PR TITLE
Fix wasm build failed in deploy-wasm CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,15 +148,15 @@ endif
 
 $(OUT)/emulate.o: CFLAGS += -foptimize-sibling-calls -fomit-frame-pointer -fno-stack-check -fno-stack-protector
 
-# Clear the .DEFAULT_GOAL special variable, so that the following turns
-# to the first target after .DEFAULT_GOAL is not set.
-.DEFAULT_GOAL :=
-
-all: config $(BIN)
+# .DEFAULT_GOAL should be set to all since the very first target is not all
+# after including "mk/external.mk"
+.DEFAULT_GOAL := all
 
 include mk/external.mk
 
 include mk/wasm.mk
+
+all: config $(BIN)
 
 OBJS := \
 	map.o \


### PR DESCRIPTION
Before executing the "make CC=emcc ENABLE_GDBSTUB=0 ENABLE_SDL=1" command during the deploy-wasm ci, the 
"$(BIN)" must be modified to “$(BIN).js”. We can easily fix this by moving the "include" mk statement ahead of the "all" target. After reordering, the first invoked make target is not "all" target but instead when no make target is specified, set the .DEFAULT_GOAL to "all" to solve it.