### PR TITLE
CI: Fix missing file in WebAssembly deployment

### DIFF
--- a/.github/workflows/deploy-wasm.yml
+++ b/.github/workflows/deploy-wasm.yml
@@ -46,6 +46,7 @@ jobs:
             mkdir /tmp/rv32emu-demo
             mv assets/html/index.html /tmp/rv32emu-demo
             mv assets/js/coi-serviceworker.min.js /tmp/rv32emu-demo
+            mv build/elf_list.js /tmp/rv32emu-demo
             mv build/rv32emu.js /tmp/rv32emu-demo
             mv build/rv32emu.wasm /tmp/rv32emu-demo
             mv build/rv32emu.worker.js /tmp/rv32emu-demo
@@ -63,6 +64,7 @@ jobs:
         run: |
             mv /tmp/rv32emu-demo/index.html .
             mv /tmp/rv32emu-demo/coi-serviceworker.min.js .
+            mv /tmp/rv32emu-demo/elf_list.js .
             mv /tmp/rv32emu-demo/rv32emu.js .
             mv /tmp/rv32emu-demo/rv32emu.wasm .
             mv /tmp/rv32emu-demo/rv32emu.worker.js .

--- a/mk/wasm.mk
+++ b/mk/wasm.mk
@@ -7,7 +7,8 @@ EXPORTED_FUNCS := _main,_indirect_rv_halt
 DEMO_DIR := demo
 WEB_FILES := $(BIN).js \
 	     $(BIN).wasm \
-	     $(BIN).worker.js
+	     $(BIN).worker.js \
+             $(OUT)/elf_list.js
 
 ifeq ("$(CC_IS_EMCC)", "1")
 BIN := $(BIN).js
@@ -37,11 +38,11 @@ CFLAGS_emcc += -sINITIAL_MEMORY=2GB \
 	       -O3 \
 	       -w
 
-$(DEMO_DIR)/elf_list.js: tools/gen-elf-list-js.py
+$(OUT)/elf_list.js: tools/gen-elf-list-js.py
 	$(Q)tools/gen-elf-list-js.py > $@
 
 # used to download all dependencies of elf executable and bundle into single wasm
-deps_emcc += $(DEMO_DIR)/elf_list.js $(DOOM_DATA) $(QUAKE_DATA) $(TIMIDITY_DATA)
+deps_emcc += $(OUT)/elf_list.js $(DOOM_DATA) $(QUAKE_DATA) $(TIMIDITY_DATA)
 
 # check browser MAJOR version if supports TCO
 CHROME_MAJOR :=


### PR DESCRIPTION
After merging #487, the elf_list.js file is generated dynamically, and the wasm service requires this file to run. However, during CI deployment, the file is not pushed to the rv32emu-demo repo, causing the GitHub Pages to malfunction. To resolve this, pushing the file to the rv32emu-demo repo is the solution.

The 'demo' directory is only created when the WASM service runs locally. To address this, the elf_list.js file should be placed in the 'build' directory instead, as the CI deployment does not invoke the Makefile's start-web target, so the 'demo' directory will not be generated.