### PR TITLE
CI: Install wget package for Alpine Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.19 as base_gcc
 
-RUN apk add --update alpine-sdk git curl
+RUN apk add --update alpine-sdk git wget
 
 # copy in the source code
 WORKDIR /home/root/rv32emu


### PR DESCRIPTION
Recently, we have been transitioning from using curl to wget for downloading files from remote hosts. However, the version of wget provided by Alpine Linux is actually a Busybox implementation, which lacks many features found in the full wget package.

Error messages:
```
  #15 [linux/amd64 base_gcc 5/6] RUN make ENABLE_SDL=0
  #15 0.207 Check the file build/.config for configured items.
  #15 0.360 Fetching prebuilt executables from "rv32emu-prebuilt" ...
  #15 0.361 wget: unrecognized option: show-progress
```

This commit attempts to install wget package instead.