### PR TITLE
Fix LTO warning by enabling parallel compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ CFLAGS += -flto
 endif
 endif
 ifeq ("$(CC_IS_GCC)", "1")
-CFLAGS += -flto
+CFLAGS += -flto=auto
 endif
 ifeq ("$(CC_IS_CLANG)", "1")
 CFLAGS += -flto=thin -fsplit-lto-unit


### PR DESCRIPTION
When using `make`, the following warning occurs:
lto-wrapper: warning: using serial compilation of 2 LTRANS jobs.

To resolve this and enable parallel compilation, -flto=auto is now used. 

According to the [GCC documentation](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html):
Use `-flto=auto` to use GNU make’s job server, if available, or otherwise fall back to autodetection of the number of CPU threads present in your system.