### PR TITLE
CI: Bump riscv-gnu-toolchain

### DIFF
--- a/.ci/riscv-toolchain-install.sh
+++ b/.ci/riscv-toolchain-install.sh
@@ -14,9 +14,9 @@ if [[ "$#" == "0" ]] || [[ "$1" != "riscv-collab" ]]; then
     TOOLCHAIN_URL=${TOOLCHAIN_REPO}/releases/download/v${GCC_VER}/xpack-riscv-none-elf-gcc-${GCC_VER}-linux-x64.tar.gz
 else
     UBUNTU_VER=`lsb_release -r | cut -f2`
-    GCC_VER=2024.09.03
+    GCC_VER=2024.11.22
     TOOLCHAIN_REPO=https://github.com/riscv-collab/riscv-gnu-toolchain
-    TOOLCHAIN_URL=${TOOLCHAIN_REPO}/releases/download/${GCC_VER}/riscv32-elf-ubuntu-${UBUNTU_VER}-gcc-nightly-${GCC_VER}-nightly.tar.gz
+    TOOLCHAIN_URL=${TOOLCHAIN_REPO}/releases/download/${GCC_VER}/riscv32-elf-ubuntu-${UBUNTU_VER}-gcc-nightly-${GCC_VER}-nightly.tar.xz
 fi
 
 wget -q ${TOOLCHAIN_URL} -O- | tar -C toolchain --strip-components=1 -xz


### PR DESCRIPTION
Ubuntu's GNU tar supports multiple compression formats [1], allowing us to extract both gzip and XZ archives using the same command, reflecting the riscv-gnu-toolchain's recent compression format change [2].

[1] https://www.gnu.org/software/tar/manual/tar.html#SEC131
[2] https://github.com/riscv-collab/riscv-gnu-toolchain/pull/1606