### PR TITLE
Upgrade CI ubuntu version to 24.04

### DIFF
--- a/.ci/check-format.sh
+++ b/.ci/check-format.sh
@@ -8,7 +8,7 @@ set -x
 
 for file in ${SOURCES};
 do
-    clang-format-12 ${file} > expected-format
+    clang-format-18 ${file} > expected-format
     diff -u -p --label="${file}" --label="expected coding style" ${file} expected-format
 done
-exit $(clang-format-12 --output-replacements-xml ${SOURCES} | egrep -c "</replacement>")
+exit $(clang-format-18 --output-replacements-xml ${SOURCES} | egrep -c "</replacement>")

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   detect-code-related-file-changes:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       has_code_related_changes: ${{ steps.set_has_code_related_changes.outputs.has_code_related_changes }}
     steps:
@@ -36,7 +36,7 @@ jobs:
   host-x64:
     needs: [detect-code-related-file-changes]
     if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: install-dependencies
@@ -46,7 +46,7 @@ jobs:
             .ci/riscv-toolchain-install.sh
             wget https://apt.llvm.org/llvm.sh
             sudo chmod +x ./llvm.sh
-            sudo ./llvm.sh 17
+            sudo ./llvm.sh 18
       shell: bash
     - name: default build
       run: make
@@ -65,6 +65,11 @@ jobs:
             make distclean && make ENABLE_SDL=0 check -j$(nproc)
     - name: gdbstub test
       run: |
+            DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC sudo apt-get -y install tzdata # without this, the following installation will require manual intervention to set tzdata
+            sudo apt install software-properties-common -y
+            sudo add-apt-repository ppa:deadsnakes/ppa
+            sudo apt update
+            sudo apt install libpython3.10 -y # due to the fact that the riscv-gnu-toolchain releases are built for ubuntu 22.04, its dependencies is python3.10
             make distclean ENABLE_GDBSTUB=1 gdbstub-test
     - name: JIT test
       run: |
@@ -80,7 +85,7 @@ jobs:
   host-arm64:
     needs: [detect-code-related-file-changes]
     if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: checkout code
       uses: actions/checkout@v4
@@ -100,7 +105,7 @@ jobs:
           git config --global --add safe.directory ${{ github.workspace }}/src/mini-gdbstub
           wget https://apt.llvm.org/llvm.sh
           chmod +x ./llvm.sh
-          ./llvm.sh 17
+          ./llvm.sh 18
         # Append custom commands here
         run: |
           make -j$(nproc)
@@ -113,12 +118,12 @@ jobs:
   coding-style:
     needs: [detect-code-related-file-changes]
     if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: coding convention
       run: |
-            sudo apt-get install -q -y clang-format-12
+            sudo apt-get install -q -y clang-format-18
             .ci/check-newline.sh
             .ci/check-format.sh
       shell: bash
@@ -136,7 +141,7 @@ jobs:
             sudo apt-get install -q -y clang clang-tools libsdl2-dev libsdl2-mixer-dev
             wget https://apt.llvm.org/llvm.sh
             chmod +x ./llvm.sh
-            sudo ./llvm.sh 17
+            sudo ./llvm.sh 18
       shell: bash
     - name: run scan-build without JIT
       run: make distclean && scan-build -v -o ~/scan-build --status-bugs --use-cc=clang --force-analyze-debug-code --show-description -analyzer-config stable-report-filename=true -enable-checker valist,nullability make ENABLE_EXT_F=0 ENABLE_SDL=0 ENABLE_JIT=0
@@ -163,7 +168,7 @@ jobs:
   docker-hub-build-and-publish:
     needs: [detect-code-related-file-changes]
     if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -119,10 +119,7 @@
  */
 
 /* Internal */
-RVOP(
-    nop,
-    { rv->X[rv_reg_zero] = 0; },
-    GEN({/* no operation */}))
+RVOP(nop, { rv->X[rv_reg_zero] = 0; }, GEN({/* no operation */}))
 
 /* LUI is used to build 32-bit constants and uses the U-type format. LUI
  * places the U-immediate value in the top 20 bits of the destination
@@ -297,13 +294,14 @@ RVOP(
         if (!untaken)                                              \
             goto nextop;                                           \
         IIF(RV32_HAS(JIT))                                         \
-        ({                                                         \
-            cache_get(rv->block_cache, PC + 4, true);              \
-            if (!set_add(&pc_set, PC + 4))                         \
-                has_loops = true;                                  \
-            if (cache_hot(rv->block_cache, PC + 4))                \
-                goto nextop;                                       \
-        }, );                                                      \
+        (                                                          \
+            {                                                      \
+                cache_get(rv->block_cache, PC + 4, true);          \
+                if (!set_add(&pc_set, PC + 4))                     \
+                    has_loops = true;                              \
+                if (cache_hot(rv->block_cache, PC + 4))            \
+                    goto nextop;                                   \
+            }, );                                                  \
         PC += 4;                                                   \
         last_pc = PC;                                              \
         MUST_TAIL return untaken->impl(rv, untaken, cycle, PC);    \
@@ -316,13 +314,14 @@ RVOP(
     struct rv_insn *taken = ir->branch_taken;                      \
     if (taken) {                                                   \
         IIF(RV32_HAS(JIT))                                         \
-        ({                                                         \
-            cache_get(rv->block_cache, PC, true);                  \
-            if (!set_add(&pc_set, PC))                             \
-                has_loops = true;                                  \
-            if (cache_hot(rv->block_cache, PC))                    \
-                goto end_op;                                       \
-        }, );                                                      \
+        (                                                          \
+            {                                                      \
+                cache_get(rv->block_cache, PC, true);              \
+                if (!set_add(&pc_set, PC))                         \
+                    has_loops = true;                              \
+                if (cache_hot(rv->block_cache, PC))                \
+                    goto end_op;                                   \
+            }, );                                                  \
         last_pc = PC;                                              \
         MUST_TAIL return taken->impl(rv, taken, cycle, PC);        \
     }                                                              \

--- a/tests/aes.c
+++ b/tests/aes.c
@@ -951,7 +951,7 @@ static void doubleBGF128(block_t block)
     {                               /* first: left-shift, then   */
         c |= block[--i] << 1;       /* append the previous MSBit */
         block[i] = (uint8_t) c;
-    }                        /* if first MSBit is carried */
+    } /* if first MSBit is carried */
     block[LAST] ^= c * 0x87; /* .. B ^= 10000111b (B.E.)  */
 }
 #endif
@@ -1132,7 +1132,7 @@ static char padBlock(const uint8_t len, block_t block)
     memset(p, n * (AES_PADDING != 2), n);
     *p ^= '\x80' * (AES_PADDING == 2); /* either PKCS#7 / IEC7816-4 */
 #else
-    if (len)                                /* default (zero) padding    */
+    if (len) /* default (zero) padding    */
     {
         memset(block + len, 0, BLOCKSIZE - len);
     }
@@ -1294,7 +1294,7 @@ char AES_CBC_decrypt(const uint8_t *key,
         xorBlock(iv, y);       /*  IV_next = C              */
         iv = x;
         x += BLOCKSIZE;
-    }        /*  r = 0 unless CTS enabled */
+    } /*  r = 0 unless CTS enabled */
     if (r) { /*  P2 =  Dec(C1) ^ C2       */
         mixThenXor(&rijndaelDecrypt, x, y, x + BLOCKSIZE, r, y + BLOCKSIZE);
         memcpy(y, x + BLOCKSIZE, r);
@@ -1544,7 +1544,7 @@ static void XEX_Cipher(fmix_t cipher,
 
     if (sectid == ~(size_t) 0) {     /* the `i` block is either   */
         memcpy(T, tweak, BLOCKSIZE); /* ..a little-endian number  */
-    }                                /* ..or a byte array.        */
+    } /* ..or a byte array.        */
     else {
         memset(T, 0, BLOCKSIZE);
         copyLVal(T, sectid, 0);
@@ -2537,7 +2537,7 @@ static void modP1305(uint8_t *block, const int ovrfl)
     {
         t += block[i];            /* to get mod, first derive  */
         block[i++] = (uint8_t) t; /* .. B + (5 * q) and then   */
-    }                             /* .. subtract q * (2^130)   */
+    } /* .. subtract q * (2^130)   */
     block[SP - 1] -= 4 * (uint8_t) q;
 }
 

--- a/tests/line.c
+++ b/tests/line.c
@@ -77,7 +77,7 @@ void svpng(FILE *fp, unsigned w, unsigned h, const uint8_t *img, bool alpha)
         SVPNG_PUT((u) >> 24);         \
         SVPNG_PUT(((u) >> 16) & 255); \
         SVPNG_PUT(((u) >> 8) & 255);  \
-        SVPNG_PUT((u) &255);          \
+        SVPNG_PUT((u) & 255);         \
     } while (0)
 
 #define SVPNG_U8C(u)              \
@@ -94,7 +94,7 @@ void svpng(FILE *fp, unsigned w, unsigned h, const uint8_t *img, bool alpha)
 
 #define SVPNG_U16LC(u)               \
     do {                             \
-        SVPNG_U8C((u) &255);         \
+        SVPNG_U8C((u) & 255);        \
         SVPNG_U8C(((u) >> 8) & 255); \
     } while (0)
 
@@ -103,7 +103,7 @@ void svpng(FILE *fp, unsigned w, unsigned h, const uint8_t *img, bool alpha)
         SVPNG_U8C((u) >> 24);         \
         SVPNG_U8C(((u) >> 16) & 255); \
         SVPNG_U8C(((u) >> 8) & 255);  \
-        SVPNG_U8C((u) &255);          \
+        SVPNG_U8C((u) & 255);         \
     } while (0)
 
 #define SVPNG_U8ADLER(u)       \


### PR DESCRIPTION
Required dependencies are all updated, such as
- clang-format-18
- LLVM 18
- fix an issue with the pip3 install
- fix an issue with testing gdbstub (notice that the riscv-gnu-toolchain releases are built using Ubuntu 22.04, thus, we need
to install libpython3.10 for the CI pipeline to work)

Reference:
- https://stackoverflow.com/questions/75608323/how-do-i-solve-error-externally-managed-environment-every-time-i-use-pip-3