### PR TITLE
Fix compilation error caused by missing softfloat dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,10 @@ OBJS := \
 OBJS := $(addprefix $(OUT)/, $(OBJS))
 deps := $(OBJS:%.o=%.o.d)
 
+ifeq ($(call has, EXT_F), 1)
+$(OBJS): $(SOFTFLOAT_LIB)
+endif
+
 $(OUT)/%.o: src/%.c $(deps_emcc)
 	$(VECHO) "  CC\t$@\n"
 	$(Q)$(CC) -o $@ $(CFLAGS) $(CFLAGS_emcc) -c -MMD -MF $@.d $<


### PR DESCRIPTION
When adding the -j flag to make for faster compilation speeds, it led to the following error:

src/riscv.h:20:10: fatal error: softfloat/softfloat.h: No such file or directory
   20 | #include "softfloat/softfloat.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.

This was due to incorrect dependency settings, where compilation of the source code started before completing the git submodule update, leading to the error. Add appropriate dependency handling to ensure that compilation of the softfloat library is completed before compiling the source code.