### PR TITLE
Specify can_branch and decode the sret instruction

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -826,10 +826,12 @@ static inline bool op_system(rv_insn_t *ir, const uint32_t insn)
             break;
         case 0x105: /* WFI: Wait for Interrupt */
         case 0x002: /* URET: return from traps in U-mode */
-        case 0x102: /* SRET: return from traps in S-mode */
         case 0x202: /* HRET: return from traps in H-mode */
-            /* illegal instruciton */
+            /* illegal instruction */
             return false;
+        case 0x102: /* SRET: return from traps in S-mode */
+            ir->opcode = rv_insn_sret;
+            break;
         case 0x302: /* MRET */
             ir->opcode = rv_insn_mret;
             break;

--- a/src/decode.h
+++ b/src/decode.h
@@ -77,7 +77,7 @@ enum op_field {
     /* RISC-V Privileged Instruction */                \
     _(wfi, 0, 4, 0, ENC(rs1, rd))                      \
     _(uret, 0, 4, 0, ENC(rs1, rd))                     \
-    _(sret, 0, 4, 0, ENC(rs1, rd))                     \
+    _(sret, 1, 4, 0, ENC(rs1, rd))                     \
     _(hret, 0, 4, 0, ENC(rs1, rd))                     \
     _(mret, 1, 4, 0, ENC(rs1, rd))                     \
     /* RV32 Zifencei Standard Extension */             \


### PR DESCRIPTION
sret instruction is used for returning from a trap when trap occurs in S-mode level. Thus, the execution flow will not be sequential. During basic block translation, the sret instruction should be considered as can_branch instruction.