### PR TITLE
Initialize ir->branch_table->PC with safe value

### DIFF
--- a/src/emulate.c
+++ b/src/emulate.c
@@ -617,6 +617,8 @@ static void block_translate(riscv_t *rv, block_t *block)
             ) {
                 ir->branch_table = calloc(1, sizeof(branch_history_table_t));
                 assert(ir->branch_table);
+                memset(ir->branch_table->PC, -1,
+                       sizeof(uint32_t) * HISTORY_SIZE);
             }
             break;
         }


### PR DESCRIPTION
If the ra(return address) is 0x0, the
LOOKUP_OR_UPDATE_BRANCH_HISTORY_TABLE will bahave abnormally since calloc initialize ir->branch_table->PC[i] to 0x0. The 0x0 address might be not yet translated to a valid block, thus ir->branch_table->target[i] might be NULL, calling a NULL function pointer cause segmentation fault. It can be solved by initializing ir->branch_table->PC will other value than 0x0. Here, I choose unsigned integer of -1.

Close #461