### PR TITLE
CI: Bump Ubuntu to 24.04-LTS

### DIFF
--- a/.ci/check-format.sh
+++ b/.ci/check-format.sh
@@ -8,7 +8,7 @@ set -x
 
 for file in ${SOURCES};
 do
-    clang-format-12 ${file} > expected-format
+    clang-format-18 ${file} > expected-format
     diff -u -p --label="${file}" --label="expected coding style" ${file} expected-format
 done
-exit $(clang-format-12 --output-replacements-xml ${SOURCES} | egrep -c "</replacement>")
+exit $(clang-format-18 --output-replacements-xml ${SOURCES} | egrep -c "</replacement>")

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,7 +28,7 @@ jobs:
       - name: default build
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
             github.event_name == 'workflow_dispatch'}}
-        run: make ENABLE_SDL=0
+        run: make ENABLE_SDL=0 all artifact
       - name: Run benchmark
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
             github.event_name == 'workflow_dispatch'}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   detect-code-related-file-changes:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       has_code_related_changes: ${{ steps.set_has_code_related_changes.outputs.has_code_related_changes }}
     steps:
@@ -36,7 +36,7 @@ jobs:
   host-x64:
     needs: [detect-code-related-file-changes]
     if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: install-dependencies
@@ -46,7 +46,7 @@ jobs:
             .ci/riscv-toolchain-install.sh
             wget https://apt.llvm.org/llvm.sh
             sudo chmod +x ./llvm.sh
-            sudo ./llvm.sh 17
+            sudo ./llvm.sh 18
       shell: bash
     - name: default build
       run: make -j$(nproc)
@@ -80,14 +80,14 @@ jobs:
   host-arm64:
     needs: [detect-code-related-file-changes]
     if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: checkout code
       uses: actions/checkout@v4
     - name: build artifact
       # The GitHub Action for non-x86 CPU
       # https://github.com/uraimo/run-on-arch-action
-      uses: uraimo/run-on-arch-action@v2.7.1
+      uses: uraimo/run-on-arch-action@v2
       with:
         arch: aarch64
         distro: ubuntu22.04
@@ -100,7 +100,7 @@ jobs:
           git config --global --add safe.directory ${{ github.workspace }}/src/mini-gdbstub
           wget https://apt.llvm.org/llvm.sh
           chmod +x ./llvm.sh
-          ./llvm.sh 17
+          ./llvm.sh 18
         # Append custom commands here
         run: |
           make -j$(nproc)
@@ -113,12 +113,12 @@ jobs:
   coding-style:
     needs: [detect-code-related-file-changes]
     if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: coding convention
       run: |
-            sudo apt-get install -q -y clang-format-12
+            sudo apt-get install -q -y clang-format-18
             .ci/check-newline.sh
             .ci/check-format.sh
       shell: bash
@@ -136,7 +136,7 @@ jobs:
             sudo apt-get install -q -y clang clang-tools libsdl2-dev libsdl2-mixer-dev
             wget https://apt.llvm.org/llvm.sh
             chmod +x ./llvm.sh
-            sudo ./llvm.sh 17
+            sudo ./llvm.sh 18
       shell: bash
     - name: run scan-build without JIT
       run: make distclean && scan-build -v -o ~/scan-build --status-bugs --use-cc=clang --force-analyze-debug-code --show-description -analyzer-config stable-report-filename=true -enable-checker valist,nullability make ENABLE_EXT_F=0 ENABLE_SDL=0 ENABLE_JIT=0
@@ -163,7 +163,7 @@ jobs:
   docker-hub-build-and-publish:
     needs: [detect-code-related-file-changes]
     if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ However, participation requires adherence to fundamental ground rules:
   This variant should be considered the standard for all documentation efforts.
   For instance, opt for "initialize" over "initialise" and "color" rather than "colour".
 
-Software requirement: [clang-format](https://clang.llvm.org/docs/ClangFormat.html) version 12 or later.
+Software requirement: [clang-format](https://clang.llvm.org/docs/ClangFormat.html) version 18 or later.
 
 This repository consistently contains an up-to-date `.clang-format` file with rules that match the explained ones.
 For maintaining a uniform coding style, execute the command `clang-format -i *.{c,h}`.

--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -119,10 +119,7 @@
  */
 
 /* Internal */
-RVOP(
-    nop,
-    { rv->X[rv_reg_zero] = 0; },
-    GEN({/* no operation */}))
+RVOP(nop, { rv->X[rv_reg_zero] = 0; }, GEN({/* no operation */}))
 
 /* LUI is used to build 32-bit constants and uses the U-type format. LUI
  * places the U-immediate value in the top 20 bits of the destination
@@ -300,13 +297,14 @@ RVOP(
         if (!untaken)                                              \
             goto nextop;                                           \
         IIF(RV32_HAS(JIT))                                         \
-        ({                                                         \
-            cache_get(rv->block_cache, PC + 4, true);              \
-            if (!set_add(&pc_set, PC + 4))                         \
-                has_loops = true;                                  \
-            if (cache_hot(rv->block_cache, PC + 4))                \
-                goto nextop;                                       \
-        }, );                                                      \
+        (                                                          \
+            {                                                      \
+                cache_get(rv->block_cache, PC + 4, true);          \
+                if (!set_add(&pc_set, PC + 4))                     \
+                    has_loops = true;                              \
+                if (cache_hot(rv->block_cache, PC + 4))            \
+                    goto nextop;                                   \
+            }, );                                                  \
         PC += 4;                                                   \
         last_pc = PC;                                              \
         MUST_TAIL return untaken->impl(rv, untaken, cycle, PC);    \
@@ -319,13 +317,14 @@ RVOP(
     struct rv_insn *taken = ir->branch_taken;                      \
     if (taken) {                                                   \
         IIF(RV32_HAS(JIT))                                         \
-        ({                                                         \
-            cache_get(rv->block_cache, PC, true);                  \
-            if (!set_add(&pc_set, PC))                             \
-                has_loops = true;                                  \
-            if (cache_hot(rv->block_cache, PC))                    \
-                goto end_op;                                       \
-        }, );                                                      \
+        (                                                          \
+            {                                                      \
+                cache_get(rv->block_cache, PC, true);              \
+                if (!set_add(&pc_set, PC))                         \
+                    has_loops = true;                              \
+                if (cache_hot(rv->block_cache, PC))                \
+                    goto end_op;                                   \
+            }, );                                                  \
         last_pc = PC;                                              \
         MUST_TAIL return taken->impl(rv, taken, cycle, PC);        \
     }                                                              \

--- a/tests/coremark.py
+++ b/tests/coremark.py
@@ -5,7 +5,7 @@ import numpy
 import os
 import json
 
-iter = 10
+iter = 1
 coremark_param = "0x0 0x0 0x66 30000 7 1 2000"
 res = []
 file_exist = os.path.exists('build/rv32emu')
@@ -14,7 +14,7 @@ if not file_exist:
     exit(1)
 print("Start Test CoreMark benchmark")
 comp_proc = subprocess.check_output(
-    "build/rv32emu build/coremark.elf {}".format(coremark_param), shell=True).decode("utf-8")
+    "build/rv32emu build/riscv32/coremark {}".format(coremark_param), shell=True).decode("utf-8")
 if not comp_proc or comp_proc.find("Error") != -1:
     print("Test Error")
     exit(1)
@@ -24,7 +24,7 @@ else:
 for i in range(iter):
     print("Running CoreMark benchmark - Run #{}".format(i + 1))
     comp_proc = subprocess.check_output(
-        "build/rv32emu build/coremark.elf {}".format(coremark_param), shell=True).decode("utf-8")
+        "build/rv32emu build/riscv32/coremark {}".format(coremark_param), shell=True).decode("utf-8")
     if not comp_proc:
         print("Fail\n")
         exit(1)

--- a/tests/dhrystone.sh
+++ b/tests/dhrystone.sh
@@ -3,18 +3,26 @@
 source tests/common.sh
 
 # Set the number of runs for the Dhrystone benchmark
-N_RUNS=10
+N_RUNS=1
+
+function sanity_check()
+{
+    if test ! -f $O/riscv32/dhrystone; then
+        make artifact || exit 1
+    fi
+}
 
 function run_dhrystone()
 {
     # Run Dhrystone and extract the DMIPS value
-    output=$($RUN $O/dhrystone.elf 2>&1)
+    output=$($RUN $O/riscv32/dhrystone 2>&1)
     local exit_code=$?
     [ $exit_code -ne 0 ] && fail
     dmips=$(echo "$output" | grep -oE '[0-9]+' | awk 'NR==5{print}')
     echo "$dmips"
 }
 
+sanity_check
 # Run Dhrystone benchmark and collect DMIPS values
 dmips_values=()
 for ((i=1; i<=$N_RUNS; i++))

--- a/tests/line.c
+++ b/tests/line.c
@@ -77,7 +77,7 @@ void svpng(FILE *fp, unsigned w, unsigned h, const uint8_t *img, bool alpha)
         SVPNG_PUT((u) >> 24);         \
         SVPNG_PUT(((u) >> 16) & 255); \
         SVPNG_PUT(((u) >> 8) & 255);  \
-        SVPNG_PUT((u) &255);          \
+        SVPNG_PUT((u) & 255);         \
     } while (0)
 
 #define SVPNG_U8C(u)              \
@@ -94,7 +94,7 @@ void svpng(FILE *fp, unsigned w, unsigned h, const uint8_t *img, bool alpha)
 
 #define SVPNG_U16LC(u)               \
     do {                             \
-        SVPNG_U8C((u) &255);         \
+        SVPNG_U8C((u) & 255);        \
         SVPNG_U8C(((u) >> 8) & 255); \
     } while (0)
 
@@ -103,7 +103,7 @@ void svpng(FILE *fp, unsigned w, unsigned h, const uint8_t *img, bool alpha)
         SVPNG_U8C((u) >> 24);         \
         SVPNG_U8C(((u) >> 16) & 255); \
         SVPNG_U8C(((u) >> 8) & 255);  \
-        SVPNG_U8C((u) &255);          \
+        SVPNG_U8C((u) & 255);         \
     } while (0)
 
 #define SVPNG_U8ADLER(u)       \

--- a/tests/uaes.c
+++ b/tests/uaes.c
@@ -951,7 +951,7 @@ static void doubleBGF128(block_t block)
     {                               /* first: left-shift, then   */
         c |= block[--i] << 1;       /* append the previous MSBit */
         block[i] = (uint8_t) c;
-    }                        /* if first MSBit is carried */
+    } /* if first MSBit is carried */
     block[LAST] ^= c * 0x87; /* .. B ^= 10000111b (B.E.)  */
 }
 #endif
@@ -1132,7 +1132,7 @@ static char padBlock(const uint8_t len, block_t block)
     memset(p, n * (AES_PADDING != 2), n);
     *p ^= '\x80' * (AES_PADDING == 2); /* either PKCS#7 / IEC7816-4 */
 #else
-    if (len)                                /* default (zero) padding    */
+    if (len) /* default (zero) padding    */
     {
         memset(block + len, 0, BLOCKSIZE - len);
     }
@@ -1294,7 +1294,7 @@ char AES_CBC_decrypt(const uint8_t *key,
         xorBlock(iv, y);       /*  IV_next = C              */
         iv = x;
         x += BLOCKSIZE;
-    }        /*  r = 0 unless CTS enabled */
+    } /*  r = 0 unless CTS enabled */
     if (r) { /*  P2 =  Dec(C1) ^ C2       */
         mixThenXor(&rijndaelDecrypt, x, y, x + BLOCKSIZE, r, y + BLOCKSIZE);
         memcpy(y, x + BLOCKSIZE, r);
@@ -1544,7 +1544,7 @@ static void XEX_Cipher(fmix_t cipher,
 
     if (sectid == ~(size_t) 0) {     /* the `i` block is either   */
         memcpy(T, tweak, BLOCKSIZE); /* ..a little-endian number  */
-    }                                /* ..or a byte array.        */
+    } /* ..or a byte array.        */
     else {
         memset(T, 0, BLOCKSIZE);
         copyLVal(T, sectid, 0);
@@ -2537,7 +2537,7 @@ static void modP1305(uint8_t *block, const int ovrfl)
     {
         t += block[i];            /* to get mod, first derive  */
         block[i++] = (uint8_t) t; /* .. B + (5 * q) and then   */
-    }                             /* .. subtract q * (2^130)   */
+    } /* .. subtract q * (2^130)   */
     block[SP - 1] -= 4 * (uint8_t) q;
 }
 


### PR DESCRIPTION
Ubuntu Linux 24.04 (noble) is the latest LTS release, and this commit updates the CI pipeline hosts and recommended development environments accordingly. The version of clang-format is updated to v18, with all C source files re-indented. LLVM is also upgraded to version 18.