### PR TITLE
Implement minimal SBI v0.3

### DIFF
--- a/src/riscv.c
+++ b/src/riscv.c
@@ -469,6 +469,9 @@ void rv_reset(riscv_t *rv, riscv_word_t pc)
     rv->csr_cycle = 0;
     rv->csr_mstatus = 0;
     rv->csr_misa |= MISA_SUPER | MISA_USER | MISA_I;
+    rv->csr_mvendorid = RV_MVENDORID;
+    rv->csr_marchid = RV_MARCHID;
+    rv->csr_mimpid = RV_MIMPID;
 #if RV32_HAS(EXT_A)
     rv->csr_misa |= MISA_A;
 #endif

--- a/src/riscv.h
+++ b/src/riscv.h
@@ -96,6 +96,51 @@ enum {
 #define MSTATUS_MPIE (1 << MSTATUS_MPIE_SHIFT)
 #define MSTATUS_MPP (3 << MSTATUS_MPP_SHIFT)
 
+/*
+ * SBI functions must return a pair of values:
+ *
+ * struct sbiret {
+ *     long error;
+ *     long value;
+ * };
+ *
+ * The error and value field will be set to register a0 and a1 respectively
+ * after the SBI function return. The error field indicate whether the
+ * SBI call is success or not. SBI_SUCCESS indicates success and
+ * SBI_ERR_NOT_SUPPORTED indicates not supported failure. The value field is
+ * the information based on the extension ID(EID) and SBI function ID(FID).
+ *
+ * SBI reference: https://github.com/riscv-non-isa/riscv-sbi-doc
+ *
+ */
+#define SBI_SUCCESS 0
+#define SBI_ERR_NOT_SUPPORTED -2
+
+/*
+ * All of the functions in the base extension must be supported by
+ * all SBI implementations.
+ */
+#define SBI_EID_BASE 0x10
+#define SBI_BASE_GET_SBI_SPEC_VERSION 0
+#define SBI_BASE_GET_SBI_IMPL_ID 1
+#define SBI_BASE_GET_SBI_IMPL_VERSION 2
+#define SBI_BASE_PROBE_EXTENSION 3
+#define SBI_BASE_GET_MVENDORID 4
+#define SBI_BASE_GET_MARCHID 5
+#define SBI_BASE_GET_MIMPID 6
+
+/* Make supervisor to schedule the clock for next timer event. */
+#define SBI_EID_TIMER 0x54494D45
+#define SBI_TIMER_SET_TIMER 0
+
+/* Allows the supervisor to request system-level reboot or shutdown. */
+#define SBI_EID_RST 0x53525354
+#define SBI_RST_SYSTEM_RESET 0
+
+#define RV_MVENDORID 0x12345678
+#define RV_MARCHID ((1ULL << 31) | 1)
+#define RV_MIMPID 1
+
 #define BLOCK_MAP_CAPACITY_BITS 10
 
 /* forward declaration for internal structure */
@@ -294,6 +339,9 @@ typedef struct {
 
     /* the data segment break address */
     riscv_word_t break_addr;
+
+    /* SBI timer */
+    uint64_t timer;
 } vm_attr_t;
 
 #ifdef __cplusplus

--- a/src/riscv_private.h
+++ b/src/riscv_private.h
@@ -110,16 +110,19 @@ struct riscv_internal {
 #endif
 
     /* csr registers */
-    uint64_t csr_cycle;    /* Machine cycle counter */
-    uint32_t csr_time[2];  /* Performance conter */
-    uint32_t csr_mstatus;  /* Machine status regester */
-    uint32_t csr_mtvec;    /* Machine trap-handler base address */
-    uint32_t csr_misa;     /* ISA and extensions */
-    uint32_t csr_mtval;    /* Machine bad address or instruction */
-    uint32_t csr_mcause;   /* Machine trap cause */
-    uint32_t csr_mscratch; /* Scartch register for machine trap handler */
-    uint32_t csr_mepc;     /* Machine exception program counter */
-    uint32_t csr_mip;      /* Machine interrupt pending */
+    uint64_t csr_cycle;     /* Machine cycle counter */
+    uint32_t csr_time[2];   /* Performance counter */
+    uint32_t csr_mstatus;   /* Machine status register */
+    uint32_t csr_mtvec;     /* Machine trap-handler base address */
+    uint32_t csr_misa;      /* ISA and extensions */
+    uint32_t csr_mtval;     /* Machine bad address or instruction */
+    uint32_t csr_mcause;    /* Machine trap cause */
+    uint32_t csr_mscratch;  /* Scratch register for machine trap handler */
+    uint32_t csr_mepc;      /* Machine exception program counter */
+    uint32_t csr_mip;       /* Machine interrupt pending */
+    uint32_t csr_mvendorid; /* vendor ID */
+    uint32_t csr_marchid;   /* Architecture ID */
+    uint32_t csr_mimpid;    /* Implementation ID */
     uint32_t csr_mbadaddr;
 
     bool compressed; /**< current instruction is compressed or not */


### PR DESCRIPTION
SBI acts as a communication layer between S-mode software and M-mode hardware. To boot Linux kernel, there are some minimal SBI extensions have to be implemented and they are:
1. Base extension(EID=0x10)
2. Timer extension(EID=0x54494D45)

SRST extension(EID=0x53525354) is optional so just implemented shutdown reason.

Related: #310