### PR TITLE
Allocate adequate memory for running arch-test

### DIFF
--- a/.ci/riscv-tests.sh
+++ b/.ci/riscv-tests.sh
@@ -9,6 +9,13 @@ set -x
 
 export PATH=`pwd`/toolchain/bin:$PATH
 
-make clean
+make distclean
+# Rebuild with all RISC-V extensions
+# FIXME: To pass the RISC-V Architecture Tests, full access to 4 GiB is
+# necessary. We need to investigate why full 4 GiB memory access is required
+# for this purpose, although the emulator can run all selected benchmarks with
+# much smaller memory mapping regions.
+make ENABLE_EXT_M=1 ENABLE_EXT_A=1 ENABLE_EXT_F=1 ENABLE_EXT_C=1 \
+     ENABLE_Zicsr=1 ENABLE_Zifencei=1 ENABLE_FULL4G=1
 make arch-test RISCV_DEVICE=IMAFCZicsrZifencei || exit 1
 make arch-test RISCV_DEVICE=FCZicsr || exit 1

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,8 @@ $(call set-feature, Zicsr)
 ENABLE_Zifencei ?= 1
 $(call set-feature, Zifencei)
 
+ENABLE_FULL4G ?= 0
+
 # Experimental SDL oriented system calls
 ENABLE_SDL ?= 1
 ifneq ("$(CC_IS_EMCC)", "1") # note that emcc generates port SDL headers/library, so it does not requires system SDL headers/library
@@ -99,10 +101,17 @@ ifeq ($(call has, SDL), 1)
 OBJS_EXT += syscall_sdl.o
 $(OUT)/syscall_sdl.o: CFLAGS += $(shell sdl2-config --cflags)
 # 4 GiB of memory is required to run video games.
-$(OUT)/main.o: CFLAGS += -DMEM_SIZE=0xFFFFFFFFULL # 2^{32} - 1
+ENABLE_FULL4G := 1
 LDFLAGS += $(shell sdl2-config --libs) -pthread
 LDFLAGS += $(shell pkg-config --libs SDL2_mixer)
 endif
+endif
+
+# Full access to a 4 GiB address space, necessitating more memory mapping
+# during emulator initialization.
+$(call set-feature, FULL4G)
+ifeq ($(call has, FULL4G), 1)
+$(OUT)/main.o: CFLAGS += -DMEM_SIZE=0xFFFFFFFFULL # 2^{32} - 1
 endif
 
 ENABLE_GDBSTUB ?= 0

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The image containing all the necessary tools for development and testing can be 
 * `ENABLE_Zicsr`: Control and Status Register (CSR)
 * `ENABLE_Zifencei`: Instruction-Fetch Fence
 * `ENABLE_GDBSTUB` : GDB remote debugging support
+* `ENABLE_FULL4G` : Full access to 4 GiB address space
 * `ENABLE_SDL` : Experimental Display and Event System Calls
 * `ENABLE_JIT` : Experimental JIT compiler
 

--- a/src/main.c
+++ b/src/main.c
@@ -174,8 +174,8 @@ static void dump_test_signature(const char *prog_name)
 #endif
 /* FIXME: MEM_SIZE shall be defined on different runtime */
 #ifndef MEM_SIZE
-/* Allocate 2^{19} - 1 bytes, which is ample for all known benchmarks. */
-#define MEM_SIZE 0x80000
+/* Allocate 2^{19} bytes, which is ample for all selective benchmarks. */
+#define MEM_SIZE 0x80000ULL
 #endif
 #define STACK_SIZE 0x1000       /* 4096 */
 #define ARGS_OFFSET_SIZE 0x1000 /* 4096 */


### PR DESCRIPTION
Once the memory mapping requirement is adjusted to 2^{19} - 1 bytes, RISC-V Architecture Tests is unable to run:
```
  make[1]: *** [rv32emu/build/arch-test/Makefile.DUT-rv32emu:5: TARGET0] Error 139
  INFO | Running Tests on Reference Model.
  INFO | Initiating signature checking.
  ERROR | Signature file : rv32emu/build/arch-test/rv32i_m/A/src/amoadd.w-01.S/dut/DUT-rv32emu.signature does not exist
```

Close #484