### PR TITLE
Refactor mpool_calloc function

### DIFF
--- a/src/mpool.c
+++ b/src/mpool.c
@@ -107,25 +107,26 @@ static void *mpool_extend(mpool_t *mp)
     return p;
 }
 
-void *mpool_alloc(mpool_t *mp)
+FORCE_INLINE void *mpool_alloc_helper(mpool_t *mp)
 {
-    if (!mp->chunk_count && !(mpool_extend(mp)))
-        return NULL;
-
     char *ptr = (char *) mp->free_chunk_head + sizeof(memchunk_t);
     mp->free_chunk_head = mp->free_chunk_head->next;
     mp->chunk_count--;
     return ptr;
 }
 
+void *mpool_alloc(mpool_t *mp)
+{
+    if (!mp->chunk_count && !(mpool_extend(mp)))
+        return NULL;
+    return mpool_alloc_helper(mp);
+}
+
 void *mpool_calloc(mpool_t *mp)
 {
     if (!mp->chunk_count && !(mpool_extend(mp)))
         return NULL;
-
-    char *ptr = (char *) mp->free_chunk_head + sizeof(memchunk_t);
-    mp->free_chunk_head = mp->free_chunk_head->next;
-    mp->chunk_count--;
+    char *ptr = mpool_alloc_helper(mp);
     memset(ptr, 0, mp->chunk_size);
     return ptr;
 }


### PR DESCRIPTION
The mpool_calloc function contains code identical to that found in the mpool_alloc function. Replace part of the code in the mpool_alloc and mpool_calloc functions with the mpool_alloc_helper function.