### PR TITLE
Fix syscall lseek() to return correct offset

### DIFF
--- a/src/syscall.c
+++ b/src/syscall.c
@@ -267,8 +267,15 @@ static void syscall_lseek(riscv_t *rv)
         return;
     }
 
+    long pos = ftell(handle);
+    if (pos == -1) {
+        /* error */
+        rv_set_reg(rv, rv_reg_a0, -1);
+        return;
+    }
+
     /* success */
-    rv_set_reg(rv, rv_reg_a0, 0);
+    rv_set_reg(rv, rv_reg_a0, pos);
 }
 
 static void syscall_read(riscv_t *rv)


### PR DESCRIPTION
Previously, lseek() always returned 0 upon success, which is incorrect. Fix the behavior by using ftell() to retrieve the correct offset location and returning it upon successful completion of lseek().