### PR TITLE
Move artifact target under emcc build condition

### DIFF
--- a/mk/wasm.mk
+++ b/mk/wasm.mk
@@ -1,5 +1,5 @@
 CFLAGS_emcc ?=
-deps_emcc := artifact
+deps_emcc :=
 ASSETS := assets
 WEB_HTML_RESOURCES := $(ASSETS)/html
 WEB_JS_RESOURCES := $(ASSETS)/js
@@ -42,7 +42,7 @@ $(OUT)/elf_list.js: tools/gen-elf-list-js.py
 	$(Q)tools/gen-elf-list-js.py > $@
 
 # used to download all dependencies of elf executable and bundle into single wasm
-deps_emcc += $(OUT)/elf_list.js $(DOOM_DATA) $(QUAKE_DATA) $(TIMIDITY_DATA)
+deps_emcc += artifact $(OUT)/elf_list.js $(DOOM_DATA) $(QUAKE_DATA) $(TIMIDITY_DATA)
 
 # check browser MAJOR version if supports TCO
 CHROME_MAJOR :=


### PR DESCRIPTION
Normal 'make' or 'make all' does not require downloading prebuilt ELF executables from the rv32emu-prebuilt repo. However, 'deps_emcc' always depends on the 'artifact' target, even when not using emcc, causing 'make' or 'make all' to always download prebuilt ELF executables. To prevent this, the 'artifact' target is moved under the emcc build condition.

Related: #491