### PR TITLE
Correctly update the information of hotspot

### DIFF
--- a/src/jit.c
+++ b/src/jit.c
@@ -1964,6 +1964,7 @@ void jit_translate(riscv_t *rv, block_t *block)
         for (int i = 0; i < state->n_blocks; i++) {
             if (block->pc_start == state->offset_map[i].pc) {
                 block->offset = state->offset_map[i].offset;
+                block->hot = true;
                 return;
             }
         }


### PR DESCRIPTION
In the original version, we didn't update the hotspot state of the block that had been translated before, resulting in the block not being able to be executed through T1C.