### PR TITLE
Add sret case to insn_is_unconditional_branch

### DIFF
--- a/src/emulate.c
+++ b/src/emulate.c
@@ -560,6 +560,7 @@ FORCE_INLINE bool insn_is_unconditional_branch(uint8_t opcode)
     case rv_insn_ebreak:
     case rv_insn_jal:
     case rv_insn_jalr:
+    case rv_insn_sret:
     case rv_insn_mret:
 #if RV32_HAS(EXT_C)
     case rv_insn_cj:


### PR DESCRIPTION
Since sret is made to branchable in #443, the relevant checking function which determine if the instruction is branchable also should be updated.