### PR TITLE
Fix unmatch close function call

### DIFF
--- a/src/elf.c
+++ b/src/elf.c
@@ -353,7 +353,7 @@ free_fd:
 #if HAVE_MMAP
     close(fd);
 #else
-    close(f);
+    fclose(f);
 #endif
 
 free_path:


### PR DESCRIPTION
If HAVE_MMAP is not set, the open and close file operations use the standard C library interface, so fclose should be used instead of the close system call.