### PR TITLE
Ask to install RISCOF before running arch-test locally

### DIFF
--- a/mk/riscv-arch-test.mk
+++ b/mk/riscv-arch-test.mk
@@ -1,3 +1,9 @@
+riscof-check:
+	$(Q)if [ "$(shell pip show riscof 2>&1 | head -n 1 | cut -d' ' -f1)" = "WARNING:" ]; then \
+	$(PRINTF) "Run 'pip3 install git+https://github.com/riscv/riscof.git@d38859f85fe407bcacddd2efcd355ada4683aee4' to install RISCOF\n"; \
+	exit 1; \
+	fi;
+
 ARCH_TEST_DIR ?= tests/riscv-arch-test
 ARCH_TEST_SUITE ?= $(ARCH_TEST_DIR)/riscv-test-suite
 export RISCV_TARGET := tests/arch-test-target
@@ -9,7 +15,7 @@ ifeq ($(RISCV_DEVICE),FCZicsr)
 ARCH_TEST_SUITE := tests/rv32fc-test-suite
 endif
 
-arch-test: $(BIN) artifact
+arch-test: riscof-check $(BIN) artifact
 ifeq ($(CROSS_COMPILE),)
 	$(error GNU Toolchain for RISC-V is required to build architecture tests. Please check package installation)
 endif


### PR DESCRIPTION
A specific version of RISCOF is used in CI, so requesting for that version as well.