### PR TITLE
Raise illegal instruction exception for Zicsr

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -788,6 +788,11 @@ static inline bool op_jal(rv_insn_t *ir, const uint32_t insn)
     return true;
 }
 
+FORCE_INLINE bool csr_is_writable(const uint32_t csr)
+{
+    return csr < 0xc00;
+}
+
 /* SYSTEM: I-type
  *  31       20 19   15 14    12 11   7 6      0
  * | imm[11:0] |  rs1  | funct3 |  rd  | opcode |
@@ -886,6 +891,8 @@ static inline bool op_system(rv_insn_t *ir, const uint32_t insn)
     default: /* illegal instruction */
         return false;
     }
+    if (!csr_is_writable(ir->imm) && ir->rs1 != rv_reg_zero)
+        return false;
     return true;
 }
 

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -201,11 +201,6 @@ static uint32_t *csr_get_ptr(riscv_t *rv, uint32_t csr)
     }
 }
 
-FORCE_INLINE bool csr_is_writable(uint32_t csr)
-{
-    return csr < 0xc00;
-}
-
 /* CSRRW (Atomic Read/Write CSR) instruction atomically swaps values in the
  * CSRs and integer registers. CSRRW reads the old value of the CSR,
  * zero-extends the value to XLEN bits, and then writes it to register rd.
@@ -224,8 +219,8 @@ static uint32_t csr_csrrw(riscv_t *rv, uint32_t csr, uint32_t val)
     if (csr == CSR_FFLAGS)
         out &= FFLAG_MASK;
 #endif
-    if (csr_is_writable(csr))
-        *c = val;
+
+    *c = val;
 
     return out;
 }
@@ -242,8 +237,8 @@ static uint32_t csr_csrrs(riscv_t *rv, uint32_t csr, uint32_t val)
     if (csr == CSR_FFLAGS)
         out &= FFLAG_MASK;
 #endif
-    if (csr_is_writable(csr))
-        *c |= val;
+
+    *c |= val;
 
     return out;
 }
@@ -263,8 +258,9 @@ static uint32_t csr_csrrc(riscv_t *rv, uint32_t csr, uint32_t val)
     if (csr == CSR_FFLAGS)
         out &= FFLAG_MASK;
 #endif
-    if (csr_is_writable(csr))
-        *c &= ~val;
+
+    *c &= ~val;
+
     return out;
 }
 #endif


### PR DESCRIPTION
According to the RISC-V privileged architecture 20211203 (Section 2.1), write a read-only register should raise illegal instruction exception. Also, unprivileged ISA 20191213 states that a CSR instruction is considered a write when the rs1 or uimm is not zero (check Table 9.1). Since the exceptions are raised during the decoding stage, the execution of csr_csrrw, csr_csrrs, and csr_csrrc function can skip checking the writability of csr anymore.