### PR TITLE
Fix insufficient memory on some platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,11 @@ LDFLAGS += -flto=thin
 endif
 endif
 
+# Allow user to config the memory size accordingly
+ifdef CONFIG_MEM_SIZE
+    CFLAGS += -DMEM_SIZE=$(CONFIG_MEM_SIZE)
+endif
+
 # Disable Intel's Control-flow Enforcement Technology (CET)
 CFLAGS += $(CFLAGS_NO_CET)
 


### PR DESCRIPTION
[Problem]
The MEM_SIZE is hard-corded, but on some platforms, memory is insufficient.
Perhaps we should allow user to config accordingly

[Solution]
Expose an environment variable, CONFIG_MEM_SIZE, to allow user config the memory size with it

[Test]
* before $> make
$> ./build/rv32emu ./build/hello.elf
rv32emu: src/riscv.c:199: rv_create: Assertion `attr->mem' failed. Aborted (core dumped)

* after $> CONFIG_MEM_SIZE=0x40000000 make
$> ./build/rv32emu ./build/hello.elf
Hello World!
Hello World!
Hello World!
Hello World!
Hello World!
inferior exit code 0

[Reference]
[#488](https://github.com/sysprog21/rv32emu/issues/448)