### PR TITLE
Add code cache flush mechanism

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -287,4 +287,16 @@ void cache_profile(const struct cache *cache,
         }
     }
 }
+
+void clear_cache_hot(const struct cache *cache, clear_func_t func)
+{
+    assert(cache);
+    assert(func);
+    for (int i = 0; i < THRESHOLD; i++) {
+        lfu_entry_t *entry, *safe;
+        list_for_each_entry_safe (entry, safe, cache->lists[i], list) {
+            func(entry->value);
+        }
+    }
+}
 #endif

--- a/src/cache.h
+++ b/src/cache.h
@@ -61,6 +61,8 @@ typedef void (*prof_func_t)(void *, uint32_t, FILE *);
 void cache_profile(const struct cache *cache,
                    FILE *output_file,
                    prof_func_t func);
+typedef void (*clear_func_t)(void *);
+void clear_cache_hot(const struct cache *cache, clear_func_t func);
 #endif
 
 uint32_t cache_freq(const struct cache *cache, uint32_t key);

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -1152,8 +1152,7 @@ void rv_step(void *arg)
             continue;
         } /* check if using frequency of block exceed threshold */
         else if (block->translatable && runtime_profiler(rv, block)) {
-            block->hot = true;
-            block->offset = jit_translate(rv, block);
+            jit_translate(rv, block);
             ((exec_block_func_t) state->buf)(
                 rv, (uintptr_t) (state->buf + block->offset));
             prev = NULL;

--- a/src/jit.h
+++ b/src/jit.h
@@ -29,6 +29,7 @@ struct jit_state {
     uint32_t size;
     uint32_t entry_loc;
     uint32_t exit_loc;
+    uint32_t org_size; /* size of prologue and epilogue */
     uint32_t retpoline_loc;
     struct offset_map *offset_map;
     int n_blocks;
@@ -43,4 +44,4 @@ struct host_reg {
 
 struct jit_state *jit_state_init(size_t size);
 void jit_state_exit(struct jit_state *state);
-uint32_t jit_translate(riscv_t *rv, block_t *block);
+void jit_translate(riscv_t *rv, block_t *block);

--- a/tools/gen-jit-template.py
+++ b/tools/gen-jit-template.py
@@ -242,7 +242,7 @@ for i in range(len(op)):
                 asm = "emit_call(state, (intptr_t) rv->io.on_{});".format(
                     items[1])
             elif items[0] == "exit":
-                asm = "emit_exit(&(*state));"
+                asm = "emit_exit(state);"
             elif items[0] == "mul":
                 asm = "muldivmod(state, {}, {}, {}, {});".format(
                     items[1], items[2], items[3], items[4])


### PR DESCRIPTION
This modification introduces a code cache flush mechanism to handle the situation when the code cache becomes full. We flush the code cache by setting the offset to its initial value and clearing all the recording data for the code cache. Subsequently, we restart the T1C translation for the target chained-block.

Close: #365