### PR TITLE
Preliminary support for MMU emulation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,10 @@ jobs:
       run: |
             make -C tests/system/alignment/
             make distclean && make ENABLE_EXT_C=0 ENABLE_SYSTEM=1 misalign-in-blk-emu -j$(nproc)
+    - name: MMU test
+      run: |
+            make -C tests/system/mmu/
+            make distclean && make ENABLE_SYSTEM=1 mmu-test -j$(nproc)
     - name: gdbstub test
       run: |
             make distclean && make ENABLE_GDBSTUB=1 gdbstub-test -j$(nproc)

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,10 @@ CFLAGS += $(CFLAGS_NO_CET)
 
 OBJS_EXT :=
 
+ifeq ($(call has, SYSTEM), 1)
+OBJS_EXT += system.o
+endif
+
 # Integer Multiplication and Division instructions
 ENABLE_EXT_M ?= 1
 $(call set-feature, EXT_M)

--- a/Makefile
+++ b/Makefile
@@ -303,6 +303,16 @@ misalign-in-blk-emu: $(BIN)
 	             exit 1; \
 	             fi;
 
+EXPECTED_mmu = STORE PAGE FAULT TEST PASSED!
+mmu-test: $(BIN)
+	$(Q)$(PRINTF) "Running vm.elf ... "; \
+	    if [ "$(shell $(BIN) tests/system/mmu/vm.elf | tail -n 2)" = "$(strip $(EXPECTED_mmu)) inferior exit code 0" ]; then \
+	    $(call notice, [OK]); \
+	    else \
+	    $(PRINTF) "Failed.\n"; \
+	    exit 1; \
+	    fi;
+
 # Non-trivial demonstration programs
 ifeq ($(call has, SDL), 1)
 doom_action := (cd $(OUT); ../$(BIN) riscv32/doom)

--- a/src/decode.c
+++ b/src/decode.c
@@ -907,9 +907,8 @@ static inline bool op_system(rv_insn_t *ir, const uint32_t insn)
     default: /* illegal instruction */
         return false;
     }
-    if (!csr_is_writable(ir->imm) && ir->rs1 != rv_reg_zero)
-        return false;
-    return true;
+
+    return csr_is_writable(ir->imm) || (ir->rs1 == rv_reg_zero);
 }
 
 /* MISC-MEM: I-type

--- a/src/feature.h
+++ b/src/feature.h
@@ -63,5 +63,10 @@
 #define RV32_FEATURE_T2C 0
 #endif
 
+/* System */
+#ifndef RV32_FEATURE_SYSTEM
+#define RV32_FEATURE_SYSTEM 0
+#endif
+
 /* Feature test macro */
 #define RV32_HAS(x) RV32_FEATURE_##x

--- a/src/gdbstub.c
+++ b/src/gdbstub.c
@@ -55,7 +55,7 @@ static int rv_read_mem(void *args, size_t addr, size_t len, void *val)
          * an invalid address. We may have to do error handling in the
          * mem_read_* function directly.
          */
-        *((uint8_t *) val + i) = rv->io.mem_read_b(addr + i);
+        *((uint8_t *) val + i) = rv->io.mem_read_b(rv, addr + i);
     }
 
     return err;
@@ -66,7 +66,7 @@ static int rv_write_mem(void *args, size_t addr, size_t len, void *val)
     riscv_t *rv = (riscv_t *) args;
 
     for (size_t i = 0; i < len; i++)
-        rv->io.mem_write_b(addr + i, *((uint8_t *) val + i));
+        rv->io.mem_write_b(rv, addr + i, *((uint8_t *) val + i));
 
     return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -217,12 +217,21 @@ int main(int argc, char **args)
         .log_level = 0,
         .run_flag = run_flag,
         .profile_output_file = prof_out_file,
+#if RV32_HAS(SYSTEM)
+        .data.system = malloc(sizeof(vm_system_t)),
+#else
         .data.user = malloc(sizeof(vm_user_t)),
+#endif
         .cycle_per_step = CYCLE_PER_STEP,
         .allow_misalign = opt_misaligned,
     };
+#if RV32_HAS(SYSTEM)
+    assert(attr.data.system);
+    attr.data.system->elf_program = opt_prog_name;
+#else
     assert(attr.data.user);
     attr.data.user->elf_program = opt_prog_name;
+#endif
 
     /* create the RISC-V runtime */
     rv = rv_create(&attr);

--- a/src/riscv.h
+++ b/src/riscv.h
@@ -91,10 +91,129 @@ enum {
 #define MISA_A (1 << ('A' - 'A'))
 #define MISA_F (1 << ('F' - 'A'))
 #define MISA_C (1 << ('C' - 'A'))
+
+/* The mstatus register keeps track of and controls the hart’s current operating
+ * state */
+#define MSTATUS_SIE_SHIFT 1
+#define MSTATUS_MIE_SHIFT 3
+#define MSTATUS_SPIE_SHIFT 5
+#define MSTATUS_UBE_SHIFT 6
 #define MSTATUS_MPIE_SHIFT 7
+#define MSTATUS_SPP_SHIFT 8
 #define MSTATUS_MPP_SHIFT 11
+#define MSTATUS_MPRV_SHIFT 17
+#define MSTATUS_SUM_SHIFT 18
+#define MSTATUS_MXR_SHIFT 18
+#define MSTATUS_TVM_SHIFT 20
+#define MSTATUS_TW_SHIFT 21
+#define MSTATUS_TSR_SHIFT 22
+#define MSTATUS_SIE (1 << MSTATUS_SIE_SHIFT)
+#define MSTATUS_MIE (1 << MSTATUS_MIE_SHIFT)
+#define MSTATUS_SPIE (1 << MSTATUS_SPIE_SHIFT)
+#define MSTATUS_UBE (1 << MSTATUS_UBE_SHIFT)
 #define MSTATUS_MPIE (1 << MSTATUS_MPIE_SHIFT)
+#define MSTATUS_SPP (1 << MSTATUS_SPP_SHIFT)
 #define MSTATUS_MPP (3 << MSTATUS_MPP_SHIFT)
+#define MSTATUS_MPRV (1 << MSTATUS_MPRV_SHIFT)
+#define MSTATUS_SUM (1 << MSTATUS_SUM_SHIFT)
+#define MSTATUS_MXR (1 << MSTATUS_MXR_SHIFT)
+#define MSTATUS_TVM (1 << MSTATUS_TVM_SHIFT)
+#define MSTATUS_TW (1 << MSTATUS_TW_SHIFT)
+#define MSTATUS_TSR (1 << MSTATUS_TSR_SHIFT)
+
+/* A restricted view of mstatus */
+#define SSTATUS_SIE_SHIFT 1
+#define SSTATUS_SPIE_SHIFT 5
+#define SSTATUS_UBE_SHIFT 6
+#define SSTATUS_SPP_SHIFT 8
+#define SSTATUS_SUM_SHIFT 18
+#define SSTATUS_MXR_SHIFT 19
+#define SSTATUS_SIE (1 << SSTATUS_SIE_SHIFT)
+#define SSTATUS_SPIE (1 << SSTATUS_SPIE_SHIFT)
+#define SSTATUS_UBE (1 << SSTATUS_UBE_SHIFT)
+#define SSTATUS_SPP (1 << SSTATUS_SPP_SHIFT)
+#define SSTATUS_SUM (1 << SSTATUS_SUM_SHIFT)
+#define SSTATUS_MXR (1 << SSTATUS_MXR_SHIFT)
+
+#define SIP_SSIP_SHIFT 1
+#define SIP_STIP_SHIFT 5
+#define SIP_SEIP_SHIFT 9
+#define SIP_SSIP (1 << SIP_SSIP_SHIFT)
+#define SIP_STIP (1 << SIP_STIP_SHIFT)
+#define SIP_SEIP (1 << SIP_SEIP_SHIFT)
+
+#define RV_PG_SHIFT 12
+#define RV_PG_SIZE (1 << RV_PG_SHIFT)
+
+#define RV_PRIV_U_MODE 0
+#define RV_PRIV_S_MODE 1
+#define RV_PRIV_M_MODE 3
+
+#define PTE_V (1U)
+#define PTE_R (1U << 1)
+#define PTE_W (1U << 2)
+#define PTE_X (1U << 3)
+#define PTE_U (1U << 4)
+#define PTE_G (1U << 5)
+#define PTE_A (1U << 6)
+#define PTE_D (1U << 7)
+
+/* PTE XWRV bit in order */
+enum SV32_PTE_PERM {
+    NEXT_PG_TBL = 0b0001,
+    RO_PAGE = 0b0011,
+    RW_PAGE = 0b0111,
+    EO_PAGE = 0b1001,
+    RX_PAGE = 0b1011,
+    RWX_PAGE = 0b1111,
+    RESRV_PAGE1 = 0b0101,
+    RESRV_PAGE2 = 0b1101,
+};
+
+/*
+ * SBI functions must return a pair of values:
+ *
+ * struct sbiret {
+ *     long error;
+ *     long value;
+ * };
+ *
+ * The error and value field will be set to register a0 and a1 respectively
+ * after the SBI function return. The error field indicate whether the
+ * SBI call is success or not. SBI_SUCCESS indicates success and
+ * SBI_ERR_NOT_SUPPORTED indicates not supported failure. The value field is
+ * the information based on the extension ID(EID) and SBI function ID(FID).
+ *
+ * SBI reference: https://github.com/riscv-non-isa/riscv-sbi-doc
+ *
+ */
+#define SBI_SUCCESS 0
+#define SBI_ERR_NOT_SUPPORTED -2
+
+/*
+ * All of the functions in the base extension must be supported by
+ * all SBI implementations.
+ */
+#define SBI_EID_BASE 0x10
+#define SBI_BASE_GET_SBI_SPEC_VERSION 0
+#define SBI_BASE_GET_SBI_IMPL_ID 1
+#define SBI_BASE_GET_SBI_IMPL_VERSION 2
+#define SBI_BASE_PROBE_EXTENSION 3
+#define SBI_BASE_GET_MVENDORID 4
+#define SBI_BASE_GET_MARCHID 5
+#define SBI_BASE_GET_MIMPID 6
+
+/* Make supervisor to schedule the clock for next timer event. */
+#define SBI_EID_TIMER 0x54494D45
+#define SBI_TIMER_SET_TIMER 0
+
+/* Allows the supervisor to request system-level reboot or shutdown. */
+#define SBI_EID_RST 0x53525354
+#define SBI_RST_SYSTEM_RESET 0
+
+#define RV_MVENDORID 0x12345678
+#define RV_MARCHID ((1ULL << 31) | 1)
+#define RV_MIMPID 1
 
 /* The mstatus register keeps track of and controls the hart’s current operating
  * state */
@@ -150,6 +269,51 @@ enum {
 #define RV_PRIV_S_MODE 1
 #define RV_PRIV_M_MODE 3
 #define RV_PRIV_IS_U_OR_S_MODE() (rv->priv_mode <= RV_PRIV_S_MODE)
+
+/* clang-format off */
+enum TRAP_CODE {
+#if !RV32_HAS(EXT_C)
+    INSN_MISALIGNED = 0,       /* Instruction address misaligned */
+#endif /* !RV32_HAS(EXT_C) */
+    ILLEGAL_INSN = 2,          /* Illegal instruction */
+    BREAKPOINT = 3,            /* Breakpoint */
+    LOAD_MISALIGNED = 4,       /* Load address misaligned */
+    STORE_MISALIGNED = 6,      /* Store/AMO address misaligned */
+#if RV32_HAS(SYSTEM)
+    PAGEFAULT_INSN = 12,       /* Instruction page fault */
+    PAGEFAULT_LOAD = 13,       /* Load page fault */
+    PAGEFAULT_STORE = 15,      /* Store page fault */
+#endif /* RV32_HAS(SYSTEM) */
+#if !RV32_HAS(SYSTEM)
+    ECALL_M = 11,              /* Environment call from M-mode */
+#endif /* !RV32_HAS(SYSTEM) */
+};
+/* clang-format on */
+
+/*
+ * For simplicity and clarity, abstracting m/scause and m/stval
+ * into a cause and tval identifier respectively.
+ */
+/* clang-format off */
+#define SET_CAUSE_AND_TVAL_THEN_TRAP(rv, cause, tval)       \
+    {                                                       \
+        /*                                                  \
+         * To align rv32emu behavior with Spike             \
+         *                                                  \
+         * If not in system mode, the __trap_handler        \
+         * should be be invoked                             \
+         */                                                 \
+        IIF(RV32_HAS(SYSTEM))(rv->is_trapped = true;, );    \
+        if(RV_PRIV_IS_U_OR_S_MODE()){                       \
+            rv->csr_scause = cause;                         \
+            rv->csr_stval = tval;                           \
+        } else {                                            \
+            rv->csr_mcause = cause;                         \
+            rv->csr_mtval = tval;                           \
+        }                                                   \
+        rv->io.on_trap(rv);                                 \
+    }
+/* clang-format on */
 
 /*
  * SBI functions must return a pair of values:
@@ -211,21 +375,28 @@ typedef softfloat_float32_t riscv_float_t;
 #endif
 
 /* memory read handlers */
-typedef riscv_word_t (*riscv_mem_ifetch)(riscv_word_t addr);
-typedef riscv_word_t (*riscv_mem_read_w)(riscv_word_t addr);
-typedef riscv_half_t (*riscv_mem_read_s)(riscv_word_t addr);
-typedef riscv_byte_t (*riscv_mem_read_b)(riscv_word_t addr);
+typedef riscv_word_t (*riscv_mem_ifetch)(riscv_t *rv, riscv_word_t addr);
+typedef riscv_word_t (*riscv_mem_read_w)(riscv_t *rv, riscv_word_t addr);
+typedef riscv_half_t (*riscv_mem_read_s)(riscv_t *rv, riscv_word_t addr);
+typedef riscv_byte_t (*riscv_mem_read_b)(riscv_t *rv, riscv_word_t addr);
 
 /* memory write handlers */
-typedef void (*riscv_mem_write_w)(riscv_word_t addr, riscv_word_t data);
-typedef void (*riscv_mem_write_s)(riscv_word_t addr, riscv_half_t data);
-typedef void (*riscv_mem_write_b)(riscv_word_t addr, riscv_byte_t data);
+typedef void (*riscv_mem_write_w)(riscv_t *rv,
+                                  riscv_word_t addr,
+                                  riscv_word_t data);
+typedef void (*riscv_mem_write_s)(riscv_t *rv,
+                                  riscv_word_t addr,
+                                  riscv_half_t data);
+typedef void (*riscv_mem_write_b)(riscv_t *rv,
+                                  riscv_word_t addr,
+                                  riscv_byte_t data);
 
 /* system instruction handlers */
 typedef void (*riscv_on_ecall)(riscv_t *rv);
 typedef void (*riscv_on_ebreak)(riscv_t *rv);
 typedef void (*riscv_on_memset)(riscv_t *rv);
 typedef void (*riscv_on_memcpy)(riscv_t *rv);
+typedef void (*riscv_on_trap)(riscv_t *rv);
 /* RISC-V emulator I/O interface */
 typedef struct {
     /* memory read interface */
@@ -246,6 +417,7 @@ typedef struct {
     riscv_on_ebreak on_ebreak;
     riscv_on_memset on_memset;
     riscv_on_memcpy on_memcpy;
+    riscv_on_trap on_trap;
 } riscv_io_t;
 
 /* run emulation */
@@ -294,6 +466,9 @@ void syscall_handler(riscv_t *rv);
 /* environment call handler */
 void ecall_handler(riscv_t *rv);
 
+/* trap handler */
+void trap_handler(riscv_t *rv);
+
 /* memset handler */
 void memset_handler(riscv_t *rv);
 
@@ -305,6 +480,17 @@ void dump_registers(riscv_t *rv, char *out_file_path);
 
 /* breakpoint exception handler */
 void ebreak_handler(riscv_t *rv);
+
+/*
+ * Trap might occurs during block emulation. For instance, page fault.
+ * In order to handle trap, we have to escape from block and execute
+ * registered trap handler. This trap_handler function helps to execute
+ * the registered trap handler, PC by PC. Once the trap is handled,
+ * resume the previous execution flow where cause the trap.
+ *
+ * Now, rv32emu supports misaligned access and page fault handling.
+ */
+void trap_handler(riscv_t *rv);
 
 /* halt the core */
 void rv_halt(riscv_t *rv);
@@ -328,9 +514,20 @@ typedef struct {
     char *elf_program;
 } vm_user_t;
 
+/* FIXME: replace with kernel image, dtb, etc */
+#if RV32_HAS(SYSTEM)
+typedef struct {
+    char *elf_program;
+} vm_system_t;
+#endif /* SYSTEM */
+
 typedef struct {
     vm_user_t *user;
-    /* TODO: system emulator stuff */
+
+#if RV32_HAS(SYSTEM)
+    vm_system_t *system;
+#endif /* SYSTEM */
+
 } vm_data_t;
 
 typedef struct {

--- a/src/syscall.c
+++ b/src/syscall.c
@@ -34,9 +34,11 @@
     _(brk,                  214)           \
     _(clock_gettime,        403)           \
     _(open,                 1024)          \
-    _(sbi_base,             0x10)          \
-    _(sbi_timer,            0x54494D45)    \
-    _(sbi_rst,              0x53525354)    \
+    IIF(RV32_HAS(SYSTEM))(                 \
+        _(sbi_base,         0x10)          \
+        _(sbi_timer,        0x54494D45)    \
+        _(sbi_rst,          0x53525354)    \
+    )                                      \
     IIF(RV32_HAS(SDL))(                    \
         _(draw_frame,       0xBEEF)        \
         _(setup_queue,      0xC0DE)        \
@@ -372,6 +374,8 @@ extern void syscall_setup_audio(riscv_t *rv);
 extern void syscall_control_audio(riscv_t *rv);
 #endif
 
+#if RV32_HAS(SYSTEM)
+
 /* SBI related system calls */
 static void syscall_sbi_timer(riscv_t *rv)
 {
@@ -459,6 +463,7 @@ static void syscall_sbi_rst(riscv_t *rv)
         break;
     }
 }
+#endif /* SYSTEM */
 
 void syscall_handler(riscv_t *rv)
 {

--- a/src/system.c
+++ b/src/system.c
@@ -1,0 +1,303 @@
+/*
+ * rv32emu is freely redistributable under the MIT License. See the file
+ * "LICENSE" for information on usage and redistribution of this file.
+ */
+
+#include "riscv_private.h"
+
+static bool ppn_is_valid(riscv_t *rv, uint32_t ppn)
+{
+    vm_attr_t *attr = PRIV(rv);
+    const uint32_t nr_pg_max = attr->mem_size / RV_PG_SIZE;
+    return ppn < nr_pg_max;
+}
+
+#define PAGE_TABLE(ppn)                                               \
+    ppn_is_valid(rv, ppn)                                             \
+        ? (uint32_t *) (attr->mem->mem_base + (ppn << (RV_PG_SHIFT))) \
+        : NULL
+
+/* Walk through page tables and get the corresponding PTE by virtual address if
+ * exists
+ * @rv: RISC-V emulator
+ * @addr: virtual address
+ * @level: the level of which the PTE is located
+ * @return: NULL if a not found or fault else the corresponding PTE
+ */
+static uint32_t *mmu_walk(riscv_t *rv, const uint32_t addr, uint32_t *level)
+{
+    vm_attr_t *attr = PRIV(rv);
+    uint32_t ppn = rv->csr_satp & MASK(22);
+
+    /* root page table */
+    uint32_t *page_table = PAGE_TABLE(ppn);
+    if (!page_table)
+        return NULL;
+
+    for (int i = 1; i >= 0; i--) {
+        *level = 2 - i;
+        uint32_t vpn =
+            (addr >> RV_PG_SHIFT >> (i * (RV_PG_SHIFT - 2))) & MASK(10);
+        uint32_t *pte = page_table + vpn;
+
+        uint8_t XWRV_bit = (*pte & MASK(4));
+        switch (XWRV_bit) {
+        case NEXT_PG_TBL: /* next level of the page table */
+            ppn = (*pte >> (RV_PG_SHIFT - 2));
+            page_table = PAGE_TABLE(ppn);
+            if (!page_table)
+                return NULL;
+            break;
+        case RO_PAGE:
+        case RW_PAGE:
+        case EO_PAGE:
+        case RX_PAGE:
+        case RWX_PAGE:
+            ppn = (*pte >> (RV_PG_SHIFT - 2));
+            if (*level == 1 &&
+                unlikely(ppn & MASK(10))) /* misaligned superpage */
+                return NULL;
+            return pte; /* leaf PTE */
+        case RESRV_PAGE1:
+        case RESRV_PAGE2:
+        default:
+            return NULL;
+        }
+    }
+
+    return NULL;
+}
+
+/* Verify the PTE and generate corresponding faults if needed
+ * @op: the operation
+ * @rv: RISC-V emulator
+ * @pte: to be verified pte
+ * @addr: the corresponding virtual address to cause fault
+ * @return: false if a any fault is generated which caused by violating the
+ * access permission else true
+ */
+/* FIXME: handle access fault, addr out of range check */
+#define MMU_FAULT_CHECK(op, rv, pte, addr, access_bits) \
+    mmu_##op##_fault_check(rv, pte, addr, access_bits)
+#define MMU_FAULT_CHECK_IMPL(op, pgfault)                                     \
+    static bool mmu_##op##_fault_check(riscv_t *rv, uint32_t *pte,            \
+                                       uint32_t addr, uint32_t access_bits)   \
+    {                                                                         \
+        uint32_t scause;                                                      \
+        uint32_t stval = addr;                                                \
+        switch (access_bits) {                                                \
+        case PTE_R:                                                           \
+            scause = PAGEFAULT_LOAD;                                          \
+            break;                                                            \
+        case PTE_W:                                                           \
+            scause = PAGEFAULT_STORE;                                         \
+            break;                                                            \
+        case PTE_X:                                                           \
+            scause = PAGEFAULT_INSN;                                          \
+            break;                                                            \
+        default:                                                              \
+            __UNREACHABLE;                                                    \
+            break;                                                            \
+        }                                                                     \
+        if (pte && (!(*pte & PTE_V))) {                                       \
+            SET_CAUSE_AND_TVAL_THEN_TRAP(rv, scause, stval);                  \
+            return false;                                                     \
+        }                                                                     \
+        if (!(pte && (*pte & access_bits))) {                                 \
+            SET_CAUSE_AND_TVAL_THEN_TRAP(rv, scause, stval);                  \
+            return false;                                                     \
+        }                                                                     \
+        /*                                                                    \
+         * (1) When MXR=0, only loads from pages marked readable (R=1) will   \
+         * succeed.                                                           \
+         *                                                                    \
+         * (2) When MXR=1, loads from pages marked either readable or         \
+         * executable (R=1 or X=1) will succeed.                              \
+         */                                                                   \
+        if (pte && ((!(SSTATUS_MXR & rv->csr_sstatus) && !(*pte & PTE_R) &&   \
+                     (access_bits == PTE_R)) ||                               \
+                    ((SSTATUS_MXR & rv->csr_sstatus) &&                       \
+                     !((*pte & PTE_R) | (*pte & PTE_X)) &&                    \
+                     (access_bits == PTE_R)))) {                              \
+            SET_CAUSE_AND_TVAL_THEN_TRAP(rv, scause, stval);                  \
+            return false;                                                     \
+        }                                                                     \
+        /*                                                                    \
+         * When SUM=0, S-mode memory accesses to pages that are accessible by \
+         * U-mode will fault.                                                 \
+         */                                                                   \
+        if (pte && rv->priv_mode == RV_PRIV_S_MODE &&                         \
+            !(SSTATUS_SUM & rv->csr_sstatus) && (*pte & PTE_U)) {             \
+            SET_CAUSE_AND_TVAL_THEN_TRAP(rv, scause, stval);                  \
+            return false;                                                     \
+        }                                                                     \
+        /* PTE not found, map it in handler */                                \
+        if (!pte) {                                                           \
+            SET_CAUSE_AND_TVAL_THEN_TRAP(rv, scause, stval);                  \
+            return false;                                                     \
+        }                                                                     \
+        /* valid PTE */                                                       \
+        return true;                                                          \
+    }
+
+MMU_FAULT_CHECK_IMPL(ifetch, pagefault_insn)
+MMU_FAULT_CHECK_IMPL(read, pagefault_load)
+MMU_FAULT_CHECK_IMPL(write, pagefault_store)
+
+#define get_ppn_and_offset()                                  \
+    uint32_t ppn;                                             \
+    uint32_t offset;                                          \
+    do {                                                      \
+        ppn = *pte >> (RV_PG_SHIFT - 2) << RV_PG_SHIFT;       \
+        offset = level == 1 ? addr & MASK((RV_PG_SHIFT + 10)) \
+                            : addr & MASK(RV_PG_SHIFT);       \
+    } while (0)
+
+/*
+ * The IO handler that operates when the Memory Management Unit (MMU)
+ * is enabled during system emulation is responsible for managing
+ * input/output operations. These callbacks are designed to implement
+ * the riscv_io_t interface, ensuring compatibility and consistency to
+ * the structure required by the interface. As a result, the riscv_io_t
+ * interface can be reused.
+ *
+ * The IO handlers include:
+ * - mmu_ifetch
+ * - mmu_read_w
+ * - mmu_read_s
+ * - mmu_read_b
+ * - mmu_write_w
+ * - mmu_write_s
+ * - mmu_write_b
+ */
+static uint32_t mmu_ifetch(riscv_t *rv, const uint32_t addr)
+{
+    if (!rv->csr_satp)
+        return memory_ifetch(addr);
+
+    uint32_t level;
+    uint32_t *pte = mmu_walk(rv, addr, &level);
+    bool ok = MMU_FAULT_CHECK(ifetch, rv, pte, addr, PTE_X);
+    if (unlikely(!ok)) {
+        pte = mmu_walk(rv, addr, &level);
+    }
+
+    get_ppn_and_offset();
+    return memory_ifetch(ppn | offset);
+}
+
+static uint32_t mmu_read_w(riscv_t *rv, const uint32_t addr)
+{
+    if (!rv->csr_satp)
+        return memory_read_w(addr);
+
+    uint32_t level;
+    uint32_t *pte = mmu_walk(rv, addr, &level);
+    bool ok = MMU_FAULT_CHECK(read, rv, pte, addr, PTE_R);
+    if (unlikely(!ok)) {
+        pte = mmu_walk(rv, addr, &level);
+    }
+
+    get_ppn_and_offset();
+    return memory_read_w(ppn | offset);
+}
+
+static uint16_t mmu_read_s(riscv_t *rv, const uint32_t addr)
+{
+    if (!rv->csr_satp)
+        return memory_read_s(addr);
+
+    uint32_t level;
+    uint32_t *pte = mmu_walk(rv, addr, &level);
+    bool ok = MMU_FAULT_CHECK(read, rv, pte, addr, PTE_R);
+    if (unlikely(!ok)) {
+        pte = mmu_walk(rv, addr, &level);
+    }
+
+    get_ppn_and_offset();
+    return memory_read_s(ppn | offset);
+}
+
+static uint8_t mmu_read_b(riscv_t *rv, const uint32_t addr)
+{
+    if (!rv->csr_satp)
+        return memory_read_b(addr);
+
+    uint32_t level;
+    uint32_t *pte = mmu_walk(rv, addr, &level);
+    bool ok = MMU_FAULT_CHECK(read, rv, pte, addr, PTE_R);
+    if (unlikely(!ok)) {
+        pte = mmu_walk(rv, addr, &level);
+    }
+
+    get_ppn_and_offset();
+    return memory_read_b(ppn | offset);
+}
+
+static void mmu_write_w(riscv_t *rv, const uint32_t addr, const uint32_t val)
+{
+    if (!rv->csr_satp)
+        return memory_write_w(addr, (uint8_t *) &val);
+
+    uint32_t level;
+    uint32_t *pte = mmu_walk(rv, addr, &level);
+    bool ok = MMU_FAULT_CHECK(write, rv, pte, addr, PTE_W);
+    if (unlikely(!ok)) {
+        pte = mmu_walk(rv, addr, &level);
+    }
+
+    get_ppn_and_offset();
+    memory_write_w(ppn | offset, (uint8_t *) &val);
+}
+
+static void mmu_write_s(riscv_t *rv, const uint32_t addr, const uint16_t val)
+{
+    if (!rv->csr_satp)
+        return memory_write_s(addr, (uint8_t *) &val);
+
+    uint32_t level;
+    uint32_t *pte = mmu_walk(rv, addr, &level);
+    bool ok = MMU_FAULT_CHECK(write, rv, pte, addr, PTE_W);
+    if (unlikely(!ok)) {
+        pte = mmu_walk(rv, addr, &level);
+    }
+
+    get_ppn_and_offset();
+    memory_write_s(ppn | offset, (uint8_t *) &val);
+}
+
+static void mmu_write_b(riscv_t *rv, const uint32_t addr, const uint8_t val)
+{
+    if (!rv->csr_satp)
+        return memory_write_b(addr, (uint8_t *) &val);
+
+    uint32_t level;
+    uint32_t *pte = mmu_walk(rv, addr, &level);
+    bool ok = MMU_FAULT_CHECK(write, rv, pte, addr, PTE_W);
+    if (unlikely(!ok)) {
+        pte = mmu_walk(rv, addr, &level);
+    }
+
+    get_ppn_and_offset();
+    memory_write_b(ppn | offset, (uint8_t *) &val);
+}
+
+riscv_io_t mmu_io = {
+    /* memory read interface */
+    .mem_ifetch = mmu_ifetch,
+    .mem_read_w = mmu_read_w,
+    .mem_read_s = mmu_read_s,
+    .mem_read_b = mmu_read_b,
+
+    /* memory write interface */
+    .mem_write_w = mmu_write_w,
+    .mem_write_s = mmu_write_s,
+    .mem_write_b = mmu_write_b,
+
+    /* system services or essential routines */
+    .on_ecall = ecall_handler,
+    .on_ebreak = ebreak_handler,
+    .on_memcpy = memcpy_handler,
+    .on_memset = memset_handler,
+    .on_trap = trap_handler,
+};

--- a/tests/system/mmu/Makefile
+++ b/tests/system/mmu/Makefile
@@ -1,0 +1,36 @@
+PREFIX ?= riscv-none-elf-
+ARCH = -march=rv32izicsr
+LINKER_SCRIPT = linker.ld
+
+DEBUG_CFLAGS = -g
+CFLAGS = -c -march=rv32i_zicsr
+LDFLAGS = -T
+EXEC = vm.elf
+
+CC = $(PREFIX)gcc
+AS = $(PREFIX)as
+LD = $(PREFIX)ld
+OBJDUMP = $(PREFIX)objdump
+
+# Locate libgcc.a dynamically, as the itoa function uses division and modulo operators,
+# which rely on __udivsi3 and __umodsi3, both provided by libgcc
+LIBGCC = $(shell $(CC) -print-libgcc-file-name)
+LIBGCC_PATH = $(shell dirname $(LIBGCC))
+
+deps = main.o setup.o vm_setup.o
+
+all:
+	$(CC) $(DEBUG_CLAGS) $(CFLAGS) main.c
+	$(CC) $(DEBUG_CLAGS) $(CFLAGS) vm_setup.c
+	$(AS) $(DEBUG_CLAGS) $(ARCH) setup.S -o setup.o
+	$(LD) $(LDFLAGS) $(LINKER_SCRIPT) -o $(EXEC) $(deps) -L$(LIBGCC_PATH) -lgcc
+
+dump:
+	$(OBJDUMP) -DS $(EXEC) | less
+
+# __udivsi3 and __umodsi3 can be found
+nm:
+	$(NM) $(LIBGCC) | less
+
+clean:
+	rm $(EXEC) $(deps)

--- a/tests/system/mmu/linker.ld
+++ b/tests/system/mmu/linker.ld
@@ -1,0 +1,31 @@
+OUTPUT_ARCH( "riscv" )
+
+ENTRY(_start)
+
+SECTIONS
+{
+  . = 0x00000000;
+  .text.main : { *(.text.main) }
+  . = ALIGN(0x1000);
+  .mystring : { *(.mystring) }
+  .data.main : { *(.data.main) }
+  .bss.main : { *(.bss.main) }
+
+  .text : {
+    . = 0x7fffeffc;
+    *(.text.setup)
+    *(.text.vm_setup)
+  }
+  . = ALIGN(0x1000);
+  .data : {
+    *(.data.setup)
+    *(.data.vm_setup)
+  }
+  .bss : {
+    *(.bss.setup)
+    *(.bss.vm_setup)
+  }
+
+  . = ALIGN(0x1000);
+  _end = .;
+}

--- a/tests/system/mmu/main.c
+++ b/tests/system/mmu/main.c
@@ -1,0 +1,102 @@
+#define SECTION_TEXT_MAIN __attribute__((section(".text.main")))
+#define SECTION_DATA_MAIN __attribute__((section(".data.main")))
+#define SECTION_BSS_MAIN __attribute__((section(".bss.main")))
+
+#define printstr(ptr, length)                   \
+    do {                                        \
+        asm volatile(                           \
+            "add a7, x0, 0x40;"                 \
+            "add a0, x0, 0x1;" /* stdout */     \
+            "add a1, x0, %0;"                   \
+            "mv a2, %1;" /* length character */ \
+            "ecall;"                            \
+            :                                   \
+            : "r"(ptr), "r"(length)             \
+            : "a0", "a1", "a2", "a7");          \
+    } while (0)
+
+#define TEST_OUTPUT(msg, length) printstr(msg, length)
+
+#define TEST_LOGGER(msg)                     \
+    {                                        \
+        char _msg[] = msg;                   \
+        TEST_OUTPUT(_msg, sizeof(_msg) - 1); \
+    }
+
+#define SUCCESS 0
+#define FAIL 1
+
+__attribute__((section(".mystring"))) const char pagefault_load_str[] =
+    "rv32emu";
+
+extern void _exit(int status);
+
+int SECTION_TEXT_MAIN main()
+{
+    /* instruction fetch page fault test */
+    int x = 100; /* trigger instruction page fault */
+    int y = 200;
+    int z = x + y;
+    TEST_LOGGER("INSTRUCTION FETCH PAGE FAULT TEST PASSED!\n");
+
+    char buf[8];
+    /* data load page fault test */
+    /* Clear buffer */
+    for (int i = 0; i < 8; i++) {
+        buf[i] = 0;
+    }
+
+    char *qtr = (char *) 0x1000; /* first data page */
+    /* should trigger load page fault and load pagefault_load_str */
+    for (int i = 0; i < 8; i++) {
+        qtr = (char *) 0x1000; /* FIXME: weird result without this */
+        buf[i] = *(qtr + i);
+    }
+
+    for (int i = 0; i < 8; i++) { /* should not trigger load page fault */
+        if (buf[i] != *(qtr + i)) {
+            TEST_LOGGER("[LOAD PAGE FAULT TEST] rv32emu string not match\n")
+            _exit(FAIL);
+        }
+    }
+    TEST_LOGGER("LOAD PAGE FAULT TEST PASSED!\n");
+
+    /* data store page fault test */
+    /* Clear buffer */
+    for (int i = 0; i < 8; i++) {
+        buf[i] = 0;
+    }
+
+    char *ptr = (char *) 0x2000; /* second data page */
+    *ptr = 'r';                  /* trigger store page fault */
+    ptr = (char *) 0x2000;       /* FIXME: weird result without this */
+    *(ptr + 1) = 'v';            /* should not trigger store page fault */
+    ptr = (char *) 0x2000;       /* FIXME: weird result without this */
+    *(ptr + 2) = '3';            /* should not trigger store page fault */
+    ptr = (char *) 0x2000;       /* FIXME: weird result without this */
+    *(ptr + 3) = '2';            /* should not trigger store page fault */
+    ptr = (char *) 0x2000;       /* FIXME: weird result without this */
+    *(ptr + 4) = 'e';            /* should not trigger store page fault */
+    ptr = (char *) 0x2000;       /* FIXME: weird result without this */
+    *(ptr + 5) = 'm';            /* should not trigger store page fault */
+    ptr = (char *) 0x2000;       /* FIXME: weird result without this */
+    *(ptr + 6) = 'u';            /* should not trigger store page fault */
+    ptr = (char *) 0x2000;       /* FIXME: weird result without this */
+    *(ptr + 7) = '\0';           /* should not trigger store page fault */
+
+    /* should not trigger load page fault */
+    for (int i = 0; i < 8; i++) {
+        buf[i] = *(ptr + i);
+    }
+
+    /* should not trigger load page fault */
+    for (int i = 0; i < 8; i++) {
+        if (buf[i] != *(ptr + i)) {
+            TEST_LOGGER("[STORE PAGE FAULT TEST] rv32emu string not match\n")
+            _exit(FAIL);
+        }
+    }
+    TEST_LOGGER("STORE PAGE FAULT TEST PASSED!\n");
+
+    _exit(SUCCESS);
+}

--- a/tests/system/mmu/setup.S
+++ b/tests/system/mmu/setup.S
@@ -1,0 +1,162 @@
+.section .text.setup
+TRAPFRAME_SIZE = 35 * 4
+PG_SIZE = 4096
+STACK_TOP = _end + PG_SIZE
+
+# FIXME: implement proper machine trap vector
+# Since I assume that all interrupts and exceptions are
+# handled by S-mode software, so the machine trap
+# vector is not that much important in here
+machine_trap_vector:
+    j _exit;
+
+.globl _start
+_start:
+    # init regs
+    li x1, 0
+    li x2, 0
+    li x3, 0
+    li x4, 0
+    li x5, 0
+    li x6, 0
+    li x7, 0
+    li x8, 0
+    li x9, 0
+    li x10, 0
+    li x11, 0
+    li x12, 0
+    li x13, 0
+    li x14, 0
+    li x15, 0
+    li x16, 0
+    li x17, 0
+    li x18, 0
+    li x19, 0
+    li x20, 0
+    li x21, 0
+    li x22, 0
+    li x23, 0
+    li x24, 0
+    li x25, 0
+    li x26, 0
+    li x27, 0
+    li x28, 0
+    li x29, 0
+    li x30, 0
+    li x31, 0
+
+    la sp, STACK_TOP - TRAPFRAME_SIZE
+    csrw mscratch, sp;
+
+    #la t0, machine_trap_vector
+    #csrw mtvec, t0
+    #csrr t0, mtvec # for debugging
+
+    # init virtual memory
+    j vm_boot
+
+.globl _exit
+_exit:
+    li a7, 93
+    ecall
+
+.globl user_entry
+user_entry:
+    la sp, STACK_TOP - TRAPFRAME_SIZE
+    jalr x0, 0x4  # jump to user space main
+
+.globl supervisor_trap_entry
+supervisor_trap_entry:
+    # get trapframe pointer (save a0 into scratch)
+    csrrw a0, sscratch, a0;
+
+    # push regs into trapframe
+    sw x1, 0*4(a0);
+    sw x2, 1*4(a0);
+    sw x3, 2*4(a0);
+    sw x4, 3*4(a0);
+    sw x5, 4*4(a0);
+    sw x6, 5*4(a0);
+    sw x7, 6*4(a0);
+    sw x8, 7*4(a0);
+    sw x9, 8*4(a0);
+    sw x11, 10*4(a0);
+    sw x12, 11*4(a0);
+    sw x13, 12*4(a0);
+    sw x14, 13*4(a0);
+    sw x15, 14*4(a0);
+    sw x16, 15*4(a0);
+    sw x17, 16*4(a0);
+    sw x18, 17*4(a0);
+    sw x19, 18*4(a0);
+    sw x20, 19*4(a0);
+    sw x21, 20*4(a0);
+    sw x22, 21*4(a0);
+    sw x23, 22*4(a0);
+    sw x24, 23*4(a0);
+    sw x25, 24*4(a0);
+    sw x26, 25*4(a0);
+    sw x27, 26*4(a0);
+    sw x28, 27*4(a0);
+    sw x29, 28*4(a0);
+    sw x20, 29*4(a0);
+    sw x31, 30*4(a0);
+
+    # load stack pointer and save trapframe pointer into scratch
+    csrrw t0, sscratch, a0;
+    sw t0, 9*4(a0);
+
+    # push status, epc, badaddr, cause
+    csrr t0, sstatus;
+    sw t0, 31*4(a0);
+    csrr t0, sepc;
+    sw t0, 32*4(a0);
+    csrr t0, stval;
+    sw t0, 33*4(a0);
+    csrr t0, scause;
+    sw t0, 34*4(a0);
+
+    csrr sp, sscratch;
+    j handle_trap;
+
+.globl pop_tf
+pop_tf:
+    # a0 need to save trapframe pointer
+    # pop epc and regs from trapframe
+    lw t0, 32*4(a0)
+    csrw sepc, t0
+    lw x1, 0*4(a0)
+    lw x2, 1*4(a0)
+    lw x3, 2*4(a0)
+    lw x4, 3*4(a0)
+    lw x5, 4*4(a0)
+    lw x6, 5*4(a0)
+    lw x7, 6*4(a0)
+    lw x8, 7*4(a0)
+    lw x9, 8*4(a0)
+    lw x11, 10*4(a0)
+    lw x12, 11*4(a0)
+    lw x13, 12*4(a0)
+    lw x14, 13*4(a0)
+    lw x15, 14*4(a0)
+    lw x16, 15*4(a0)
+    lw x17, 16*4(a0)
+    lw x18, 17*4(a0)
+    lw x19, 18*4(a0)
+    lw x20, 19*4(a0)
+    lw x21, 20*4(a0)
+    lw x22, 21*4(a0)
+    lw x23, 22*4(a0)
+    lw x24, 23*4(a0)
+    lw x25, 24*4(a0)
+    lw x26, 25*4(a0)
+    lw x27, 26*4(a0)
+    lw x28, 27*4(a0)
+    lw x29, 28*4(a0)
+    lw x20, 29*4(a0)
+    lw x31, 30*4(a0)
+
+    # save trapframe pointer to sscratch
+    csrrw a0, sscratch, a0;
+
+    sret

--- a/tests/system/mmu/vm_setup.c
+++ b/tests/system/mmu/vm_setup.c
@@ -1,0 +1,420 @@
+/*
+ * Reference:
+ * 1. https://github.com/sifive/example-vm-test
+ * 2. https://github.com/yutongshen/RISC-V-Simulator
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#if !defined(__GNUC__) || !defined(__riscv) || 32 != __riscv_xlen
+#error "GNU Toolchain for 32-bit RISC-V is required"
+#endif
+
+#define SECTION_TEXT_VMSETUP __attribute__((section(".text.vm_setup")))
+#define SECTION_DATA_VMSETUP __attribute__((section(".data.vm_setup")))
+#define SECTION_BSS_VMSETUP __attribute__((section(".bss.vm_setup")))
+
+#define assert(x)                                                     \
+    do {                                                              \
+        if (!x) {                                                     \
+            printf("Assertion failed '%s' at line %d of '%s'\n", #x); \
+            _exit(1);                                                 \
+        }                                                             \
+    } while (0)
+
+#define read_csr(reg)                                 \
+    ({                                                \
+        uint32_t __tmp;                               \
+        asm volatile("csrr %0, " #reg : "=r"(__tmp)); \
+        __tmp;                                        \
+    })
+
+#define write_csr(reg, val) ({ asm volatile("csrw " #reg ", %0" ::"rK"(val)); })
+
+#define swap_csr(reg, val)                                                \
+    ({                                                                    \
+        uint32_t __tmp;                                                   \
+        asm volatile("csrrw %0, " #reg ", %1" : "=r"(__tmp) : "rK"(val)); \
+        __tmp;                                                            \
+    })
+
+#define set_csr(reg, bit)                                                 \
+    ({                                                                    \
+        uint32_t __tmp;                                                   \
+        asm volatile("csrrs %0, " #reg ", %1" : "=r"(__tmp) : "rK"(bit)); \
+        __tmp;                                                            \
+    })
+
+#define clear_csr(reg, bit)                                               \
+    ({                                                                    \
+        uint32_t __tmp;                                                   \
+        asm volatile("csrrc %0, " #reg ", %1" : "=r"(__tmp) : "rK"(bit)); \
+        __tmp;                                                            \
+    })
+
+typedef struct {
+    uint32_t ra;
+    uint32_t sp;
+    uint32_t gp;
+    uint32_t tp;
+    uint32_t t0;
+    uint32_t t1;
+    uint32_t t2;
+    uint32_t s0;
+    uint32_t s1;
+    uint32_t a0;
+    uint32_t a1;
+    uint32_t a2;
+    uint32_t a3;
+    uint32_t a4;
+    uint32_t a5;
+    uint32_t a6;
+    uint32_t a7;
+    uint32_t s2;
+    uint32_t s3;
+    uint32_t s4;
+    uint32_t s5;
+    uint32_t s6;
+    uint32_t s7;
+    uint32_t s8;
+    uint32_t s9;
+    uint32_t s10;
+    uint32_t s11;
+    uint32_t t3;
+    uint32_t t4;
+    uint32_t t5;
+    uint32_t t6;
+    uint32_t status;
+    uint32_t epc;
+    uint32_t badvaddr;
+    uint32_t cause;
+} trapframe_t;
+
+#define SV32_MODE 0x80000000
+#define BARE_MODE 0x00000000
+#define PG_SHIFT 12
+#define PG_SIZE (1U << 12)
+#define FREE_FRAME_BASE 0x400000
+#define MAX_TEST_PG 32          /* FREE_FRAME_BASE - 0x41ffff */
+#define MEGA_PG (PG_SIZE << 10) /* 4 MiB */
+
+#define CAUSE_USER_ECALL (1U << 8)
+#define CAUSE_SUPERVISOR_ECALL (1U << 9)
+#define CAUSE_FETCH_PAGE_FAULT (1U << 12)
+#define CAUSE_LOAD_PAGE_FAULT (1U << 13)
+#define CAUSE_STORE_PAGE_FAULT (1U << 15)
+
+#define SSTATUS_SUM (1U << 18)
+
+#define PTE_V (1U)
+#define PTE_R (1U << 1)
+#define PTE_W (1U << 2)
+#define PTE_X (1U << 3)
+#define PTE_U (1U << 4)
+#define PTE_G (1U << 5)
+#define PTE_A (1U << 6)
+#define PTE_D (1U << 7)
+
+extern void main();
+extern void _start();
+extern int user_entry();
+extern void supervisor_trap_entry();
+extern void pop_tf(trapframe_t *);
+extern void _exit(int status);
+
+typedef uint32_t pte_t;
+typedef struct {
+    pte_t addr;
+    void *next;
+} freelist_t;
+
+freelist_t freelist_nodes[MAX_TEST_PG] SECTION_BSS_VMSETUP;
+freelist_t *SECTION_BSS_VMSETUP freelist_head;
+freelist_t *SECTION_BSS_VMSETUP freelist_tail;
+
+#define l1pt pt[0]
+#define user_l1pt pt[1]
+#define NPT 2
+#define PTES_PER_PT (1U << 10)
+#define PTE_PPN_SHIFT 10
+pte_t pt[NPT][PTES_PER_PT] SECTION_BSS_VMSETUP
+    __attribute__((aligned(PG_SIZE)));
+
+#define MASK(n) (~((~0U << (n))))
+#define pa2kva(x) (((pte_t) (x)) - ((pte_t) (_start)) - MEGA_PG)
+#define uva2kva(x) (((pte_t) (x)) - MEGA_PG)
+
+void *SECTION_TEXT_VMSETUP memcpy(void *ptr, void *src, size_t len)
+{
+    uint32_t *word_ptr = ptr;
+    uint32_t *word_src = src;
+
+    while (len >= 4) {
+        *word_ptr++ = *word_src++;
+        len -= 4;
+    }
+
+    char *byte_ptr = (char *) word_ptr;
+    char *byte_src = (char *) word_src;
+    while (len--) {
+        *byte_ptr++ = *byte_src++;
+    }
+
+    return ptr;
+}
+
+void *SECTION_TEXT_VMSETUP memset(void *ptr, int val, size_t len)
+{
+    uint32_t *word_ptr = ptr;
+    uint32_t write_word = (char) val;
+    write_word |= write_word << 8;
+    write_word |= write_word << 16;
+
+    while (len >= 4) {
+        *word_ptr++ = write_word;
+        len -= 4;
+    }
+
+    char *byte_ptr = (char *) word_ptr;
+    while (len--) {
+        *byte_ptr++ = val;
+    }
+
+    return ptr;
+}
+
+#define SYSCALL_WRITE 64
+int SECTION_TEXT_VMSETUP putchar(int ch)
+{
+    int syscall_nr = SYSCALL_WRITE;
+    asm volatile(
+        "mv a7, %0;"
+        "li a0, 0x1;" /* stdout */
+        "add a1, x0, %1;"
+        "li a2, 0x1;" /* one character */
+        "ecall;"
+        :
+        : "r"(syscall_nr), "r"(&ch)
+        : "a0", "a1", "a2", "a7");
+
+    return 0;
+}
+
+int SECTION_TEXT_VMSETUP _puts(const char *s)
+{
+    int res = 0;
+    while (*s) {
+        putchar(*(s++));
+        ++res;
+    }
+
+    return res;
+}
+
+int SECTION_TEXT_VMSETUP puts(const char *s)
+{
+    int res = 1;
+    res += _puts(s);
+    putchar('\n');
+
+    return res;
+}
+
+char *SECTION_TEXT_VMSETUP itoa(uint32_t value,
+                                int base,
+                                int min_len,
+                                char fill_char)
+{
+    static char digitals[16] = {'0', '1', '2', '3', '4', '5', '6', '7',
+                                '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+    static char str[64];
+    char *ptr = str + 63;
+    int tmp;
+    *ptr = 0;
+    do {
+        if (!value)
+            *--ptr = fill_char;
+        else
+            *--ptr = digitals[value % base];
+        value /= base;
+    } while (--min_len > 0 || value);
+
+    return ptr;
+}
+
+int SECTION_TEXT_VMSETUP printf(const char *format, ...)
+{
+    const char *ptr = format;
+    int res = 0;
+
+    va_list va;
+    va_start(va, format);
+
+    while (*ptr) {
+        if (*ptr == '%') {
+            int min_len = 0;
+            char fill_char = 0;
+        loop1:
+            switch (*(++ptr)) {
+            case 'c':
+                assert(!(min_len || fill_char));
+                ++res;
+                putchar(va_arg(va, int));
+                break;
+            case 's':
+                assert(!(min_len || fill_char));
+                res += _puts(va_arg(va, const char *));
+                break;
+            case 'x': {
+                assert(!(!fill_char ^ !min_len));
+                uint32_t n = va_arg(va, uint32_t);
+                res += _puts(itoa(n, 16, min_len, min_len ? fill_char : '0'));
+            } break;
+            case 'd': {
+                assert(!(!fill_char ^ !min_len));
+                int64_t n = va_arg(va, int64_t);
+                if (n < 0) {
+                    ++res;
+                    putchar('-');
+                    n = -n;
+                }
+                res += _puts(itoa(n, 10, min_len, min_len ? fill_char : '0'));
+            } break;
+            case '%':
+                ++res;
+                putchar('%');
+                break;
+            case '1':
+                assert(fill_char);
+                min_len *= 10;
+                min_len += 1;
+                goto loop1;
+            case '2':
+                assert(fill_char);
+                min_len *= 10;
+                min_len += 2;
+                goto loop1;
+            case '3':
+                assert(fill_char);
+                min_len *= 10;
+                min_len += 3;
+                goto loop1;
+            case '4':
+                assert(fill_char);
+                min_len *= 10;
+                min_len += 4;
+                goto loop1;
+            case '5':
+                assert(fill_char);
+                min_len *= 10;
+                min_len += 5;
+                goto loop1;
+            case '6':
+                assert(fill_char);
+                min_len *= 10;
+                min_len += 6;
+                goto loop1;
+            case '7':
+                assert(fill_char);
+                min_len *= 10;
+                min_len += 7;
+                goto loop1;
+            case '8':
+                assert(fill_char);
+                min_len *= 10;
+                min_len += 8;
+                goto loop1;
+            case '9':
+                assert(fill_char);
+                min_len *= 10;
+                min_len += 9;
+                goto loop1;
+            default:
+                assert(!min_len);
+                fill_char = *ptr;
+                goto loop1;
+            }
+        } else {
+            ++res;
+            putchar(*ptr);
+        }
+        ++ptr;
+    }
+    return res;
+}
+
+void SECTION_TEXT_VMSETUP handle_fault(uint32_t addr, uint32_t cause)
+{
+    addr = addr >> PG_SHIFT << PG_SHIFT; /* round down page */
+    pte_t *pte = user_l1pt + ((addr >> PG_SHIFT) & MASK(10));
+
+    /* create a new pte */
+    assert(freelist_head);
+    pte_t pa = freelist_head->addr;
+    freelist_head = freelist_head->next;
+    *pte = (pa >> PG_SHIFT << PTE_PPN_SHIFT) | PTE_A | PTE_U | PTE_R | PTE_W |
+           PTE_X | PTE_V;
+    if ((1U << cause) == CAUSE_STORE_PAGE_FAULT)
+        *pte |= PTE_D;
+
+    /* temporarily allow kernel to access user memory to copy data */
+    set_csr(sstatus, SSTATUS_SUM);
+    /* page table is updated, so main should not cause trap here */
+    memcpy((uint32_t *) addr, (uint32_t *) uva2kva(addr), PG_SIZE);
+    /* disallow kernel to access user memory */
+    clear_csr(sstatus, SSTATUS_SUM);
+}
+
+void SECTION_TEXT_VMSETUP handle_trap(trapframe_t *tf)
+{
+    if ((1U << tf->cause) == CAUSE_FETCH_PAGE_FAULT ||
+        (1U << tf->cause) == CAUSE_LOAD_PAGE_FAULT ||
+        (1U << tf->cause) == CAUSE_STORE_PAGE_FAULT) {
+        handle_fault(tf->badvaddr, tf->cause);
+    } else
+        assert(!"Unknown exception");
+
+    pop_tf(tf);
+}
+
+void SECTION_TEXT_VMSETUP vm_boot()
+{
+    /* map first page table entry to a next level page table for user */
+    l1pt[0] = ((pte_t) user_l1pt >> PG_SHIFT << PTE_PPN_SHIFT) | PTE_V;
+    /* map last page table leaf entry for kernel which direct maps for user
+     * virtual memory, note that this is a trick of 2's complement, e.g., 0 -
+     * MEGA_PG = 0b1111111111xxx...x when page fault occurs after entering main
+     */
+    l1pt[PTES_PER_PT - 1] = ((pte_t) main >> PG_SHIFT << PTE_PPN_SHIFT) |
+                            PTE_V | PTE_R | PTE_W | PTE_X | PTE_A | PTE_D;
+
+    /* direct map kernel virtual memory */
+    l1pt[PTES_PER_PT >> 1] = ((pte_t) _start >> PG_SHIFT << PTE_PPN_SHIFT) |
+                             PTE_V | PTE_R | PTE_W | PTE_X | PTE_A | PTE_D;
+
+    /* Enable paging */
+    uintptr_t satp_val = ((pte_t) &l1pt >> PG_SHIFT) | SV32_MODE;
+    write_csr(satp, satp_val);
+
+    /* set up supervisor trap handler */
+    write_csr(stvec, supervisor_trap_entry);
+    write_csr(sscratch, read_csr(mscratch));
+    /* No delegation */
+    /*write_csr(medeleg, CAUSE_FETCH_PAGE_FAULT | CAUSE_LOAD_PAGE_FAULT |
+                           CAUSE_STORE_PAGE_FAULT);*/
+
+    freelist_head = (void *) &freelist_nodes[0];
+    freelist_tail = &freelist_nodes[MAX_TEST_PG - 1];
+    for (uint32_t i = 0; i < MAX_TEST_PG; i++) {
+        freelist_nodes[i].addr = FREE_FRAME_BASE + i * PG_SIZE;
+        freelist_nodes[i].next = &freelist_nodes[i + 1];
+    }
+    freelist_nodes[MAX_TEST_PG - 1].next = 0;
+
+    trapframe_t tf;
+    memset(&tf, 0, sizeof(tf));
+    tf.epc = (uint32_t) &user_entry;
+    pop_tf(&tf);
+}


### PR DESCRIPTION
The purpose of this commit is to boot 32-bit RISC-V Linux in the future. The virtual memory scheme to support is Sv32. There are one change to original code base to adapt the MMU: the prototype of `riscv_io_t` interface needs to be changed. Particularly, add a RISC-V instance(`riscv_t`) as the first parameter. MMU related callbacks require to access the satp CSR to perform a page table walk during virtual memory translation but satp CSR is stored in RISC-V instance(`riscv_t`), thus it should have a way to access the satp CSR. The trivial solution is adding RISC-V
instance(`riscv_t`) to the prototype of `riscv_io_t` interface.

After this change, we can reuse riscv_io_t for system emulation afterward.

The rest of changes are implementing the Sv32 virtual memory scheme. For every memory access, it has to walk through the page table to get the corresponding PTE. Depends on the retrieval of PTE, there are several page faults to be handled if necessary, so there are three exceptions handlers have been introduced which are insn_pgfault, load_pgfault, and store_pgfault and they are used in MMU_CHECK_FAULT. In this commit, the access fault are not handled well since they are related to PMA and PMP and they might not the must to boot 32-bit RISC-V Linux (tested on semu). More PTE, S-mode, M-mode CSR helper macro are introduced as well.

Related: #310