### PR TITLE
Fix gdbstub dependency and enable parallel compilation for faster CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
             sudo ./llvm.sh 17
       shell: bash
     - name: default build
-      run: make
+      run: make -j$(nproc)
     - name: check + tests
       run: |
             make check -j$(nproc)
@@ -65,7 +65,7 @@ jobs:
             make distclean && make ENABLE_SDL=0 check -j$(nproc)
     - name: gdbstub test
       run: |
-            make distclean ENABLE_GDBSTUB=1 gdbstub-test
+            make distclean && make ENABLE_GDBSTUB=1 gdbstub-test -j$(nproc)
     - name: JIT test
       run: |
             make ENABLE_JIT=1 clean && make ENABLE_JIT=1 check -j$(nproc)

--- a/Makefile
+++ b/Makefile
@@ -124,8 +124,6 @@ src/mini-gdbstub/Makefile:
 GDBSTUB_LIB := $(GDBSTUB_OUT)/libgdbstub.a
 $(GDBSTUB_LIB): src/mini-gdbstub/Makefile
 	$(MAKE) -C $(dir $<) O=$(dir $@)
-# FIXME: track gdbstub dependency properly
-$(OUT)/decode.o: $(GDBSTUB_LIB)
 OBJS_EXT += gdbstub.o breakpoint.o
 CFLAGS += -D'GDBSTUB_COMM="$(GDBSTUB_COMM)"'
 LDFLAGS += $(GDBSTUB_LIB) -pthread
@@ -217,6 +215,10 @@ deps := $(OBJS:%.o=%.o.d)
 
 ifeq ($(call has, EXT_F), 1)
 $(OBJS): $(SOFTFLOAT_LIB)
+endif
+
+ifeq ($(call has, GDBSTUB), 1)
+$(OBJS): $(GDBSTUB_LIB)
 endif
 
 $(OUT)/%.o: src/%.c $(deps_emcc)


### PR DESCRIPTION
Fix a compilation error related to the missing gdbstub dependency in the Makefile when building with ENABLE_GDBSTUB=1, ensuring the gdbstub library is correctly compiled before the dependent source files to prevent missing header file issues. Additionally, it introduces parallel compilation using -j$(nproc) for both the default build and gdbstub tests, utilizing all available CPU cores to accelerate the build and testing processes, reducing CI execution time.