### PR TITLE
Add dummy WFI implementation

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -835,6 +835,8 @@ static inline bool op_system(rv_insn_t *ir, const uint32_t insn)
             ir->opcode = rv_insn_ebreak;
             break;
         case 0x105: /* WFI: Wait for Interrupt */
+            ir->opcode = rv_insn_wfi;
+            break;
         case 0x002: /* URET: return from traps in U-mode */
         case 0x202: /* HRET: return from traps in H-mode */
             /* illegal instruction */

--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -982,8 +982,9 @@ RVOP(
 RVOP(
     wfi,
     {
+        PC += 4;
         /* FIXME: Implement */
-        return false;
+        goto end_op;
     },
     GEN({
         assert; /* FIXME: Implement */


### PR DESCRIPTION
The Wait for Interrupt instruction (WFI) provides a hint to the implementation that the current hart can be stalled until an interrupt might need servicing. As well, Linux kernel might call wait_for_interrupt() to enter idle state. In this commit, we could simply make PC + 4 and not really enter idle state.

Related: #310