### PR TITLE
Allow JIT compilation for system emulation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -243,6 +243,14 @@ jobs:
             .ci/boot-linux.sh
             make ENABLE_SYSTEM=1 clean
       if: ${{ always() }}
+    - name: boot Linux kernel test (JIT)
+      env:
+        CC: ${{ steps.install_cc.outputs.cc }}
+      run: |
+            make distclean && make INITRD_SIZE=32 ENABLE_SYSTEM=1 ENABLE_JIT=1 ENABLE_T2C=0 ENABLE_MOP_FUSION=0 -j$(nproc) && make ENABLE_SYSTEM=1 artifact -j$(nproc)
+            .ci/boot-linux.sh
+            make ENABLE_SYSTEM=1 ENABLE_JIT=1 ENABLE_T2C=0 ENABLE_MOP_FUSION=0 clean
+      if: ${{ always() }}
     - name: Architecture test
       env:
         CC: ${{ steps.install_cc.outputs.cc }}

--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,4 @@ tests/arch-test-target/config.ini
 tests/arch-test-target/sail_cSim/riscv_sim_RV32
 tests/scimark2/
 __pycache__/
-src/rv32_jit.c
 src/minimal_dtb.h

--- a/Makefile
+++ b/Makefile
@@ -257,9 +257,6 @@ ifeq ($(call has, JIT), 1)
         $(error JIT mode only supports for x64 and arm64 target currently.)
     endif
 
-src/rv32_jit.c:
-	$(Q)tools/gen-jit-template.py $(CFLAGS) > $@
-
 $(OUT)/jit.o: src/jit.c src/rv32_jit.c
 	$(VECHO) "  CC\t$@\n"
 	$(Q)$(CC) -o $@ $(CFLAGS) -c -MMD -MF $@.d $<
@@ -409,9 +406,10 @@ endif
 
 clean:
 	$(VECHO) "Cleaning... "
-	$(Q)$(RM) $(BIN) $(OBJS) $(DEV_OBJS) $(BUILD_DTB) $(BUILD_DTB2C) $(HIST_BIN) $(HIST_OBJS) $(deps) $(WEB_FILES) $(CACHE_OUT) src/rv32_jit.c
+	$(Q)$(RM) $(BIN) $(OBJS) $(DEV_OBJS) $(BUILD_DTB) $(BUILD_DTB2C) $(HIST_BIN) $(HIST_OBJS) $(deps) $(WEB_FILES) $(CACHE_OUT)
 	$(Q)-$(RM) $(SOFTFLOAT_LIB)
 	$(Q)$(call notice, [OK])
+
 distclean: clean
 	$(VECHO) "Deleting all generated files... "
 	$(Q)$(RM) -r $(OUT)/id1

--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ ifeq ($(call has, JIT), 1)
         ifeq ("$(CHECK_LLVM_LIBS)", "0")
             OBJS_EXT += t2c.o
             CFLAGS += -g $(shell $(LLVM_CONFIG) --cflags)
-            LDFLAGS += $(shell $(LLVM_CONFIG) --libs)
+            LDFLAGS += $(shell $(LLVM_CONFIG) --libfiles)
         else
             $(error No llvm-config-18 installed. Check llvm-config-18 installation in advance, or use "ENABLE_T2C=0" to disable tier-2 LLVM compiler)
         endif

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ CFLAGS = -std=gnu99 $(OPT_LEVEL) -Wall -Wextra -Werror
 CFLAGS += -Wno-unused-label
 CFLAGS += -include src/common.h -Isrc/
 
+OBJS_EXT :=
+
 # In the system test suite, the executable is an ELF file (e.g., MMU).
 # However, the Linux kernel emulation includes the Image, DT, and
 # root filesystem (rootfs). Therefore, the test suite needs this
@@ -35,6 +37,10 @@ $(call set-feature, LOG_COLOR)
 # Enable system emulation
 ENABLE_SYSTEM ?= 0
 $(call set-feature, SYSTEM)
+
+ifeq ($(call has, SYSTEM), 1)
+    OBJS_EXT += system.o
+endif
 
 # Definition that bridges:
 #   Device Tree(initrd, memory range)
@@ -95,8 +101,6 @@ endif
 
 # Disable Intel's Control-flow Enforcement Technology (CET)
 CFLAGS += $(CFLAGS_NO_CET)
-
-OBJS_EXT :=
 
 # Integer Multiplication and Division instructions
 ENABLE_EXT_M ?= 1

--- a/src/decode.h
+++ b/src/decode.h
@@ -332,6 +332,9 @@ typedef struct {
     struct rv_insn *target[HISTORY_SIZE];
 #else
     uint32_t times[HISTORY_SIZE];
+#if RV32_HAS(SYSTEM)
+    uint32_t satp[HISTORY_SIZE];
+#endif
 #endif
 } branch_history_table_t;
 

--- a/src/jit.h
+++ b/src/jit.h
@@ -14,11 +14,17 @@ struct jump {
     uint32_t offset_loc;
     uint32_t target_pc;
     uint32_t target_offset;
+#if RV32_HAS(SYSTEM)
+    uint32_t target_satp;
+#endif
 };
 
 struct offset_map {
     uint32_t pc;
     uint32_t offset;
+#if RV32_HAS(SYSTEM)
+    uint32_t satp;
+#endif
 };
 
 struct jit_state {

--- a/src/riscv_private.h
+++ b/src/riscv_private.h
@@ -90,6 +90,9 @@ typedef struct block {
     bool
         translatable; /**< Determine the block has RV32AF insturctions or not */
     bool has_loops;   /**< Determine the block has loop or not */
+#if RV32_HAS(SYSTEM)
+    uint32_t satp;
+#endif
 #if RV32_HAS(T2C)
     bool compiled; /**< The T2C request is enqueued or not */
 #endif
@@ -119,15 +122,31 @@ void block_map_clear(riscv_t *rv);
 struct riscv_internal {
     bool halt; /* indicate whether the core is halted */
 
-    /* I/O interface */
-    riscv_io_t io;
-
     /* integer registers */
+    /*
+     * Aarch64 encoder only accepts 9 bits signed offset. Do not put this
+     * structure below the section.
+     */
     riscv_word_t X[N_RV_REGS];
     riscv_word_t PC;
 
+#if RV32_HAS(JIT) && RV32_HAS(SYSTEM)
+    /*
+     * Aarch64 encoder only accepts 9 bits signed offset. Do not put this
+     * structure below the section.
+     */
+    struct {
+        uint32_t is_mmio; /* whether is MMIO or not */
+        uint32_t type;    /* 0: read, 1: write */
+        uint32_t vaddr;
+        uint32_t paddr;
+    } jit_mmu;
+#endif
     /* user provided data */
     riscv_user_t data;
+
+    /* I/O interface */
+    riscv_io_t io;
 
 #if RV32_HAS(EXT_F)
     /* float registers */

--- a/src/rv32_jit.c
+++ b/src/rv32_jit.c
@@ -13,7 +13,7 @@ GEN(jal, {
         emit_load_imm(state, vm_reg[0], ir->pc + 4);
     }
     store_back(state);
-    emit_jmp(state, ir->pc + ir->imm);
+    emit_jmp(state, ir->pc + ir->imm, rv->csr_satp);
     emit_load_imm(state, temp_reg, ir->pc + ir->imm);
     emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
     emit_exit(state);
@@ -28,7 +28,7 @@ GEN(jalr, {
         emit_load_imm(state, vm_reg[1], ir->pc + 4);
     }
     store_back(state);
-    parse_branch_history_table(state, ir);
+    parse_branch_history_table(state, rv, ir);
     emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
     emit_exit(state);
 })
@@ -36,17 +36,17 @@ GEN(beq, {
     ra_load2(state, ir->rs1, ir->rs2);
     emit_cmp32(state, vm_reg[1], vm_reg[0]);
     store_back(state);
-    uint32_t jump_loc = state->offset;
+    uint32_t jump_loc_0 = state->offset;
     emit_jcc_offset(state, 0x84);
     if (ir->branch_untaken) {
-        emit_jmp(state, ir->pc + 4);
+        emit_jmp(state, ir->pc + 4, rv->csr_satp);
     }
     emit_load_imm(state, temp_reg, ir->pc + 4);
     emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
     emit_exit(state);
-    emit_jump_target_offset(state, JUMP_LOC, state->offset);
+    emit_jump_target_offset(state, JUMP_LOC_0, state->offset);
     if (ir->branch_taken) {
-        emit_jmp(state, ir->pc + ir->imm);
+        emit_jmp(state, ir->pc + ir->imm, rv->csr_satp);
     }
     emit_load_imm(state, temp_reg, ir->pc + ir->imm);
     emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
@@ -56,17 +56,17 @@ GEN(bne, {
     ra_load2(state, ir->rs1, ir->rs2);
     emit_cmp32(state, vm_reg[1], vm_reg[0]);
     store_back(state);
-    uint32_t jump_loc = state->offset;
+    uint32_t jump_loc_0 = state->offset;
     emit_jcc_offset(state, 0x85);
     if (ir->branch_untaken) {
-        emit_jmp(state, ir->pc + 4);
+        emit_jmp(state, ir->pc + 4, rv->csr_satp);
     }
     emit_load_imm(state, temp_reg, ir->pc + 4);
     emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
     emit_exit(state);
-    emit_jump_target_offset(state, JUMP_LOC, state->offset);
+    emit_jump_target_offset(state, JUMP_LOC_0, state->offset);
     if (ir->branch_taken) {
-        emit_jmp(state, ir->pc + ir->imm);
+        emit_jmp(state, ir->pc + ir->imm, rv->csr_satp);
     }
     emit_load_imm(state, temp_reg, ir->pc + ir->imm);
     emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
@@ -76,17 +76,17 @@ GEN(blt, {
     ra_load2(state, ir->rs1, ir->rs2);
     emit_cmp32(state, vm_reg[1], vm_reg[0]);
     store_back(state);
-    uint32_t jump_loc = state->offset;
+    uint32_t jump_loc_0 = state->offset;
     emit_jcc_offset(state, 0x8c);
     if (ir->branch_untaken) {
-        emit_jmp(state, ir->pc + 4);
+        emit_jmp(state, ir->pc + 4, rv->csr_satp);
     }
     emit_load_imm(state, temp_reg, ir->pc + 4);
     emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
     emit_exit(state);
-    emit_jump_target_offset(state, JUMP_LOC, state->offset);
+    emit_jump_target_offset(state, JUMP_LOC_0, state->offset);
     if (ir->branch_taken) {
-        emit_jmp(state, ir->pc + ir->imm);
+        emit_jmp(state, ir->pc + ir->imm, rv->csr_satp);
     }
     emit_load_imm(state, temp_reg, ir->pc + ir->imm);
     emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
@@ -96,17 +96,17 @@ GEN(bge, {
     ra_load2(state, ir->rs1, ir->rs2);
     emit_cmp32(state, vm_reg[1], vm_reg[0]);
     store_back(state);
-    uint32_t jump_loc = state->offset;
+    uint32_t jump_loc_0 = state->offset;
     emit_jcc_offset(state, 0x8d);
     if (ir->branch_untaken) {
-        emit_jmp(state, ir->pc + 4);
+        emit_jmp(state, ir->pc + 4, rv->csr_satp);
     }
     emit_load_imm(state, temp_reg, ir->pc + 4);
     emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
     emit_exit(state);
-    emit_jump_target_offset(state, JUMP_LOC, state->offset);
+    emit_jump_target_offset(state, JUMP_LOC_0, state->offset);
     if (ir->branch_taken) {
-        emit_jmp(state, ir->pc + ir->imm);
+        emit_jmp(state, ir->pc + ir->imm, rv->csr_satp);
     }
     emit_load_imm(state, temp_reg, ir->pc + ir->imm);
     emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
@@ -116,17 +116,17 @@ GEN(bltu, {
     ra_load2(state, ir->rs1, ir->rs2);
     emit_cmp32(state, vm_reg[1], vm_reg[0]);
     store_back(state);
-    uint32_t jump_loc = state->offset;
+    uint32_t jump_loc_0 = state->offset;
     emit_jcc_offset(state, 0x82);
     if (ir->branch_untaken) {
-        emit_jmp(state, ir->pc + 4);
+        emit_jmp(state, ir->pc + 4, rv->csr_satp);
     }
     emit_load_imm(state, temp_reg, ir->pc + 4);
     emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
     emit_exit(state);
-    emit_jump_target_offset(state, JUMP_LOC, state->offset);
+    emit_jump_target_offset(state, JUMP_LOC_0, state->offset);
     if (ir->branch_taken) {
-        emit_jmp(state, ir->pc + ir->imm);
+        emit_jmp(state, ir->pc + ir->imm, rv->csr_satp);
     }
     emit_load_imm(state, temp_reg, ir->pc + ir->imm);
     emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
@@ -136,17 +136,17 @@ GEN(bgeu, {
     ra_load2(state, ir->rs1, ir->rs2);
     emit_cmp32(state, vm_reg[1], vm_reg[0]);
     store_back(state);
-    uint32_t jump_loc = state->offset;
+    uint32_t jump_loc_0 = state->offset;
     emit_jcc_offset(state, 0x83);
     if (ir->branch_untaken) {
-        emit_jmp(state, ir->pc + 4);
+        emit_jmp(state, ir->pc + 4, rv->csr_satp);
     }
     emit_load_imm(state, temp_reg, ir->pc + 4);
     emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
     emit_exit(state);
-    emit_jump_target_offset(state, JUMP_LOC, state->offset);
+    emit_jump_target_offset(state, JUMP_LOC_0, state->offset);
     if (ir->branch_taken) {
-        emit_jmp(state, ir->pc + ir->imm);
+        emit_jmp(state, ir->pc + ir->imm, rv->csr_satp);
     }
     emit_load_imm(state, temp_reg, ir->pc + ir->imm);
     emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
@@ -155,66 +155,412 @@ GEN(bgeu, {
 GEN(lb, {
     memory_t *m = PRIV(rv)->mem;
     vm_reg[0] = ra_load(state, ir->rs1);
-    emit_load_imm_sext(state, temp_reg, (intptr_t) (m->mem_base + ir->imm));
-    emit_alu64(state, 0x01, vm_reg[0], temp_reg);
-    vm_reg[1] = map_vm_reg(state, ir->rd);
-    emit_load_sext(state, S8, temp_reg, vm_reg[1], 0);
+    IIF(RV32_HAS(SYSTEM))
+    (
+        {
+            emit_load_imm_sext(state, temp_reg, ir->imm);
+            emit_alu32(state, 0x01, vm_reg[0], temp_reg);
+            emit_store(state, S32, temp_reg, parameter_reg[0],
+                       offsetof(riscv_t, jit_mmu.vaddr));
+            emit_load_imm(state, temp_reg, rv_insn_lb);
+            emit_store(state, S32, temp_reg, parameter_reg[0],
+                       offsetof(riscv_t, jit_mmu.type));
+
+            store_back(state);
+            emit_jit_mmu_handler(state, ir->rd);
+            /* clear register mapping */
+            reset_reg();
+
+            /*
+             * If it's MMIO, assign the read value to host register, otherwise,
+             * load from memory.
+             */
+            emit_load(state, S32, parameter_reg[0], temp_reg,
+                      offsetof(riscv_t, jit_mmu.is_mmio));
+            emit_cmp_imm32(state, temp_reg, 0);
+            uint32_t jump_loc_0 = state->offset;
+            emit_jcc_offset(state, 0x84);
+            vm_reg[1] = map_vm_reg(state, ir->rd);
+
+            emit_load(state, S32, parameter_reg[0], vm_reg[1],
+                      offsetof(riscv_t, X) + 4 * ir->rd);
+            /* skip regular loading */
+            uint64_t jump_loc_1 = state->offset;
+            emit_jcc_offset(state, 0xe9);
+
+            emit_jump_target_offset(state, JUMP_LOC_0, state->offset);
+            emit_load(state, S32, parameter_reg[0], vm_reg[0],
+                      offsetof(riscv_t, jit_mmu.paddr));
+            emit_load_imm_sext(state, temp_reg, (intptr_t) m->mem_base);
+            emit_alu64(state, 0x01, vm_reg[0], temp_reg);
+            emit_load_sext(state, S8, temp_reg, vm_reg[1], 0);
+            emit_jump_target_offset(state, JUMP_LOC_1, state->offset);
+        },
+        {
+            emit_load_imm_sext(state, temp_reg,
+                               (intptr_t) (m->mem_base + ir->imm));
+            emit_alu64(state, 0x01, vm_reg[0], temp_reg);
+            vm_reg[1] = map_vm_reg(state, ir->rd);
+            emit_load_sext(state, S8, temp_reg, vm_reg[1], 0);
+        })
 })
 GEN(lh, {
     memory_t *m = PRIV(rv)->mem;
     vm_reg[0] = ra_load(state, ir->rs1);
-    emit_load_imm_sext(state, temp_reg, (intptr_t) (m->mem_base + ir->imm));
-    emit_alu64(state, 0x01, vm_reg[0], temp_reg);
-    vm_reg[1] = map_vm_reg(state, ir->rd);
-    emit_load_sext(state, S16, temp_reg, vm_reg[1], 0);
+    IIF(RV32_HAS(SYSTEM))
+    (
+        {
+            emit_load_imm_sext(state, temp_reg, ir->imm);
+            emit_alu32(state, 0x01, vm_reg[0], temp_reg);
+            emit_store(state, S32, temp_reg, parameter_reg[0],
+                       offsetof(riscv_t, jit_mmu.vaddr));
+            emit_load_imm(state, temp_reg, rv_insn_lh);
+            emit_store(state, S32, temp_reg, parameter_reg[0],
+                       offsetof(riscv_t, jit_mmu.type));
+
+            store_back(state);
+            emit_jit_mmu_handler(state, ir->rd);
+            /* clear register mapping */
+            reset_reg();
+
+            /*
+             * If it's MMIO, assign the read value to host register, otherwise,
+             * load from memory.
+             */
+            emit_load(state, S32, parameter_reg[0], temp_reg,
+                      offsetof(riscv_t, jit_mmu.is_mmio));
+            emit_cmp_imm32(state, temp_reg, 0);
+            uint32_t jump_loc_0 = state->offset;
+            emit_jcc_offset(state, 0x84);
+            vm_reg[1] = map_vm_reg(state, ir->rd);
+
+            emit_load(state, S32, parameter_reg[0], vm_reg[1],
+                      offsetof(riscv_t, X) + 4 * ir->rd);
+            /* skip regular loading */
+            uint64_t jump_loc_1 = state->offset;
+            emit_jcc_offset(state, 0xe9);
+
+            emit_jump_target_offset(state, JUMP_LOC_0, state->offset);
+            emit_load(state, S32, parameter_reg[0], vm_reg[0],
+                      offsetof(riscv_t, jit_mmu.paddr));
+            emit_load_imm_sext(state, temp_reg, (intptr_t) m->mem_base);
+            emit_alu64(state, 0x01, vm_reg[0], temp_reg);
+            emit_load_sext(state, S16, temp_reg, vm_reg[1], 0);
+            emit_jump_target_offset(state, JUMP_LOC_1, state->offset);
+        },
+        {
+            emit_load_imm_sext(state, temp_reg,
+                               (intptr_t) (m->mem_base + ir->imm));
+            emit_alu64(state, 0x01, vm_reg[0], temp_reg);
+            vm_reg[1] = map_vm_reg(state, ir->rd);
+            emit_load_sext(state, S16, temp_reg, vm_reg[1], 0);
+        })
 })
 GEN(lw, {
     memory_t *m = PRIV(rv)->mem;
     vm_reg[0] = ra_load(state, ir->rs1);
-    emit_load_imm_sext(state, temp_reg, (intptr_t) (m->mem_base + ir->imm));
-    emit_alu64(state, 0x01, vm_reg[0], temp_reg);
-    vm_reg[1] = map_vm_reg(state, ir->rd);
-    emit_load(state, S32, temp_reg, vm_reg[1], 0);
+    IIF(RV32_HAS(SYSTEM))
+    (
+        {
+            emit_load_imm_sext(state, temp_reg, ir->imm);
+            emit_alu32(state, 0x01, vm_reg[0], temp_reg);
+            emit_store(state, S32, temp_reg, parameter_reg[0],
+                       offsetof(riscv_t, jit_mmu.vaddr));
+            emit_load_imm(state, temp_reg, rv_insn_lw);
+            emit_store(state, S32, temp_reg, parameter_reg[0],
+                       offsetof(riscv_t, jit_mmu.type));
+
+            store_back(state);
+            emit_jit_mmu_handler(state, ir->rd);
+            /* clear register mapping */
+            reset_reg();
+
+            /*
+             * If it's MMIO, assign the read value to host register, otherwise,
+             * load from memory.
+             */
+            emit_load(state, S32, parameter_reg[0], temp_reg,
+                      offsetof(riscv_t, jit_mmu.is_mmio));
+            emit_cmp_imm32(state, temp_reg, 0);
+            uint32_t jump_loc_0 = state->offset;
+            emit_jcc_offset(state, 0x84);
+            vm_reg[1] = map_vm_reg(state, ir->rd);
+
+            emit_load(state, S32, parameter_reg[0], vm_reg[1],
+                      offsetof(riscv_t, X) + 4 * ir->rd);
+            /* skip regular loading */
+            uint64_t jump_loc_1 = state->offset;
+            emit_jcc_offset(state, 0xe9);
+
+            emit_jump_target_offset(state, JUMP_LOC_0, state->offset);
+            emit_load(state, S32, parameter_reg[0], vm_reg[0],
+                      offsetof(riscv_t, jit_mmu.paddr));
+            emit_load_imm_sext(state, temp_reg, (intptr_t) m->mem_base);
+            emit_alu64(state, 0x01, vm_reg[0], temp_reg);
+            emit_load(state, S32, temp_reg, vm_reg[1], 0);
+            emit_jump_target_offset(state, JUMP_LOC_1, state->offset);
+        },
+        {
+            emit_load_imm_sext(state, temp_reg,
+                               (intptr_t) (m->mem_base + ir->imm));
+            emit_alu64(state, 0x01, vm_reg[0], temp_reg);
+            vm_reg[1] = map_vm_reg(state, ir->rd);
+            emit_load(state, S32, temp_reg, vm_reg[1], 0);
+        })
 })
 GEN(lbu, {
     memory_t *m = PRIV(rv)->mem;
     vm_reg[0] = ra_load(state, ir->rs1);
-    emit_load_imm_sext(state, temp_reg, (intptr_t) (m->mem_base + ir->imm));
-    emit_alu64(state, 0x01, vm_reg[0], temp_reg);
-    vm_reg[1] = map_vm_reg(state, ir->rd);
-    emit_load(state, S8, temp_reg, vm_reg[1], 0);
+    IIF(RV32_HAS(SYSTEM))
+    (
+        {
+            emit_load_imm_sext(state, temp_reg, ir->imm);
+            emit_alu32(state, 0x01, vm_reg[0], temp_reg);
+            emit_store(state, S32, temp_reg, parameter_reg[0],
+                       offsetof(riscv_t, jit_mmu.vaddr));
+            emit_load_imm(state, temp_reg, rv_insn_lbu);
+            emit_store(state, S32, temp_reg, parameter_reg[0],
+                       offsetof(riscv_t, jit_mmu.type));
+
+            store_back(state);
+            emit_jit_mmu_handler(state, ir->rd);
+            /* clear register mapping */
+            reset_reg();
+
+            /*
+             * If it's MMIO, assign the read value to host register, otherwise,
+             * load from memory.
+             */
+            emit_load(state, S32, parameter_reg[0], temp_reg,
+                      offsetof(riscv_t, jit_mmu.is_mmio));
+            emit_cmp_imm32(state, temp_reg, 0);
+            uint32_t jump_loc_0 = state->offset;
+            emit_jcc_offset(state, 0x84);
+            vm_reg[1] = map_vm_reg(state, ir->rd);
+
+            emit_load(state, S32, parameter_reg[0], vm_reg[1],
+                      offsetof(riscv_t, X) + 4 * ir->rd);
+            /* skip regular loading */
+            uint64_t jump_loc_1 = state->offset;
+            emit_jcc_offset(state, 0xe9);
+
+            emit_jump_target_offset(state, JUMP_LOC_0, state->offset);
+            emit_load(state, S32, parameter_reg[0], vm_reg[0],
+                      offsetof(riscv_t, jit_mmu.paddr));
+            emit_load_imm_sext(state, temp_reg, (intptr_t) m->mem_base);
+            emit_alu64(state, 0x01, vm_reg[0], temp_reg);
+            emit_load(state, S8, temp_reg, vm_reg[1], 0);
+            emit_jump_target_offset(state, JUMP_LOC_1, state->offset);
+        },
+        {
+            emit_load_imm_sext(state, temp_reg,
+                               (intptr_t) (m->mem_base + ir->imm));
+            emit_alu64(state, 0x01, vm_reg[0], temp_reg);
+            vm_reg[1] = map_vm_reg(state, ir->rd);
+            emit_load(state, S8, temp_reg, vm_reg[1], 0);
+        })
 })
 GEN(lhu, {
     memory_t *m = PRIV(rv)->mem;
     vm_reg[0] = ra_load(state, ir->rs1);
-    emit_load_imm_sext(state, temp_reg, (intptr_t) (m->mem_base + ir->imm));
-    emit_alu64(state, 0x01, vm_reg[0], temp_reg);
-    vm_reg[1] = map_vm_reg(state, ir->rd);
-    emit_load(state, S16, temp_reg, vm_reg[1], 0);
+    IIF(RV32_HAS(SYSTEM))
+    (
+        {
+            emit_load_imm_sext(state, temp_reg, ir->imm);
+            emit_alu32(state, 0x01, vm_reg[0], temp_reg);
+            emit_store(state, S32, temp_reg, parameter_reg[0],
+                       offsetof(riscv_t, jit_mmu.vaddr));
+            emit_load_imm(state, temp_reg, rv_insn_lhu);
+            emit_store(state, S32, temp_reg, parameter_reg[0],
+                       offsetof(riscv_t, jit_mmu.type));
+
+            store_back(state);
+            emit_jit_mmu_handler(state, ir->rd);
+            /* clear register mapping */
+            reset_reg();
+
+            /*
+             * If it's MMIO, assign the read value to host register, otherwise,
+             * load from memory.
+             */
+            emit_load(state, S32, parameter_reg[0], temp_reg,
+                      offsetof(riscv_t, jit_mmu.is_mmio));
+            emit_cmp_imm32(state, temp_reg, 0);
+            uint32_t jump_loc_0 = state->offset;
+            emit_jcc_offset(state, 0x84);
+            vm_reg[1] = map_vm_reg(state, ir->rd);
+
+            emit_load(state, S32, parameter_reg[0], vm_reg[1],
+                      offsetof(riscv_t, X) + 4 * ir->rd);
+            /* skip regular loading */
+            uint64_t jump_loc_1 = state->offset;
+            emit_jcc_offset(state, 0xe9);
+
+            emit_jump_target_offset(state, JUMP_LOC_0, state->offset);
+            emit_load(state, S32, parameter_reg[0], vm_reg[0],
+                      offsetof(riscv_t, jit_mmu.paddr));
+            emit_load_imm_sext(state, temp_reg, (intptr_t) m->mem_base);
+            emit_alu64(state, 0x01, vm_reg[0], temp_reg);
+            emit_load(state, S16, temp_reg, vm_reg[1], 0);
+            emit_jump_target_offset(state, JUMP_LOC_1, state->offset);
+        },
+        {
+            emit_load_imm_sext(state, temp_reg,
+                               (intptr_t) (m->mem_base + ir->imm));
+            emit_alu64(state, 0x01, vm_reg[0], temp_reg);
+            vm_reg[1] = map_vm_reg(state, ir->rd);
+            emit_load(state, S16, temp_reg, vm_reg[1], 0);
+        })
 })
 GEN(sb, {
     memory_t *m = PRIV(rv)->mem;
     vm_reg[0] = ra_load(state, ir->rs1);
-    emit_load_imm_sext(state, temp_reg, (intptr_t) (m->mem_base + ir->imm));
-    emit_alu64(state, 0x01, vm_reg[0], temp_reg);
-    vm_reg[1] = ra_load(state, ir->rs2);
-    emit_store(state, S8, vm_reg[1], temp_reg, 0);
+    IIF(RV32_HAS(SYSTEM))
+    (
+        {
+            emit_load_imm_sext(state, temp_reg, ir->imm);
+            emit_alu32(state, 0x01, vm_reg[0], temp_reg);
+            emit_store(state, S32, temp_reg, parameter_reg[0],
+                       offsetof(riscv_t, jit_mmu.vaddr));
+            emit_load_imm(state, temp_reg, rv_insn_sb);
+            emit_store(state, S32, temp_reg, parameter_reg[0],
+                       offsetof(riscv_t, jit_mmu.type));
+            store_back(state);
+            emit_jit_mmu_handler(state, ir->rs2);
+            /* clear register mapping */
+            reset_reg();
+
+            /*
+             * If it's MMIO, it does not need to do the storing since it has
+             * been done in the mmio handler, otherwise, store the value into
+             * memory.
+             */
+            emit_load(state, S32, parameter_reg[0], temp_reg,
+                      offsetof(riscv_t, jit_mmu.is_mmio));
+            emit_cmp_imm32(state, temp_reg, 1);
+            uint32_t jump_loc_0 = state->offset;
+            emit_jcc_offset(state, 0x84);
+
+            emit_load(state, S32, parameter_reg[0], vm_reg[0],
+                      offsetof(riscv_t, jit_mmu.paddr));
+            emit_load_imm_sext(state, temp_reg, (intptr_t) m->mem_base);
+            emit_alu64(state, 0x01, vm_reg[0], temp_reg);
+            vm_reg[1] = ra_load(state, ir->rs2);
+            emit_store(state, S8, vm_reg[1], temp_reg, 0);
+            emit_jump_target_offset(state, JUMP_LOC_0, state->offset);
+            /*
+             * Clear register mapping since we do not ensure operand "ir->rs2"
+             * is loaded or not.
+             */
+            reset_reg();
+        },
+        {
+            emit_load_imm_sext(state, temp_reg,
+                               (intptr_t) (m->mem_base + ir->imm));
+            emit_alu64(state, 0x01, vm_reg[0], temp_reg);
+            vm_reg[1] = ra_load(state, ir->rs2);
+            emit_store(state, S8, vm_reg[1], temp_reg, 0);
+        })
 })
 GEN(sh, {
     memory_t *m = PRIV(rv)->mem;
     vm_reg[0] = ra_load(state, ir->rs1);
-    emit_load_imm_sext(state, temp_reg, (intptr_t) (m->mem_base + ir->imm));
-    emit_alu64(state, 0x01, vm_reg[0], temp_reg);
-    vm_reg[1] = ra_load(state, ir->rs2);
-    emit_store(state, S16, vm_reg[1], temp_reg, 0);
+    IIF(RV32_HAS(SYSTEM))
+    (
+        {
+            emit_load_imm_sext(state, temp_reg, ir->imm);
+            emit_alu32(state, 0x01, vm_reg[0], temp_reg);
+            emit_store(state, S32, temp_reg, parameter_reg[0],
+                       offsetof(riscv_t, jit_mmu.vaddr));
+            emit_load_imm(state, temp_reg, rv_insn_sh);
+            emit_store(state, S32, temp_reg, parameter_reg[0],
+                       offsetof(riscv_t, jit_mmu.type));
+            store_back(state);
+            emit_jit_mmu_handler(state, ir->rs2);
+            /* clear register mapping */
+            reset_reg();
+
+            /*
+             * If it's MMIO, it does not need to do the storing since it has
+             * been done in the mmio handler, otherwise, store the value into
+             * memory.
+             */
+            emit_load(state, S32, parameter_reg[0], temp_reg,
+                      offsetof(riscv_t, jit_mmu.is_mmio));
+            emit_cmp_imm32(state, temp_reg, 1);
+            uint32_t jump_loc_0 = state->offset;
+            emit_jcc_offset(state, 0x84);
+
+            emit_load(state, S32, parameter_reg[0], vm_reg[0],
+                      offsetof(riscv_t, jit_mmu.paddr));
+            emit_load_imm_sext(state, temp_reg, (intptr_t) m->mem_base);
+            emit_alu64(state, 0x01, vm_reg[0], temp_reg);
+            vm_reg[1] = ra_load(state, ir->rs2);
+            emit_store(state, S16, vm_reg[1], temp_reg, 0);
+            emit_jump_target_offset(state, JUMP_LOC_0, state->offset);
+            /*
+             * Clear register mapping since we do not ensure operand "ir->rs2"
+             * is loaded or not.
+             */
+            reset_reg();
+        },
+        {
+            emit_load_imm_sext(state, temp_reg,
+                               (intptr_t) (m->mem_base + ir->imm));
+            emit_alu64(state, 0x01, vm_reg[0], temp_reg);
+            vm_reg[1] = ra_load(state, ir->rs2);
+            emit_store(state, S16, vm_reg[1], temp_reg, 0);
+        })
 })
 GEN(sw, {
     memory_t *m = PRIV(rv)->mem;
     vm_reg[0] = ra_load(state, ir->rs1);
-    emit_load_imm_sext(state, temp_reg, (intptr_t) (m->mem_base + ir->imm));
-    emit_alu64(state, 0x01, vm_reg[0], temp_reg);
-    vm_reg[1] = ra_load(state, ir->rs2);
-    emit_store(state, S32, vm_reg[1], temp_reg, 0);
+    IIF(RV32_HAS(SYSTEM))
+    (
+        {
+            emit_load_imm_sext(state, temp_reg, ir->imm);
+            emit_alu32(state, 0x01, vm_reg[0], temp_reg);
+            emit_store(state, S32, temp_reg, parameter_reg[0],
+                       offsetof(riscv_t, jit_mmu.vaddr));
+            emit_load_imm(state, temp_reg, rv_insn_sw);
+            emit_store(state, S32, temp_reg, parameter_reg[0],
+                       offsetof(riscv_t, jit_mmu.type));
+            store_back(state);
+            emit_jit_mmu_handler(state, ir->rs2);
+            /* clear register mapping */
+            reset_reg();
+
+            /*
+             * If it's MMIO, it does not need to do the storing since it has
+             * been done in the mmio handler, otherwise, store the value into
+             * memory.
+             */
+            emit_load(state, S32, parameter_reg[0], temp_reg,
+                      offsetof(riscv_t, jit_mmu.is_mmio));
+            emit_cmp_imm32(state, temp_reg, 1);
+            uint32_t jump_loc_0 = state->offset;
+            emit_jcc_offset(state, 0x84);
+
+            emit_load(state, S32, parameter_reg[0], vm_reg[0],
+                      offsetof(riscv_t, jit_mmu.paddr));
+            emit_load_imm_sext(state, temp_reg, (intptr_t) m->mem_base);
+            emit_alu64(state, 0x01, vm_reg[0], temp_reg);
+            vm_reg[1] = ra_load(state, ir->rs2);
+            emit_store(state, S32, vm_reg[1], temp_reg, 0);
+            emit_jump_target_offset(state, JUMP_LOC_0, state->offset);
+            /*
+             * Clear register mapping since we do not ensure operand "ir->rs2"
+             * is loaded into host register "vm_reg[1]" or not.
+             */
+            reset_reg();
+        },
+        {
+            emit_load_imm_sext(state, temp_reg,
+                               (intptr_t) (m->mem_base + ir->imm));
+            emit_alu64(state, 0x01, vm_reg[0], temp_reg);
+            vm_reg[1] = ra_load(state, ir->rs2);
+            emit_store(state, S32, vm_reg[1], temp_reg, 0);
+        })
 })
 GEN(addi, {
     vm_reg[0] = ra_load(state, ir->rs1);
@@ -229,20 +575,20 @@ GEN(slti, {
     emit_cmp_imm32(state, vm_reg[0], ir->imm);
     vm_reg[1] = map_vm_reg(state, ir->rd);
     emit_load_imm(state, vm_reg[1], 1);
-    uint32_t jump_loc = state->offset;
+    uint32_t jump_loc_0 = state->offset;
     emit_jcc_offset(state, 0x8c);
     emit_load_imm(state, vm_reg[1], 0);
-    emit_jump_target_offset(state, JUMP_LOC, state->offset);
+    emit_jump_target_offset(state, JUMP_LOC_0, state->offset);
 })
 GEN(sltiu, {
     vm_reg[0] = ra_load(state, ir->rs1);
     emit_cmp_imm32(state, vm_reg[0], ir->imm);
     vm_reg[1] = map_vm_reg(state, ir->rd);
     emit_load_imm(state, vm_reg[1], 1);
-    uint32_t jump_loc = state->offset;
+    uint32_t jump_loc_0 = state->offset;
     emit_jcc_offset(state, 0x82);
     emit_load_imm(state, vm_reg[1], 0);
-    emit_jump_target_offset(state, JUMP_LOC, state->offset);
+    emit_jump_target_offset(state, JUMP_LOC_0, state->offset);
 })
 GEN(xori, {
     vm_reg[0] = ra_load(state, ir->rs1);
@@ -319,20 +665,20 @@ GEN(slt, {
     vm_reg[2] = map_vm_reg(state, ir->rd);
     emit_cmp32(state, vm_reg[1], vm_reg[0]);
     emit_load_imm(state, vm_reg[2], 1);
-    uint32_t jump_loc = state->offset;
+    uint32_t jump_loc_0 = state->offset;
     emit_jcc_offset(state, 0x8c);
     emit_load_imm(state, vm_reg[2], 0);
-    emit_jump_target_offset(state, JUMP_LOC, state->offset);
+    emit_jump_target_offset(state, JUMP_LOC_0, state->offset);
 })
 GEN(sltu, {
     ra_load2(state, ir->rs1, ir->rs2);
     vm_reg[2] = map_vm_reg(state, ir->rd);
     emit_cmp32(state, vm_reg[1], vm_reg[0]);
     emit_load_imm(state, vm_reg[2], 1);
-    uint32_t jump_loc = state->offset;
+    uint32_t jump_loc_0 = state->offset;
     emit_jcc_offset(state, 0x82);
     emit_load_imm(state, vm_reg[2], 0);
-    emit_jump_target_offset(state, JUMP_LOC, state->offset);
+    emit_jump_target_offset(state, JUMP_LOC_0, state->offset);
 })
 GEN(xor, {
   ra_load2(state, ir->rs1, ir->rs2);
@@ -388,17 +734,24 @@ GEN(ebreak, {
 })
 GEN(wfi, { assert(NULL); })
 GEN(uret, { assert(NULL); })
+#if RV32_HAS(SYSTEM)
 GEN(sret, { assert(NULL); })
+#endif
 GEN(hret, { assert(NULL); })
 GEN(mret, { assert(NULL); })
 GEN(sfencevma, { assert(NULL); })
+#if RV32_HAS(Zifencei) /* RV32 Zifencei Standard Extension */
 GEN(fencei, { assert(NULL); })
+#endif
+#if RV32_HAS(Zicsr) /* RV32 Zicsr Standard Extension */
 GEN(csrrw, { assert(NULL); })
 GEN(csrrs, { assert(NULL); })
 GEN(csrrc, { assert(NULL); })
 GEN(csrrwi, { assert(NULL); })
 GEN(csrrsi, { assert(NULL); })
 GEN(csrrci, { assert(NULL); })
+#endif
+#if RV32_HAS(EXT_M)
 GEN(mul, {
     ra_load2(state, ir->rs1, ir->rs2);
     vm_reg[2] = map_vm_reg(state, ir->rd);
@@ -458,6 +811,8 @@ GEN(remu, {
     emit_mov(state, vm_reg[0], vm_reg[2]);
     muldivmod(state, 0x98, temp_reg, vm_reg[2], 0);
 })
+#endif
+#if RV32_HAS(EXT_A)
 GEN(lrw, { assert(NULL); })
 GEN(scw, { assert(NULL); })
 GEN(amoswapw, { assert(NULL); })
@@ -469,6 +824,8 @@ GEN(amominw, { assert(NULL); })
 GEN(amomaxw, { assert(NULL); })
 GEN(amominuw, { assert(NULL); })
 GEN(amomaxuw, { assert(NULL); })
+#endif
+#if RV32_HAS(EXT_F)
 GEN(flw, { assert(NULL); })
 GEN(fsw, { assert(NULL); })
 GEN(fmadds, { assert(NULL); })
@@ -495,6 +852,8 @@ GEN(fclasss, { assert(NULL); })
 GEN(fcvtsw, { assert(NULL); })
 GEN(fcvtswu, { assert(NULL); })
 GEN(fmvwx, { assert(NULL); })
+#endif
+#if RV32_HAS(EXT_C)
 GEN(caddi4spn, {
     vm_reg[0] = ra_load(state, rv_reg_sp);
     vm_reg[1] = map_vm_reg(state, ir->rd);
@@ -528,7 +887,7 @@ GEN(cjal, {
     vm_reg[0] = map_vm_reg(state, rv_reg_ra);
     emit_load_imm(state, vm_reg[0], ir->pc + 2);
     store_back(state);
-    emit_jmp(state, ir->pc + ir->imm);
+    emit_jmp(state, ir->pc + ir->imm, rv->csr_satp);
     emit_load_imm(state, temp_reg, ir->pc + ir->imm);
     emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
     emit_exit(state);
@@ -587,7 +946,7 @@ GEN(cand, {
 })
 GEN(cj, {
     store_back(state);
-    emit_jmp(state, ir->pc + ir->imm);
+    emit_jmp(state, ir->pc + ir->imm, rv->csr_satp);
     emit_load_imm(state, temp_reg, ir->pc + ir->imm);
     emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
     emit_exit(state);
@@ -596,17 +955,17 @@ GEN(cbeqz, {
     vm_reg[0] = ra_load(state, ir->rs1);
     emit_cmp_imm32(state, vm_reg[0], 0);
     store_back(state);
-    uint32_t jump_loc = state->offset;
+    uint32_t jump_loc_0 = state->offset;
     emit_jcc_offset(state, 0x84);
     if (ir->branch_untaken) {
-        emit_jmp(state, ir->pc + 2);
+        emit_jmp(state, ir->pc + 2, rv->csr_satp);
     }
     emit_load_imm(state, temp_reg, ir->pc + 2);
     emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
     emit_exit(state);
-    emit_jump_target_offset(state, JUMP_LOC, state->offset);
+    emit_jump_target_offset(state, JUMP_LOC_0, state->offset);
     if (ir->branch_taken) {
-        emit_jmp(state, ir->pc + ir->imm);
+        emit_jmp(state, ir->pc + ir->imm, rv->csr_satp);
     }
     emit_load_imm(state, temp_reg, ir->pc + ir->imm);
     emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
@@ -616,17 +975,17 @@ GEN(cbnez, {
     vm_reg[0] = ra_load(state, ir->rs1);
     emit_cmp_imm32(state, vm_reg[0], 0);
     store_back(state);
-    uint32_t jump_loc = state->offset;
+    uint32_t jump_loc_0 = state->offset;
     emit_jcc_offset(state, 0x85);
     if (ir->branch_untaken) {
-        emit_jmp(state, ir->pc + 2);
+        emit_jmp(state, ir->pc + 2, rv->csr_satp);
     }
     emit_load_imm(state, temp_reg, ir->pc + 2);
     emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
     emit_exit(state);
-    emit_jump_target_offset(state, JUMP_LOC, state->offset);
+    emit_jump_target_offset(state, JUMP_LOC_0, state->offset);
     if (ir->branch_taken) {
-        emit_jmp(state, ir->pc + ir->imm);
+        emit_jmp(state, ir->pc + ir->imm, rv->csr_satp);
     }
     emit_load_imm(state, temp_reg, ir->pc + ir->imm);
     emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
@@ -648,7 +1007,7 @@ GEN(cjr, {
     vm_reg[0] = ra_load(state, ir->rs1);
     emit_mov(state, vm_reg[0], temp_reg);
     store_back(state);
-    parse_branch_history_table(state, ir);
+    parse_branch_history_table(state, rv, ir);
     emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
     emit_exit(state);
 })
@@ -674,7 +1033,7 @@ GEN(cjalr, {
     vm_reg[1] = map_vm_reg(state, rv_reg_ra);
     emit_load_imm(state, vm_reg[1], ir->pc + 2);
     store_back(state);
-    parse_branch_history_table(state, ir);
+    parse_branch_history_table(state, rv, ir);
     emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
     emit_exit(state);
 })
@@ -693,13 +1052,19 @@ GEN(cswsp, {
     vm_reg[1] = ra_load(state, ir->rs2);
     emit_store(state, S32, vm_reg[1], temp_reg, 0);
 })
+#endif
+#if RV32_HAS(EXT_C) && RV32_HAS(EXT_F)
 GEN(cflwsp, { assert(NULL); })
 GEN(cfswsp, { assert(NULL); })
 GEN(cflw, { assert(NULL); })
 GEN(cfsw, { assert(NULL); })
+#endif
+#if RV32_HAS(Zba)
 GEN(sh1add, { assert(NULL); })
 GEN(sh2add, { assert(NULL); })
 GEN(sh3add, { assert(NULL); })
+#endif
+#if RV32_HAS(Zbb)
 GEN(andn, { assert(NULL); })
 GEN(orn, { assert(NULL); })
 GEN(xnor, { assert(NULL); })
@@ -718,9 +1083,13 @@ GEN(ror, { assert(NULL); })
 GEN(rori, { assert(NULL); })
 GEN(orcb, { assert(NULL); })
 GEN(rev8, { assert(NULL); })
+#endif
+#if RV32_HAS(Zbc)
 GEN(clmul, { assert(NULL); })
 GEN(clmulh, { assert(NULL); })
 GEN(clmulr, { assert(NULL); })
+#endif
+#if RV32_HAS(Zbs)
 GEN(bclr, { assert(NULL); })
 GEN(bclri, { assert(NULL); })
 GEN(bext, { assert(NULL); })
@@ -729,3 +1098,4 @@ GEN(binv, { assert(NULL); })
 GEN(binvi, { assert(NULL); })
 GEN(bset, { assert(NULL); })
 GEN(bseti, { assert(NULL); })
+#endif

--- a/src/rv32_jit.c
+++ b/src/rv32_jit.c
@@ -1,0 +1,731 @@
+GEN(nop, {})
+GEN(lui, {
+    vm_reg[0] = map_vm_reg(state, ir->rd);
+    emit_load_imm(state, vm_reg[0], ir->imm);
+})
+GEN(auipc, {
+    vm_reg[0] = map_vm_reg(state, ir->rd);
+    emit_load_imm(state, vm_reg[0], ir->pc + ir->imm);
+})
+GEN(jal, {
+    if (ir->rd) {
+        vm_reg[0] = map_vm_reg(state, ir->rd);
+        emit_load_imm(state, vm_reg[0], ir->pc + 4);
+    }
+    store_back(state);
+    emit_jmp(state, ir->pc + ir->imm);
+    emit_load_imm(state, temp_reg, ir->pc + ir->imm);
+    emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
+    emit_exit(state);
+})
+GEN(jalr, {
+    vm_reg[0] = ra_load(state, ir->rs1);
+    emit_mov(state, vm_reg[0], temp_reg);
+    emit_alu32_imm32(state, 0x81, 0, temp_reg, ir->imm);
+    emit_alu32_imm32(state, 0x81, 4, temp_reg, ~1U);
+    if (ir->rd) {
+        vm_reg[1] = map_vm_reg(state, ir->rd);
+        emit_load_imm(state, vm_reg[1], ir->pc + 4);
+    }
+    store_back(state);
+    parse_branch_history_table(state, ir);
+    emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
+    emit_exit(state);
+})
+GEN(beq, {
+    ra_load2(state, ir->rs1, ir->rs2);
+    emit_cmp32(state, vm_reg[1], vm_reg[0]);
+    store_back(state);
+    uint32_t jump_loc = state->offset;
+    emit_jcc_offset(state, 0x84);
+    if (ir->branch_untaken) {
+        emit_jmp(state, ir->pc + 4);
+    }
+    emit_load_imm(state, temp_reg, ir->pc + 4);
+    emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
+    emit_exit(state);
+    emit_jump_target_offset(state, JUMP_LOC, state->offset);
+    if (ir->branch_taken) {
+        emit_jmp(state, ir->pc + ir->imm);
+    }
+    emit_load_imm(state, temp_reg, ir->pc + ir->imm);
+    emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
+    emit_exit(state);
+})
+GEN(bne, {
+    ra_load2(state, ir->rs1, ir->rs2);
+    emit_cmp32(state, vm_reg[1], vm_reg[0]);
+    store_back(state);
+    uint32_t jump_loc = state->offset;
+    emit_jcc_offset(state, 0x85);
+    if (ir->branch_untaken) {
+        emit_jmp(state, ir->pc + 4);
+    }
+    emit_load_imm(state, temp_reg, ir->pc + 4);
+    emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
+    emit_exit(state);
+    emit_jump_target_offset(state, JUMP_LOC, state->offset);
+    if (ir->branch_taken) {
+        emit_jmp(state, ir->pc + ir->imm);
+    }
+    emit_load_imm(state, temp_reg, ir->pc + ir->imm);
+    emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
+    emit_exit(state);
+})
+GEN(blt, {
+    ra_load2(state, ir->rs1, ir->rs2);
+    emit_cmp32(state, vm_reg[1], vm_reg[0]);
+    store_back(state);
+    uint32_t jump_loc = state->offset;
+    emit_jcc_offset(state, 0x8c);
+    if (ir->branch_untaken) {
+        emit_jmp(state, ir->pc + 4);
+    }
+    emit_load_imm(state, temp_reg, ir->pc + 4);
+    emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
+    emit_exit(state);
+    emit_jump_target_offset(state, JUMP_LOC, state->offset);
+    if (ir->branch_taken) {
+        emit_jmp(state, ir->pc + ir->imm);
+    }
+    emit_load_imm(state, temp_reg, ir->pc + ir->imm);
+    emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
+    emit_exit(state);
+})
+GEN(bge, {
+    ra_load2(state, ir->rs1, ir->rs2);
+    emit_cmp32(state, vm_reg[1], vm_reg[0]);
+    store_back(state);
+    uint32_t jump_loc = state->offset;
+    emit_jcc_offset(state, 0x8d);
+    if (ir->branch_untaken) {
+        emit_jmp(state, ir->pc + 4);
+    }
+    emit_load_imm(state, temp_reg, ir->pc + 4);
+    emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
+    emit_exit(state);
+    emit_jump_target_offset(state, JUMP_LOC, state->offset);
+    if (ir->branch_taken) {
+        emit_jmp(state, ir->pc + ir->imm);
+    }
+    emit_load_imm(state, temp_reg, ir->pc + ir->imm);
+    emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
+    emit_exit(state);
+})
+GEN(bltu, {
+    ra_load2(state, ir->rs1, ir->rs2);
+    emit_cmp32(state, vm_reg[1], vm_reg[0]);
+    store_back(state);
+    uint32_t jump_loc = state->offset;
+    emit_jcc_offset(state, 0x82);
+    if (ir->branch_untaken) {
+        emit_jmp(state, ir->pc + 4);
+    }
+    emit_load_imm(state, temp_reg, ir->pc + 4);
+    emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
+    emit_exit(state);
+    emit_jump_target_offset(state, JUMP_LOC, state->offset);
+    if (ir->branch_taken) {
+        emit_jmp(state, ir->pc + ir->imm);
+    }
+    emit_load_imm(state, temp_reg, ir->pc + ir->imm);
+    emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
+    emit_exit(state);
+})
+GEN(bgeu, {
+    ra_load2(state, ir->rs1, ir->rs2);
+    emit_cmp32(state, vm_reg[1], vm_reg[0]);
+    store_back(state);
+    uint32_t jump_loc = state->offset;
+    emit_jcc_offset(state, 0x83);
+    if (ir->branch_untaken) {
+        emit_jmp(state, ir->pc + 4);
+    }
+    emit_load_imm(state, temp_reg, ir->pc + 4);
+    emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
+    emit_exit(state);
+    emit_jump_target_offset(state, JUMP_LOC, state->offset);
+    if (ir->branch_taken) {
+        emit_jmp(state, ir->pc + ir->imm);
+    }
+    emit_load_imm(state, temp_reg, ir->pc + ir->imm);
+    emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
+    emit_exit(state);
+})
+GEN(lb, {
+    memory_t *m = PRIV(rv)->mem;
+    vm_reg[0] = ra_load(state, ir->rs1);
+    emit_load_imm_sext(state, temp_reg, (intptr_t) (m->mem_base + ir->imm));
+    emit_alu64(state, 0x01, vm_reg[0], temp_reg);
+    vm_reg[1] = map_vm_reg(state, ir->rd);
+    emit_load_sext(state, S8, temp_reg, vm_reg[1], 0);
+})
+GEN(lh, {
+    memory_t *m = PRIV(rv)->mem;
+    vm_reg[0] = ra_load(state, ir->rs1);
+    emit_load_imm_sext(state, temp_reg, (intptr_t) (m->mem_base + ir->imm));
+    emit_alu64(state, 0x01, vm_reg[0], temp_reg);
+    vm_reg[1] = map_vm_reg(state, ir->rd);
+    emit_load_sext(state, S16, temp_reg, vm_reg[1], 0);
+})
+GEN(lw, {
+    memory_t *m = PRIV(rv)->mem;
+    vm_reg[0] = ra_load(state, ir->rs1);
+    emit_load_imm_sext(state, temp_reg, (intptr_t) (m->mem_base + ir->imm));
+    emit_alu64(state, 0x01, vm_reg[0], temp_reg);
+    vm_reg[1] = map_vm_reg(state, ir->rd);
+    emit_load(state, S32, temp_reg, vm_reg[1], 0);
+})
+GEN(lbu, {
+    memory_t *m = PRIV(rv)->mem;
+    vm_reg[0] = ra_load(state, ir->rs1);
+    emit_load_imm_sext(state, temp_reg, (intptr_t) (m->mem_base + ir->imm));
+    emit_alu64(state, 0x01, vm_reg[0], temp_reg);
+    vm_reg[1] = map_vm_reg(state, ir->rd);
+    emit_load(state, S8, temp_reg, vm_reg[1], 0);
+})
+GEN(lhu, {
+    memory_t *m = PRIV(rv)->mem;
+    vm_reg[0] = ra_load(state, ir->rs1);
+    emit_load_imm_sext(state, temp_reg, (intptr_t) (m->mem_base + ir->imm));
+    emit_alu64(state, 0x01, vm_reg[0], temp_reg);
+    vm_reg[1] = map_vm_reg(state, ir->rd);
+    emit_load(state, S16, temp_reg, vm_reg[1], 0);
+})
+GEN(sb, {
+    memory_t *m = PRIV(rv)->mem;
+    vm_reg[0] = ra_load(state, ir->rs1);
+    emit_load_imm_sext(state, temp_reg, (intptr_t) (m->mem_base + ir->imm));
+    emit_alu64(state, 0x01, vm_reg[0], temp_reg);
+    vm_reg[1] = ra_load(state, ir->rs2);
+    emit_store(state, S8, vm_reg[1], temp_reg, 0);
+})
+GEN(sh, {
+    memory_t *m = PRIV(rv)->mem;
+    vm_reg[0] = ra_load(state, ir->rs1);
+    emit_load_imm_sext(state, temp_reg, (intptr_t) (m->mem_base + ir->imm));
+    emit_alu64(state, 0x01, vm_reg[0], temp_reg);
+    vm_reg[1] = ra_load(state, ir->rs2);
+    emit_store(state, S16, vm_reg[1], temp_reg, 0);
+})
+GEN(sw, {
+    memory_t *m = PRIV(rv)->mem;
+    vm_reg[0] = ra_load(state, ir->rs1);
+    emit_load_imm_sext(state, temp_reg, (intptr_t) (m->mem_base + ir->imm));
+    emit_alu64(state, 0x01, vm_reg[0], temp_reg);
+    vm_reg[1] = ra_load(state, ir->rs2);
+    emit_store(state, S32, vm_reg[1], temp_reg, 0);
+})
+GEN(addi, {
+    vm_reg[0] = ra_load(state, ir->rs1);
+    vm_reg[1] = map_vm_reg(state, ir->rd);
+    if (vm_reg[0] != vm_reg[1]) {
+        emit_mov(state, vm_reg[0], vm_reg[1]);
+    }
+    emit_alu32_imm32(state, 0x81, 0, vm_reg[1], ir->imm);
+})
+GEN(slti, {
+    vm_reg[0] = ra_load(state, ir->rs1);
+    emit_cmp_imm32(state, vm_reg[0], ir->imm);
+    vm_reg[1] = map_vm_reg(state, ir->rd);
+    emit_load_imm(state, vm_reg[1], 1);
+    uint32_t jump_loc = state->offset;
+    emit_jcc_offset(state, 0x8c);
+    emit_load_imm(state, vm_reg[1], 0);
+    emit_jump_target_offset(state, JUMP_LOC, state->offset);
+})
+GEN(sltiu, {
+    vm_reg[0] = ra_load(state, ir->rs1);
+    emit_cmp_imm32(state, vm_reg[0], ir->imm);
+    vm_reg[1] = map_vm_reg(state, ir->rd);
+    emit_load_imm(state, vm_reg[1], 1);
+    uint32_t jump_loc = state->offset;
+    emit_jcc_offset(state, 0x82);
+    emit_load_imm(state, vm_reg[1], 0);
+    emit_jump_target_offset(state, JUMP_LOC, state->offset);
+})
+GEN(xori, {
+    vm_reg[0] = ra_load(state, ir->rs1);
+    vm_reg[1] = map_vm_reg(state, ir->rd);
+    if (vm_reg[0] != vm_reg[1]) {
+        emit_mov(state, vm_reg[0], vm_reg[1]);
+    }
+    emit_alu32_imm32(state, 0x81, 6, vm_reg[1], ir->imm);
+})
+GEN(ori, {
+    vm_reg[0] = ra_load(state, ir->rs1);
+    vm_reg[1] = map_vm_reg(state, ir->rd);
+    if (vm_reg[0] != vm_reg[1]) {
+        emit_mov(state, vm_reg[0], vm_reg[1]);
+    }
+    emit_alu32_imm32(state, 0x81, 1, vm_reg[1], ir->imm);
+})
+GEN(andi, {
+    vm_reg[0] = ra_load(state, ir->rs1);
+    vm_reg[1] = map_vm_reg(state, ir->rd);
+    if (vm_reg[0] != vm_reg[1]) {
+        emit_mov(state, vm_reg[0], vm_reg[1]);
+    }
+    emit_alu32_imm32(state, 0x81, 4, vm_reg[1], ir->imm);
+})
+GEN(slli, {
+    vm_reg[0] = ra_load(state, ir->rs1);
+    vm_reg[1] = map_vm_reg(state, ir->rd);
+    if (vm_reg[0] != vm_reg[1]) {
+        emit_mov(state, vm_reg[0], vm_reg[1]);
+    }
+    emit_alu32_imm8(state, 0xc1, 4, vm_reg[1], ir->imm & 0x1f);
+})
+GEN(srli, {
+    vm_reg[0] = ra_load(state, ir->rs1);
+    vm_reg[1] = map_vm_reg(state, ir->rd);
+    if (vm_reg[0] != vm_reg[1]) {
+        emit_mov(state, vm_reg[0], vm_reg[1]);
+    }
+    emit_alu32_imm8(state, 0xc1, 5, vm_reg[1], ir->imm & 0x1f);
+})
+GEN(srai, {
+    vm_reg[0] = ra_load(state, ir->rs1);
+    vm_reg[1] = map_vm_reg(state, ir->rd);
+    if (vm_reg[0] != vm_reg[1]) {
+        emit_mov(state, vm_reg[0], vm_reg[1]);
+    }
+    emit_alu32_imm8(state, 0xc1, 7, vm_reg[1], ir->imm & 0x1f);
+})
+GEN(add, {
+    ra_load2(state, ir->rs1, ir->rs2);
+    vm_reg[2] = map_vm_reg(state, ir->rd);
+    emit_mov(state, vm_reg[1], temp_reg);
+    emit_mov(state, vm_reg[0], vm_reg[2]);
+    emit_alu32(state, 0x01, temp_reg, vm_reg[2]);
+})
+GEN(sub, {
+    ra_load2(state, ir->rs1, ir->rs2);
+    vm_reg[2] = map_vm_reg(state, ir->rd);
+    emit_mov(state, vm_reg[1], temp_reg);
+    emit_mov(state, vm_reg[0], vm_reg[2]);
+    emit_alu32(state, 0x29, temp_reg, vm_reg[2]);
+})
+GEN(sll, {
+    ra_load2(state, ir->rs1, ir->rs2);
+    vm_reg[2] = map_vm_reg(state, ir->rd);
+    emit_mov(state, vm_reg[1], temp_reg);
+    emit_mov(state, vm_reg[0], vm_reg[2]);
+    emit_alu32_imm32(state, 0x81, 4, temp_reg, 0x1f);
+    emit_alu32(state, 0xd3, 4, vm_reg[2]);
+})
+GEN(slt, {
+    ra_load2(state, ir->rs1, ir->rs2);
+    vm_reg[2] = map_vm_reg(state, ir->rd);
+    emit_cmp32(state, vm_reg[1], vm_reg[0]);
+    emit_load_imm(state, vm_reg[2], 1);
+    uint32_t jump_loc = state->offset;
+    emit_jcc_offset(state, 0x8c);
+    emit_load_imm(state, vm_reg[2], 0);
+    emit_jump_target_offset(state, JUMP_LOC, state->offset);
+})
+GEN(sltu, {
+    ra_load2(state, ir->rs1, ir->rs2);
+    vm_reg[2] = map_vm_reg(state, ir->rd);
+    emit_cmp32(state, vm_reg[1], vm_reg[0]);
+    emit_load_imm(state, vm_reg[2], 1);
+    uint32_t jump_loc = state->offset;
+    emit_jcc_offset(state, 0x82);
+    emit_load_imm(state, vm_reg[2], 0);
+    emit_jump_target_offset(state, JUMP_LOC, state->offset);
+})
+GEN(xor, {
+  ra_load2(state, ir->rs1, ir->rs2);
+  vm_reg[2] = map_vm_reg(state, ir->rd);
+  emit_mov(state, vm_reg[1], temp_reg);
+  emit_mov(state, vm_reg[0], vm_reg[2]);
+  emit_alu32(state, 0x31, temp_reg, vm_reg[2]);
+})
+GEN(srl, {
+    ra_load2(state, ir->rs1, ir->rs2);
+    vm_reg[2] = map_vm_reg(state, ir->rd);
+    emit_mov(state, vm_reg[1], temp_reg);
+    emit_mov(state, vm_reg[0], vm_reg[2]);
+    emit_alu32_imm32(state, 0x81, 4, temp_reg, 0x1f);
+    emit_alu32(state, 0xd3, 5, vm_reg[2]);
+})
+GEN(sra, {
+    ra_load2(state, ir->rs1, ir->rs2);
+    vm_reg[2] = map_vm_reg(state, ir->rd);
+    emit_mov(state, vm_reg[1], temp_reg);
+    emit_mov(state, vm_reg[0], vm_reg[2]);
+    emit_alu32_imm32(state, 0x81, 4, temp_reg, 0x1f);
+    emit_alu32(state, 0xd3, 7, vm_reg[2]);
+})
+GEN(or, {
+    ra_load2(state, ir->rs1, ir->rs2);
+    vm_reg[2] = map_vm_reg(state, ir->rd);
+    emit_mov(state, vm_reg[1], temp_reg);
+    emit_mov(state, vm_reg[0], vm_reg[2]);
+    emit_alu32(state, 0x09, temp_reg, vm_reg[2]);
+})
+GEN(and, {
+    ra_load2(state, ir->rs1, ir->rs2);
+    vm_reg[2] = map_vm_reg(state, ir->rd);
+    emit_mov(state, vm_reg[1], temp_reg);
+    emit_mov(state, vm_reg[0], vm_reg[2]);
+    emit_alu32(state, 0x21, temp_reg, vm_reg[2]);
+})
+GEN(fence, { assert(NULL); })
+GEN(ecall, {
+    store_back(state);
+    emit_load_imm(state, temp_reg, ir->pc);
+    emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
+    emit_call(state, (intptr_t) rv->io.on_ecall);
+    emit_exit(state);
+})
+GEN(ebreak, {
+    store_back(state);
+    emit_load_imm(state, temp_reg, ir->pc);
+    emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
+    emit_call(state, (intptr_t) rv->io.on_ebreak);
+    emit_exit(state);
+})
+GEN(wfi, { assert(NULL); })
+GEN(uret, { assert(NULL); })
+GEN(sret, { assert(NULL); })
+GEN(hret, { assert(NULL); })
+GEN(mret, { assert(NULL); })
+GEN(sfencevma, { assert(NULL); })
+GEN(fencei, { assert(NULL); })
+GEN(csrrw, { assert(NULL); })
+GEN(csrrs, { assert(NULL); })
+GEN(csrrc, { assert(NULL); })
+GEN(csrrwi, { assert(NULL); })
+GEN(csrrsi, { assert(NULL); })
+GEN(csrrci, { assert(NULL); })
+GEN(mul, {
+    ra_load2(state, ir->rs1, ir->rs2);
+    vm_reg[2] = map_vm_reg(state, ir->rd);
+    emit_mov(state, vm_reg[1], temp_reg);
+    emit_mov(state, vm_reg[0], vm_reg[2]);
+    muldivmod(state, 0x28, temp_reg, vm_reg[2], 0);
+})
+GEN(mulh, {
+    ra_load2_sext(state, ir->rs1, ir->rs2, true, true);
+    vm_reg[2] = map_vm_reg(state, ir->rd);
+    emit_mov(state, vm_reg[1], temp_reg);
+    emit_mov(state, vm_reg[0], vm_reg[2]);
+    muldivmod(state, 0x2f, temp_reg, vm_reg[2], 0);
+    emit_alu64_imm8(state, 0xc1, 5, vm_reg[2], 32);
+})
+GEN(mulhsu, {
+    ra_load2_sext(state, ir->rs1, ir->rs2, true, false);
+    vm_reg[2] = map_vm_reg(state, ir->rd);
+    emit_mov(state, vm_reg[1], temp_reg);
+    emit_mov(state, vm_reg[0], vm_reg[2]);
+    muldivmod(state, 0x2f, temp_reg, vm_reg[2], 0);
+    emit_alu64_imm8(state, 0xc1, 5, vm_reg[2], 32);
+})
+GEN(mulhu, {
+    ra_load2(state, ir->rs1, ir->rs2);
+    vm_reg[2] = map_vm_reg(state, ir->rd);
+    emit_mov(state, vm_reg[1], temp_reg);
+    emit_mov(state, vm_reg[0], vm_reg[2]);
+    muldivmod(state, 0x2f, temp_reg, vm_reg[2], 0);
+    emit_alu64_imm8(state, 0xc1, 5, vm_reg[2], 32);
+})
+GEN(div, {
+    ra_load2_sext(state, ir->rs1, ir->rs2, true, true);
+    vm_reg[2] = map_vm_reg(state, ir->rd);
+    emit_mov(state, vm_reg[1], temp_reg);
+    emit_mov(state, vm_reg[0], vm_reg[2]);
+    muldivmod(state, 0x38, temp_reg, vm_reg[2], 1);
+})
+GEN(divu, {
+    ra_load2(state, ir->rs1, ir->rs2);
+    vm_reg[2] = map_vm_reg(state, ir->rd);
+    emit_mov(state, vm_reg[1], temp_reg);
+    emit_mov(state, vm_reg[0], vm_reg[2]);
+    muldivmod(state, 0x38, temp_reg, vm_reg[2], 0);
+})
+GEN(rem, {
+    ra_load2_sext(state, ir->rs1, ir->rs2, true, true);
+    vm_reg[2] = map_vm_reg(state, ir->rd);
+    emit_mov(state, vm_reg[1], temp_reg);
+    emit_mov(state, vm_reg[0], vm_reg[2]);
+    muldivmod(state, 0x98, temp_reg, vm_reg[2], 1);
+})
+GEN(remu, {
+    ra_load2(state, ir->rs1, ir->rs2);
+    vm_reg[2] = map_vm_reg(state, ir->rd);
+    emit_mov(state, vm_reg[1], temp_reg);
+    emit_mov(state, vm_reg[0], vm_reg[2]);
+    muldivmod(state, 0x98, temp_reg, vm_reg[2], 0);
+})
+GEN(lrw, { assert(NULL); })
+GEN(scw, { assert(NULL); })
+GEN(amoswapw, { assert(NULL); })
+GEN(amoaddw, { assert(NULL); })
+GEN(amoxorw, { assert(NULL); })
+GEN(amoandw, { assert(NULL); })
+GEN(amoorw, { assert(NULL); })
+GEN(amominw, { assert(NULL); })
+GEN(amomaxw, { assert(NULL); })
+GEN(amominuw, { assert(NULL); })
+GEN(amomaxuw, { assert(NULL); })
+GEN(flw, { assert(NULL); })
+GEN(fsw, { assert(NULL); })
+GEN(fmadds, { assert(NULL); })
+GEN(fmsubs, { assert(NULL); })
+GEN(fnmsubs, { assert(NULL); })
+GEN(fnmadds, { assert(NULL); })
+GEN(fadds, { assert(NULL); })
+GEN(fsubs, { assert(NULL); })
+GEN(fmuls, { assert(NULL); })
+GEN(fdivs, { assert(NULL); })
+GEN(fsqrts, { assert(NULL); })
+GEN(fsgnjs, { assert(NULL); })
+GEN(fsgnjns, { assert(NULL); })
+GEN(fsgnjxs, { assert(NULL); })
+GEN(fmins, { assert(NULL); })
+GEN(fmaxs, { assert(NULL); })
+GEN(fcvtws, { assert(NULL); })
+GEN(fcvtwus, { assert(NULL); })
+GEN(fmvxw, { assert(NULL); })
+GEN(feqs, { assert(NULL); })
+GEN(flts, { assert(NULL); })
+GEN(fles, { assert(NULL); })
+GEN(fclasss, { assert(NULL); })
+GEN(fcvtsw, { assert(NULL); })
+GEN(fcvtswu, { assert(NULL); })
+GEN(fmvwx, { assert(NULL); })
+GEN(caddi4spn, {
+    vm_reg[0] = ra_load(state, rv_reg_sp);
+    vm_reg[1] = map_vm_reg(state, ir->rd);
+    if (vm_reg[0] != vm_reg[1]) {
+        emit_mov(state, vm_reg[0], vm_reg[1]);
+    }
+    emit_alu32_imm32(state, 0x81, 0, vm_reg[1], (uint16_t) ir->imm);
+})
+GEN(clw, {
+    memory_t *m = PRIV(rv)->mem;
+    vm_reg[0] = ra_load(state, ir->rs1);
+    emit_load_imm_sext(state, temp_reg, (intptr_t) (m->mem_base + ir->imm));
+    emit_alu64(state, 0x01, vm_reg[0], temp_reg);
+    vm_reg[1] = map_vm_reg(state, ir->rd);
+    emit_load(state, S32, temp_reg, vm_reg[1], 0);
+})
+GEN(csw, {
+    memory_t *m = PRIV(rv)->mem;
+    vm_reg[0] = ra_load(state, ir->rs1);
+    emit_load_imm_sext(state, temp_reg, (intptr_t) (m->mem_base + ir->imm));
+    emit_alu64(state, 0x01, vm_reg[0], temp_reg);
+    vm_reg[1] = ra_load(state, ir->rs2);
+    emit_store(state, S32, vm_reg[1], temp_reg, 0);
+})
+GEN(cnop, {})
+GEN(caddi, {
+    vm_reg[0] = ra_load(state, ir->rd);
+    emit_alu32_imm32(state, 0x81, 0, vm_reg[0], (int16_t) ir->imm);
+})
+GEN(cjal, {
+    vm_reg[0] = map_vm_reg(state, rv_reg_ra);
+    emit_load_imm(state, vm_reg[0], ir->pc + 2);
+    store_back(state);
+    emit_jmp(state, ir->pc + ir->imm);
+    emit_load_imm(state, temp_reg, ir->pc + ir->imm);
+    emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
+    emit_exit(state);
+})
+GEN(cli, {
+    vm_reg[0] = map_vm_reg(state, ir->rd);
+    emit_load_imm(state, vm_reg[0], ir->imm);
+})
+GEN(caddi16sp, {
+    vm_reg[0] = ra_load(state, ir->rd);
+    emit_alu32_imm32(state, 0x81, 0, vm_reg[0], ir->imm);
+})
+GEN(clui, {
+    vm_reg[0] = map_vm_reg(state, ir->rd);
+    emit_load_imm(state, vm_reg[0], ir->imm);
+})
+GEN(csrli, {
+    vm_reg[0] = ra_load(state, ir->rs1);
+    emit_alu32_imm8(state, 0xc1, 5, vm_reg[0], ir->shamt);
+})
+GEN(csrai, {
+    vm_reg[0] = ra_load(state, ir->rs1);
+    emit_alu32_imm8(state, 0xc1, 7, vm_reg[0], ir->shamt);
+})
+GEN(candi, {
+    vm_reg[0] = ra_load(state, ir->rs1);
+    emit_alu32_imm32(state, 0x81, 4, vm_reg[0], ir->imm);
+})
+GEN(csub, {
+    ra_load2(state, ir->rs1, ir->rs2);
+    vm_reg[2] = map_vm_reg(state, ir->rd);
+    emit_mov(state, vm_reg[1], temp_reg);
+    emit_mov(state, vm_reg[0], vm_reg[2]);
+    emit_alu32(state, 0x29, temp_reg, vm_reg[2]);
+})
+GEN(cxor, {
+    ra_load2(state, ir->rs1, ir->rs2);
+    vm_reg[2] = map_vm_reg(state, ir->rd);
+    emit_mov(state, vm_reg[1], temp_reg);
+    emit_mov(state, vm_reg[0], vm_reg[2]);
+    emit_alu32(state, 0x31, temp_reg, vm_reg[2]);
+})
+GEN(cor, {
+    ra_load2(state, ir->rs1, ir->rs2);
+    vm_reg[2] = map_vm_reg(state, ir->rd);
+    emit_mov(state, vm_reg[1], temp_reg);
+    emit_mov(state, vm_reg[0], vm_reg[2]);
+    emit_alu32(state, 0x09, temp_reg, vm_reg[2]);
+})
+GEN(cand, {
+    ra_load2(state, ir->rs1, ir->rs2);
+    vm_reg[2] = map_vm_reg(state, ir->rd);
+    emit_mov(state, vm_reg[1], temp_reg);
+    emit_mov(state, vm_reg[0], vm_reg[2]);
+    emit_alu32(state, 0x21, temp_reg, vm_reg[2]);
+})
+GEN(cj, {
+    store_back(state);
+    emit_jmp(state, ir->pc + ir->imm);
+    emit_load_imm(state, temp_reg, ir->pc + ir->imm);
+    emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
+    emit_exit(state);
+})
+GEN(cbeqz, {
+    vm_reg[0] = ra_load(state, ir->rs1);
+    emit_cmp_imm32(state, vm_reg[0], 0);
+    store_back(state);
+    uint32_t jump_loc = state->offset;
+    emit_jcc_offset(state, 0x84);
+    if (ir->branch_untaken) {
+        emit_jmp(state, ir->pc + 2);
+    }
+    emit_load_imm(state, temp_reg, ir->pc + 2);
+    emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
+    emit_exit(state);
+    emit_jump_target_offset(state, JUMP_LOC, state->offset);
+    if (ir->branch_taken) {
+        emit_jmp(state, ir->pc + ir->imm);
+    }
+    emit_load_imm(state, temp_reg, ir->pc + ir->imm);
+    emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
+    emit_exit(state);
+})
+GEN(cbnez, {
+    vm_reg[0] = ra_load(state, ir->rs1);
+    emit_cmp_imm32(state, vm_reg[0], 0);
+    store_back(state);
+    uint32_t jump_loc = state->offset;
+    emit_jcc_offset(state, 0x85);
+    if (ir->branch_untaken) {
+        emit_jmp(state, ir->pc + 2);
+    }
+    emit_load_imm(state, temp_reg, ir->pc + 2);
+    emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
+    emit_exit(state);
+    emit_jump_target_offset(state, JUMP_LOC, state->offset);
+    if (ir->branch_taken) {
+        emit_jmp(state, ir->pc + ir->imm);
+    }
+    emit_load_imm(state, temp_reg, ir->pc + ir->imm);
+    emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
+    emit_exit(state);
+})
+GEN(cslli, {
+    vm_reg[0] = ra_load(state, ir->rd);
+    emit_alu32_imm8(state, 0xc1, 4, vm_reg[0], (uint8_t) ir->imm);
+})
+GEN(clwsp, {
+    memory_t *m = PRIV(rv)->mem;
+    vm_reg[0] = ra_load(state, rv_reg_sp);
+    emit_load_imm_sext(state, temp_reg, (intptr_t) (m->mem_base + ir->imm));
+    emit_alu64(state, 0x01, vm_reg[0], temp_reg);
+    vm_reg[1] = map_vm_reg(state, ir->rd);
+    emit_load(state, S32, temp_reg, vm_reg[1], 0);
+})
+GEN(cjr, {
+    vm_reg[0] = ra_load(state, ir->rs1);
+    emit_mov(state, vm_reg[0], temp_reg);
+    store_back(state);
+    parse_branch_history_table(state, ir);
+    emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
+    emit_exit(state);
+})
+GEN(cmv, {
+    vm_reg[0] = ra_load(state, ir->rs2);
+    vm_reg[1] = map_vm_reg(state, ir->rd);
+    if (vm_reg[0] != vm_reg[1]) {
+        emit_mov(state, vm_reg[0], vm_reg[1]);
+    } else {
+        set_dirty(vm_reg[1], true);
+    }
+})
+GEN(cebreak, {
+    store_back(state);
+    emit_load_imm(state, temp_reg, ir->pc);
+    emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
+    emit_call(state, (intptr_t) rv->io.on_ebreak);
+    emit_exit(state);
+})
+GEN(cjalr, {
+    vm_reg[0] = ra_load(state, ir->rs1);
+    emit_mov(state, vm_reg[0], temp_reg);
+    vm_reg[1] = map_vm_reg(state, rv_reg_ra);
+    emit_load_imm(state, vm_reg[1], ir->pc + 2);
+    store_back(state);
+    parse_branch_history_table(state, ir);
+    emit_store(state, S32, temp_reg, parameter_reg[0], offsetof(riscv_t, PC));
+    emit_exit(state);
+})
+GEN(cadd, {
+    ra_load2(state, ir->rs1, ir->rs2);
+    vm_reg[2] = map_vm_reg(state, ir->rd);
+    emit_mov(state, vm_reg[1], temp_reg);
+    emit_mov(state, vm_reg[0], vm_reg[2]);
+    emit_alu32(state, 0x01, temp_reg, vm_reg[2]);
+})
+GEN(cswsp, {
+    memory_t *m = PRIV(rv)->mem;
+    vm_reg[0] = ra_load(state, rv_reg_sp);
+    emit_load_imm_sext(state, temp_reg, (intptr_t) (m->mem_base + ir->imm));
+    emit_alu64(state, 0x01, vm_reg[0], temp_reg);
+    vm_reg[1] = ra_load(state, ir->rs2);
+    emit_store(state, S32, vm_reg[1], temp_reg, 0);
+})
+GEN(cflwsp, { assert(NULL); })
+GEN(cfswsp, { assert(NULL); })
+GEN(cflw, { assert(NULL); })
+GEN(cfsw, { assert(NULL); })
+GEN(sh1add, { assert(NULL); })
+GEN(sh2add, { assert(NULL); })
+GEN(sh3add, { assert(NULL); })
+GEN(andn, { assert(NULL); })
+GEN(orn, { assert(NULL); })
+GEN(xnor, { assert(NULL); })
+GEN(clz, { assert(NULL); })
+GEN(ctz, { assert(NULL); })
+GEN(cpop, { assert(NULL); })
+GEN(max, { assert(NULL); })
+GEN(min, { assert(NULL); })
+GEN(maxu, { assert(NULL); })
+GEN(minu, { assert(NULL); })
+GEN(sextb, { assert(NULL); })
+GEN(sexth, { assert(NULL); })
+GEN(zexth, { assert(NULL); })
+GEN(rol, { assert(NULL); })
+GEN(ror, { assert(NULL); })
+GEN(rori, { assert(NULL); })
+GEN(orcb, { assert(NULL); })
+GEN(rev8, { assert(NULL); })
+GEN(clmul, { assert(NULL); })
+GEN(clmulh, { assert(NULL); })
+GEN(clmulr, { assert(NULL); })
+GEN(bclr, { assert(NULL); })
+GEN(bclri, { assert(NULL); })
+GEN(bext, { assert(NULL); })
+GEN(bexti, { assert(NULL); })
+GEN(binv, { assert(NULL); })
+GEN(binvi, { assert(NULL); })
+GEN(bset, { assert(NULL); })
+GEN(bseti, { assert(NULL); })

--- a/src/system.h
+++ b/src/system.h
@@ -1,0 +1,175 @@
+/*
+ * rv32emu is freely redistributable under the MIT License. See the file
+ * "LICENSE" for information on usage and redistribution of this file.
+ */
+
+#pragma once
+
+#if !RV32_HAS(SYSTEM)
+#error "Do not manage to build this file unless you enable system support."
+#endif
+
+#include "devices/plic.h"
+#include "devices/uart.h"
+#include "riscv_private.h"
+
+#define R 1
+#define W 0
+
+#if !RV32_HAS(ELF_LOADER)
+
+#define MMIO_R 1
+#define MMIO_W 0
+
+enum SUPPORTED_MMIO {
+    MMIO_PLIC,
+    MMIO_UART,
+    MMIO_VIRTIOBLK,
+};
+
+/* clang-format off */
+#define MMIO_OP(io, rw)                                                          \
+    switch(io){                                                                  \
+        case MMIO_PLIC:                                                          \
+            IIF(rw)( /* read */                                                  \
+                mmio_read_val = plic_read(PRIV(rv)->plic, addr & 0x3FFFFFF);     \
+                plic_update_interrupts(PRIV(rv)->plic);                          \
+                return mmio_read_val;                                            \
+                ,    /* write */                                                 \
+                plic_write(PRIV(rv)->plic, addr & 0x3FFFFFF, val);               \
+                plic_update_interrupts(PRIV(rv)->plic);                          \
+                return;                                                          \
+            )                                                                    \
+            break;                                                               \
+        case MMIO_UART:                                                          \
+            IIF(rw)( /* read */                                                  \
+                mmio_read_val = u8250_read(PRIV(rv)->uart, addr & 0xFFFFF);      \
+                emu_update_uart_interrupts(rv);                                  \
+                return mmio_read_val;                                            \
+                ,    /* write */                                                 \
+                u8250_write(PRIV(rv)->uart, addr & 0xFFFFF, val);                \
+                emu_update_uart_interrupts(rv);                                  \
+                return;                                                          \
+            )                                                                    \
+            break;                                                               \
+        case MMIO_VIRTIOBLK:                                                     \
+            IIF(rw)( /* read */                                                  \
+                mmio_read_val = virtio_blk_read(PRIV(rv)->vblk, addr & 0xFFFFF); \
+                emu_update_vblk_interrupts(rv);                                  \
+                return mmio_read_val;                                            \
+                ,    /* write */                                                 \
+                virtio_blk_write(PRIV(rv)->vblk, addr & 0xFFFFF, val);           \
+                emu_update_vblk_interrupts(rv);                                  \
+                return;                                                          \
+            )                                                                    \
+            break;                                                               \
+        default:                                                                 \
+            rv_log_error("unknown MMIO type %d\n", io);                          \
+            break;                                                               \
+    }
+/* clang-format on */
+
+#define MMIO_READ()                                         \
+    do {                                                    \
+        uint32_t mmio_read_val;                             \
+        if ((addr >> 28) == 0xF) { /* MMIO at 0xF_______ */ \
+            /* 256 regions of 1MiB */                       \
+            switch ((addr >> 20) & MASK(8)) {               \
+            case 0x0:                                       \
+            case 0x2: /* PLIC (0 - 0x3F) */                 \
+                MMIO_OP(MMIO_PLIC, MMIO_R);                 \
+                break;                                      \
+            case 0x40: /* UART */                           \
+                MMIO_OP(MMIO_UART, MMIO_R);                 \
+                break;                                      \
+            case 0x42: /* Virtio-blk */                     \
+                MMIO_OP(MMIO_VIRTIOBLK, MMIO_R);            \
+                break;                                      \
+            default:                                        \
+                __UNREACHABLE;                              \
+                break;                                      \
+            }                                               \
+        }                                                   \
+    } while (0)
+
+#define MMIO_WRITE()                                        \
+    do {                                                    \
+        if ((addr >> 28) == 0xF) { /* MMIO at 0xF_______ */ \
+            /* 256 regions of 1MiB */                       \
+            switch ((addr >> 20) & MASK(8)) {               \
+            case 0x0:                                       \
+            case 0x2: /* PLIC (0 - 0x3F) */                 \
+                MMIO_OP(MMIO_PLIC, MMIO_W);                 \
+                break;                                      \
+            case 0x40: /* UART */                           \
+                MMIO_OP(MMIO_UART, MMIO_W);                 \
+                break;                                      \
+            case 0x42: /* Virtio-blk */                     \
+                MMIO_OP(MMIO_VIRTIOBLK, MMIO_W);            \
+                break;                                      \
+            default:                                        \
+                __UNREACHABLE;                              \
+                break;                                      \
+            }                                               \
+        }                                                   \
+    } while (0)
+
+void emu_update_uart_interrupts(riscv_t *rv);
+void emu_update_vblk_interrupts(riscv_t *rv);
+
+/*
+ * Linux kernel might create signal frame when returning from trap
+ * handling, which modifies the SEPC CSR. Thus, the fault instruction
+ * cannot always redo. For example, invalid memory access causes SIGSEGV.
+ */
+extern bool need_handle_signal;
+
+#define CHECK_PENDING_SIGNAL(rv, signal_flag)              \
+    do {                                                   \
+        signal_flag = (rv->csr_sepc != rv->last_csr_sepc); \
+    } while (0)
+
+#endif
+
+/* Walk through page tables and get the corresponding PTE by virtual address if
+ * exists
+ * @rv: RISC-V emulator
+ * @addr: virtual address
+ * @level: the level of which the PTE is located
+ * @return: NULL if a not found or fault else the corresponding PTE
+ */
+uint32_t *mmu_walk(riscv_t *rv, const uint32_t addr, uint32_t *level);
+
+/* Verify the PTE and generate corresponding faults if needed
+ * @op: the operation
+ * @rv: RISC-V emulator
+ * @pte: to be verified pte
+ * @addr: the corresponding virtual address to cause fault
+ * @return: false if a any fault is generated which caused by violating the
+ * access permission else true
+ */
+/* FIXME: handle access fault, addr out of range check */
+#define MMU_FAULT_CHECK_DECL(op)                                            \
+    bool mmu_##op##_fault_check(riscv_t *rv, uint32_t *pte, uint32_t vaddr, \
+                                uint32_t access_bits);
+
+MMU_FAULT_CHECK_DECL(ifetch);
+MMU_FAULT_CHECK_DECL(read);
+MMU_FAULT_CHECK_DECL(write);
+
+/*
+ * TODO: dTLB can be introduced here to
+ * cache the gVA to gPA tranlation.
+ */
+uint32_t mmu_translate(riscv_t *rv, uint32_t vaddr, bool rw);
+
+uint32_t *mmu_walk(riscv_t *rv, const uint32_t addr, uint32_t *level);
+
+#define get_ppn_and_offset()                                   \
+    uint32_t ppn;                                              \
+    uint32_t offset;                                           \
+    do {                                                       \
+        ppn = *pte >> (RV_PG_SHIFT - 2) << RV_PG_SHIFT;        \
+        offset = level == 1 ? vaddr & MASK((RV_PG_SHIFT + 10)) \
+                            : vaddr & MASK(RV_PG_SHIFT);       \
+    } while (0)

--- a/src/utils.c
+++ b/src/utils.c
@@ -3,6 +3,7 @@
  * "LICENSE" for information on usage and redistribution of this file.
  */
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -186,15 +187,18 @@ void set_reset(set_t *set)
  * @set: a pointer points to target set
  * @key: the key of the inserted entry
  */
-bool set_add(set_t *set, uint32_t key)
+bool set_add(set_t *set, rv_hash_key_t key)
 {
-    const uint32_t index = set_hash(key);
+    const rv_hash_key_t index = set_hash(key);
+
     uint8_t count = 0;
-    while (set->table[index][count]) {
-        if (set->table[index][count++] == key)
+    for (; set->table[index][count]; count++) {
+        assert(count < SET_SLOTS_SIZE);
+        if (set->table[index][count] == key)
             return false;
     }
 
+    assert(count < SET_SLOTS_SIZE);
     set->table[index][count] = key;
     return true;
 }
@@ -204,10 +208,12 @@ bool set_add(set_t *set, uint32_t key)
  * @set: a pointer points to target set
  * @key: the key of the inserted entry
  */
-bool set_has(set_t *set, uint32_t key)
+bool set_has(set_t *set, rv_hash_key_t key)
 {
-    const uint32_t index = set_hash(key);
+    const rv_hash_key_t index = set_hash(key);
+
     for (uint8_t count = 0; set->table[index][count]; count++) {
+        assert(count < SET_SLOTS_SIZE);
         if (set->table[index][count] == key)
             return true;
     }


### PR DESCRIPTION
This patch makes `rv32emu` support the just-in-time (JIT) compilation in system simulation. To achieve this goal, a "satp (supervisor address translation and protection)" field has been introduced to the block structure in JIT mode to ensure the block cache is replaced correctly.

The file `src/system.c` has been updated for the easier reuse of functions, and the MOP fusion and T2C are disabled temporarily. To boot the Linux Kernel, try the following commands:

```shell
$ make ENABLE_SYSTEM=1 ENABLE_MOP_FUSION=0 ENABLE_JIT=1 ENABLE_T2C=0
$ ./build/rv32emu -k <image> -i <rootfs> -b <dtb>
``` 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR implements JIT compilation support for RISC-V system emulation by adding SATP tracking and MMU-aware instruction handling. The changes include refactoring MMIO operations into separate helper functions, implementing comprehensive instruction handlers with proper memory access handling, and enhancing the block caching system with improved error handling for Linux kernel boot compatibility.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 5
</div>