### PR TITLE
Reintroduce benchmark.yml

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,50 @@
+name: Benchmark
+
+on: [push, pull_request_target, workflow_dispatch]
+
+jobs:
+  benchmark:
+    name: Performance regression check
+    if: contains(toJSON(github.event.head_commit.message), 'Merge pull request ') == false
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+        with:
+          files: |
+              src/riscv.c
+              src/decode.c
+              src/emulate.c
+              src/rv32_template.c
+              src/rv32_constopt.c
+      - name: install-dependencies
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
+            github.event_name == 'workflow_dispatch'}}
+        run: |
+            sudo pip3 install numpy --break-system-packages
+        shell: bash
+      - name: default build
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
+            github.event_name == 'workflow_dispatch'}}
+        run: make ENABLE_SDL=0
+      - name: Run benchmark
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
+            github.event_name == 'workflow_dispatch'}}
+        run: |
+          tests/bench-aggregator.py
+      - name: Store benchmark results
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
+            github.event_name == 'workflow_dispatch'}}
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Benchmarks
+          tool: 'customBiggerIsBetter'
+          output-file-path: benchmark_output.json
+          github-token: ${{ secrets.RV32EMU_BENCH_TOKEN }}
+          gh-repository: 'github.com/sysprog21/rv32emu-bench'
+          gh-pages-branch: 'master'
+          auto-push: true
+          comment-always: true
+          benchmark-data-dir-path: .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,51 +1,8 @@
 name: CI
 
-on: [push, pull_request, workflow_dispatch]
+on: [push, pull_request]
 
 jobs:
-  benchmark:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Test changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v44
-        with:
-          files: |
-              src/riscv.c
-              src/decode.c
-              src/emulate.c
-              src/rv32_template.c
-              src/rv32_constopt.c
-      - name: install-dependencies
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
-            github.event_name == 'workflow_dispatch'}}
-        run: |
-            sudo pip3 install numpy --break-system-packages
-        shell: bash
-      - name: default build
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
-            github.event_name == 'workflow_dispatch'}}
-        run: make ENABLE_SDL=0
-      - name: Run benchmark
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
-            github.event_name == 'workflow_dispatch'}}
-        run: |
-          tests/bench-aggregator.py
-      - name: Store benchmark results
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
-            github.event_name == 'workflow_dispatch'}}
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: Benchmarks
-          tool: 'customBiggerIsBetter'
-          output-file-path: benchmark_output.json
-          github-token: ${{ secrets.RV32EMU_BENCH_TOKEN }}
-          gh-repository: 'github.com/sysprog21/rv32emu-bench'
-          gh-pages-branch: 'master'
-          auto-push: true
-          comment-always: true
-          benchmark-data-dir-path: .
   detect-code-related-file-changes:
     runs-on: ubuntu-22.04
     outputs:


### PR DESCRIPTION
There is an issue with accessing `github-token` from `mail.yml`, see https://github.com/sysprog21/rv32emu/actions/runs/9873045064/job/27264462124?pr=467.

The error is `Error: 'auto-push' is enabled but 'github-token' is not set. Please give API token to push GitHub pages branch to remote`. This wasn't present when the benchmark was in its dedicated file.

The proposal is to move the modified benchmark pipeline back to its original file. 