### PR TITLE
CI: Parallelize compilation for faster testing 

### DIFF
--- a/.ci/riscv-tests.sh
+++ b/.ci/riscv-tests.sh
@@ -10,11 +10,4 @@ set -x
 export PATH=`pwd`/toolchain/riscv/bin:$PATH
 
 make clean
-make arch-test RISCV_DEVICE=I || exit 1
-make arch-test RISCV_DEVICE=IM  || exit 1
-make arch-test RISCV_DEVICE=IC || exit 1
-make arch-test RISCV_DEVICE=FCZicsr || exit 1
-make arch-test RISCV_DEVICE=IZifencei || exit 1
-make arch-test RISCV_DEVICE=IZicsr || exit 1
-make arch-test RISCV_DEVICE=FZicsr || exit 1
-make arch-test RISCV_DEVICE=IMA || exit 1
+make arch-test RISCV_DEVICE=IMAFCZicsrZifencei || exit 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,30 +49,30 @@ jobs:
       run: make
     - name: check + tests
       run: |
-            make check
-            make tests
-            make misalign
-            make tool
+            make check -j$(nproc)
+            make tests -j$(nproc)
+            make misalign -j$(nproc)
+            make tool -j$(nproc)
     - name: diverse configurations
       run: |
-            make distclean && make ENABLE_EXT_M=0 check
-            make distclean && make ENABLE_EXT_A=0 check
-            make distclean && make ENABLE_EXT_F=0 check
-            make distclean && make ENABLE_EXT_C=0 check
-            make distclean && make ENABLE_SDL=0 check
+            make distclean && make ENABLE_EXT_M=0 check -j$(nproc)
+            make distclean && make ENABLE_EXT_A=0 check -j$(nproc)
+            make distclean && make ENABLE_EXT_F=0 check -j$(nproc)
+            make distclean && make ENABLE_EXT_C=0 check -j$(nproc)
+            make distclean && make ENABLE_SDL=0 check -j$(nproc)
     - name: gdbstub test
       run: |
             make distclean ENABLE_GDBSTUB=1 gdbstub-test
     - name: JIT test
       run: |
-            make clean && make ENABLE_JIT=1 check
-            make clean && make ENABLE_EXT_A=0 ENABLE_JIT=1 check
-            make clean && make ENABLE_EXT_F=0 ENABLE_JIT=1 check
-            make clean && make ENABLE_EXT_C=0 ENABLE_JIT=1 check
+            make clean && make ENABLE_JIT=1 check -j$(nproc)
+            make clean && make ENABLE_EXT_A=0 ENABLE_JIT=1 check -j$(nproc)
+            make clean && make ENABLE_EXT_F=0 ENABLE_JIT=1 check -j$(nproc)
+            make clean && make ENABLE_EXT_C=0 ENABLE_JIT=1 check -j$(nproc)
     - name: undefined behavior test
       run: |
-            make clean && make ENABLE_UBSAN=1 check
-            make clean && make ENABLE_JIT=1 ENABLE_UBSAN=1 check
+            make clean && make ENABLE_UBSAN=1 check -j$(nproc)
+            make clean && make ENABLE_JIT=1 ENABLE_UBSAN=1 check -j$(nproc)
 
   host-arm64:
     needs: [detect-code-related-file-changes]
@@ -97,12 +97,12 @@ jobs:
           git config --global --add safe.directory ${{ github.workspace }}/src/mini-gdbstub
         # Append custom commands here
         run: |
-          make
-          make check
-          make clean && make ENABLE_JIT=1 check
-          make clean && make ENABLE_EXT_A=0 ENABLE_JIT=1 check
-          make clean && make ENABLE_EXT_F=0 ENABLE_JIT=1 check
-          make clean && make ENABLE_EXT_C=0 ENABLE_JIT=1 check
+          make -j$(nproc)
+          make check -j$(nproc)
+          make clean && make ENABLE_JIT=1 check -j$(nproc)
+          make clean && make ENABLE_EXT_A=0 ENABLE_JIT=1 check -j$(nproc)
+          make clean && make ENABLE_EXT_F=0 ENABLE_JIT=1 check -j$(nproc)
+          make clean && make ENABLE_EXT_C=0 ENABLE_JIT=1 check -j$(nproc)
 
   coding-style:
     needs: [detect-code-related-file-changes]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,24 +55,24 @@ jobs:
             make tool
     - name: diverse configurations
       run: |
-            make distclean ENABLE_EXT_M=0 check
-            make distclean ENABLE_EXT_A=0 check
-            make distclean ENABLE_EXT_F=0 check
-            make distclean ENABLE_EXT_C=0 check
-            make distclean ENABLE_SDL=0 check
+            make distclean && make ENABLE_EXT_M=0 check
+            make distclean && make ENABLE_EXT_A=0 check
+            make distclean && make ENABLE_EXT_F=0 check
+            make distclean && make ENABLE_EXT_C=0 check
+            make distclean && make ENABLE_SDL=0 check
     - name: gdbstub test
       run: |
             make distclean ENABLE_GDBSTUB=1 gdbstub-test
     - name: JIT test
       run: |
-            make ENABLE_JIT=1 clean check
-            make ENABLE_EXT_A=0 ENABLE_JIT=1 clean check
-            make ENABLE_EXT_F=0 ENABLE_JIT=1 clean check
-            make ENABLE_EXT_C=0 ENABLE_JIT=1 clean check
+            make clean && make ENABLE_JIT=1 check
+            make clean && make ENABLE_EXT_A=0 ENABLE_JIT=1 check
+            make clean && make ENABLE_EXT_F=0 ENABLE_JIT=1 check
+            make clean && make ENABLE_EXT_C=0 ENABLE_JIT=1 check
     - name: undefined behavior test
       run: |
-            make ENABLE_UBSAN=1 clean check
-            make ENABLE_JIT=1 ENABLE_UBSAN=1 clean check
+            make clean && make ENABLE_UBSAN=1 check
+            make clean && make ENABLE_JIT=1 ENABLE_UBSAN=1 check
 
   host-arm64:
     needs: [detect-code-related-file-changes]
@@ -99,10 +99,10 @@ jobs:
         run: |
           make
           make check
-          make ENABLE_JIT=1 clean check
-          make ENABLE_EXT_A=0 ENABLE_JIT=1 clean check
-          make ENABLE_EXT_F=0 ENABLE_JIT=1 clean check
-          make ENABLE_EXT_C=0 ENABLE_JIT=1 clean check
+          make clean && make ENABLE_JIT=1 check
+          make clean && make ENABLE_EXT_A=0 ENABLE_JIT=1 check
+          make clean && make ENABLE_EXT_F=0 ENABLE_JIT=1 check
+          make clean && make ENABLE_EXT_C=0 ENABLE_JIT=1 check
 
   coding-style:
     needs: [detect-code-related-file-changes]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,9 +130,9 @@ jobs:
             sudo apt-get install -q -y clang clang-tools libsdl2-dev libsdl2-mixer-dev
       shell: bash
     - name: run scan-build without JIT
-      run: make clean && make distclean && scan-build -v -o ~/scan-build --status-bugs --use-cc=clang --force-analyze-debug-code --show-description -analyzer-config stable-report-filename=true -enable-checker valist,nullability make ENABLE_EXT_F=0 ENABLE_SDL=0 ENABLE_JIT=0
+      run: make distclean && scan-build -v -o ~/scan-build --status-bugs --use-cc=clang --force-analyze-debug-code --show-description -analyzer-config stable-report-filename=true -enable-checker valist,nullability make ENABLE_EXT_F=0 ENABLE_SDL=0 ENABLE_JIT=0
     - name: run scan-build with JIT
-      run: make clean && make distclean && scan-build -v -o ~/scan-build --status-bugs --use-cc=clang --force-analyze-debug-code --show-description -analyzer-config stable-report-filename=true -enable-checker valist,nullability make ENABLE_EXT_F=0 ENABLE_SDL=0 ENABLE_JIT=1
+      run: make distclean && scan-build -v -o ~/scan-build --status-bugs --use-cc=clang --force-analyze-debug-code --show-description -analyzer-config stable-report-filename=true -enable-checker valist,nullability make ENABLE_EXT_F=0 ENABLE_SDL=0 ENABLE_JIT=1
 
   compliance-test:
     needs: [detect-code-related-file-changes]


### PR DESCRIPTION
Utilize -j$(nproc) flag to accelerate building time in CI. Additionally, prevent duplicate execution of architectural tests to ensure each test suite runs only once. These optimizations in CI reduced testing times on my GitHub Action:

| Test Suite       | Before | After |
|------------------|---------------------|--------------------|
| host-x86 tests   | 2m3s                | 1m26s              |
| host-arm64 tests | 11m0s               | 8m34s              |
| compliance-test  | 10m4s               | 6m53s              |

Note: Depends on #423 to pass the tests.