### PR TITLE
jit: Introduce background compilation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
     - name: undefined behavior test
       run: |
             make clean && make ENABLE_UBSAN=1 check -j$(nproc)
-            make ENABLE_JIT=1 clean clean && make ENABLE_JIT=1 ENABLE_UBSAN=1 check -j$(nproc)
+            make ENABLE_JIT=1 clean && make ENABLE_JIT=1 ENABLE_UBSAN=1 check -j$(nproc)
 
   host-arm64:
     needs: [detect-code-related-file-changes]
@@ -134,6 +134,9 @@ jobs:
       run: |
             sudo apt-get update -q -y
             sudo apt-get install -q -y clang clang-tools libsdl2-dev libsdl2-mixer-dev
+            wget https://apt.llvm.org/llvm.sh
+            chmod +x ./llvm.sh
+            sudo ./llvm.sh 17
       shell: bash
     - name: run scan-build without JIT
       run: make distclean && scan-build -v -o ~/scan-build --status-bugs --use-cc=clang --force-analyze-debug-code --show-description -analyzer-config stable-report-filename=true -enable-checker valist,nullability make ENABLE_EXT_F=0 ENABLE_SDL=0 ENABLE_JIT=0

--- a/src/feature.h
+++ b/src/feature.h
@@ -57,5 +57,11 @@
 #define RV32_FEATURE_T2C 0
 #endif
 
+/* T2C depends on JIT configuration */
+#if !RV32_FEATURE_JIT
+#undef RV32_FEATURE_T2C
+#define RV32_FEATURE_T2C 0
+#endif
+
 /* Feature test macro */
 #define RV32_HAS(x) RV32_FEATURE_##x

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -28,6 +28,9 @@
 #include "riscv_private.h"
 #include "utils.h"
 #if RV32_HAS(JIT)
+#if RV32_HAS(T2C)
+#include <pthread.h>
+#endif
 #include "cache.h"
 #include "jit.h"
 #define CODE_CACHE_SIZE (4 * 1024 * 1024)
@@ -184,6 +187,27 @@ IO_HANDLER_IMPL(byte, write_b, W)
 #undef R
 #undef W
 
+#if RV32_HAS(T2C)
+static pthread_t t2c_thread;
+static void *t2c_runloop(void *arg)
+{
+    riscv_t *rv = (riscv_t *) arg;
+    while (rv->quit) {
+        if (!list_empty(&rv->wait_queue)) {
+            queue_entry_t *entry =
+                list_last_entry(&rv->wait_queue, queue_entry_t, list);
+            pthread_mutex_lock(&rv->wait_queue_lock);
+            list_del_init(&entry->list);
+            pthread_mutex_unlock(&rv->wait_queue_lock);
+            t2c_compile(entry->block,
+                        (uint64_t) ((memory_t *) PRIV(rv)->mem)->mem_base);
+            free(entry);
+        }
+    }
+    return NULL;
+}
+#endif
+
 riscv_t *rv_create(riscv_user_t rv_attr)
 {
     assert(rv_attr);
@@ -269,6 +293,14 @@ riscv_t *rv_create(riscv_user_t rv_attr)
     rv->jit_state = jit_state_init(CODE_CACHE_SIZE);
     rv->block_cache = cache_create(BLOCK_MAP_CAPACITY_BITS);
     assert(rv->block_cache);
+#if RV32_HAS(T2C)
+    rv->quit = false;
+    /* prepare wait queue. */
+    pthread_mutex_init(&rv->wait_queue_lock, NULL);
+    INIT_LIST_HEAD(&rv->wait_queue);
+    /* activate the background compilation thread. */
+    pthread_create(&t2c_thread, NULL, t2c_runloop, rv);
+#endif
 #endif
 
     return rv;
@@ -353,6 +385,11 @@ void rv_delete(riscv_t *rv)
     memory_delete(attr->mem);
     block_map_destroy(rv);
 #else
+#if RV32_HAS(T2C)
+    rv->quit = true;
+    pthread_join(t2c_thread, NULL);
+    pthread_mutex_destroy(&rv->wait_queue_lock);
+#endif
     mpool_destroy(rv->chain_entry_mp);
     jit_state_exit(rv->jit_state);
     cache_free(rv->block_cache);


### PR DESCRIPTION
Given the significant runtime compilation overhead associated with performing aggressive optimizations, we have implemented a background compilation mechanism to mitigate this issue. When the runtime profiler identifies a strong hotspot, it adds a T2C compilation request to the wait queue. A background thread, which continuously monitors this queue, triggers T2C to process the requests and notifies the main thread upon completion by updating a flag.

This mechanism defers the execution of T2C-generated machine code, leading to more frequent use of T1C-generated code. Despite this, the approach effectively minimizes runtime compilation delays by eliminating the need for the main thread to wait for T2C compilation to complete, thereby improving overall performance.

* The workflow of background compilation.
![image](https://github.com/sysprog21/rv32emu/assets/48278026/56e2bd62-deb1-4677-9a63-3bf283023080)

* The performance comparison with and without the background compialtion.
![image](https://github.com/sysprog21/rv32emu/assets/48278026/b6805c4d-0859-487f-b2d0-e3d1c4b42e08)

Close: #239