### PR TITLE
Fix canonical order of RISC-V extension names in help information

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -52,7 +52,7 @@ static char *prof_out_file;
 static void print_usage(const char *filename)
 {
     fprintf(stderr,
-            "RV32I[MACF] Emulator which loads an ELF file to execute.\n"
+            "RV32I[MAFC] Emulator which loads an ELF file to execute.\n"
             "Usage: %s [options] [filename] [arguments]\n"
             "Options:\n"
             "  -t : print executable trace\n"


### PR DESCRIPTION
Similar to commit d511c1e2b07a ("Use the canonical order of RISC-V extension names (#363)"), this change corrects the display of the canonical order of RISC-V extension names in the help information.

Link: https://github.com/sysprog21/rv32emu/issues/359