### PR TITLE
Modify get_time_info() to return seconds and nanoseconds

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -59,11 +59,6 @@ void rv_gettimeofday(struct timeval *tv)
     tv->tv_usec = tv_usec;
 }
 
-/* TODO: Clarify newlib's handling of time units.
- * It appears that newlib is using millisecond resolution for time manipulation,
- * while clock_gettime expects nanoseconds in the timespec struct.
- * Further investigation are needed.
- */
 void rv_clock_gettime(struct timespec *tp)
 {
     int32_t tv_sec, tv_usec;


### PR DESCRIPTION
Modify get_time_info() to return seconds and nanoseconds to get higher time resolution. Additionally, remove the outdated TODO comments as it was solved in newlib v4.4.0 [1].

Link: https://sourceware.org/git/?p=newlib-cygwin.git;a=commit;h=5f15d7c5817b07a6b18cbab17342c95cb7b42be4 [1]