### PR TITLE
Fix unused function warning in 'mult_frac'

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -31,6 +31,7 @@
  * Reference:
  * https://elixir.bootlin.com/linux/v6.10.7/source/include/linux/math.h#L121
  */
+#if !defined(HAVE_POSIX_TIMER)
 static inline uint64_t mult_frac(uint64_t x, uint64_t n, uint64_t d)
 {
     const uint64_t q = x / d;
@@ -38,6 +39,7 @@ static inline uint64_t mult_frac(uint64_t x, uint64_t n, uint64_t d)
 
     return q * n + r * n / d;
 }
+#endif
 
 static void get_time_info(int32_t *tv_sec, int32_t *tv_nsec)
 {


### PR DESCRIPTION
When compiling with clang, the following warning message was generated:

src/utils.c:35:24: warning: unused function 'mult_frac' [-Wunused-function]
   35 | static inline uint64_t mult_frac(uint64_t x, uint64_t n, uint64_t d)
      |                        ^~~~~~~~~
1 warning generated.

To prevent this warning, a preprocessor condition
('#if !defined(HAVE_POSIX_TIMER)') was added, ensuring the function is only compiled when necessary.

Reported-by: Kuan-Wei Chiu <visitorckw@gmail.com>