### PR TITLE
CI: Reinstate rv32fc test suite

### DIFF
--- a/.ci/riscv-tests.sh
+++ b/.ci/riscv-tests.sh
@@ -11,3 +11,4 @@ export PATH=`pwd`/toolchain/riscv/bin:$PATH
 
 make clean
 make arch-test RISCV_DEVICE=IMAFCZicsrZifencei || exit 1
+make arch-test RISCV_DEVICE=FCZicsr || exit 1


### PR DESCRIPTION
Fix the accidental removal of the rv32fc test suite from the architectural tests. It ensures comprehensive testing by adding it back.

Fixes: 432caa97f349 ("CI: Prevent duplicate execution of architectural test suites")