### PR TITLE
Use instruction-based emulation for debug mode

### DIFF
--- a/src/gdbstub.c
+++ b/src/gdbstub.c
@@ -80,14 +80,12 @@ static gdb_action_t rv_cont(void *args)
 {
     riscv_t *rv = (riscv_t *) args;
     assert(rv);
-    vm_attr_t *attr = PRIV(rv);
-    attr->cycle_per_step = 1;
 
     for (; !rv_has_halted(rv) && !rv_is_interrupt(rv);) {
         if (breakpoint_map_find(rv->breakpoint_map, rv_get_pc(rv)))
             break;
 
-        rv_step(rv);
+        rv_step_debug(rv);
     }
 
     /* Clear the interrupt if it's pending */
@@ -100,10 +98,8 @@ static gdb_action_t rv_stepi(void *args)
 {
     riscv_t *rv = (riscv_t *) args;
     assert(rv);
-    vm_attr_t *attr = PRIV(rv);
-    attr->cycle_per_step = 1;
 
-    rv_step(rv);
+    rv_step_debug(rv);
     return ACT_RESUME;
 }
 

--- a/src/riscv.h
+++ b/src/riscv.h
@@ -454,6 +454,9 @@ void rv_debug(riscv_t *rv);
 /* step the RISC-V emulator */
 void rv_step(void *arg);
 
+/* step the RISC-V emulator for debug mode */
+void rv_step_debug(void *arg);
+
 /* set the program counter of a RISC-V emulator */
 bool rv_set_pc(riscv_t *rv, riscv_word_t pc);
 

--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -224,52 +224,60 @@ RVOP(
      * In addition, before relocate_enable_mmu, the block maybe retranslated,  \
      * thus the branch history lookup table should not be updated too.         \
      */                                                                        \
-    IIF(RV32_HAS(SYSTEM)(if (!rv->is_trapped && !reloc_enable_mmu), ))         \
+    IIF(RV32_HAS(GDBSTUB)(if (!rv->debug_mode), ))                             \
     {                                                                          \
-        for (int i = 0; i < HISTORY_SIZE; i++) {                               \
-            if (ir->branch_table->PC[i] == PC) {                               \
-                MUST_TAIL return ir->branch_table->target[i]->impl(            \
-                    rv, ir->branch_table->target[i], cycle, PC);               \
+        IIF(RV32_HAS(SYSTEM)(if (!rv->is_trapped && !reloc_enable_mmu), ))     \
+        {                                                                      \
+            for (int i = 0; i < HISTORY_SIZE; i++) {                           \
+                if (ir->branch_table->PC[i] == PC) {                           \
+                    MUST_TAIL return ir->branch_table->target[i]->impl(        \
+                        rv, ir->branch_table->target[i], cycle, PC);           \
+                }                                                              \
             }                                                                  \
-        }                                                                      \
-        block_t *block = block_find(&rv->block_map, PC);                       \
-        if (block) {                                                           \
-            /* update branch history table */                                  \
-            ir->branch_table->PC[ir->branch_table->idx] = PC;                  \
-            ir->branch_table->target[ir->branch_table->idx] = block->ir_head;  \
-            ir->branch_table->idx =                                            \
-                (ir->branch_table->idx + 1) % HISTORY_SIZE;                    \
-            MUST_TAIL return block->ir_head->impl(rv, block->ir_head, cycle,   \
-                                                  PC);                         \
+            block_t *block = block_find(&rv->block_map, PC);                   \
+            if (block) {                                                       \
+                /* update branch history table */                              \
+                ir->branch_table->PC[ir->branch_table->idx] = PC;              \
+                ir->branch_table->target[ir->branch_table->idx] =              \
+                    block->ir_head;                                            \
+                ir->branch_table->idx =                                        \
+                    (ir->branch_table->idx + 1) % HISTORY_SIZE;                \
+                MUST_TAIL return block->ir_head->impl(rv, block->ir_head,      \
+                                                      cycle, PC);              \
+            }                                                                  \
         }                                                                      \
     }
 #else
-#define LOOKUP_OR_UPDATE_BRANCH_HISTORY_TABLE()                               \
-    block_t *block = cache_get(rv->block_cache, PC, true);                    \
-    if (block) {                                                              \
-        for (int i = 0; i < HISTORY_SIZE; i++) {                              \
-            if (ir->branch_table->PC[i] == PC) {                              \
-                ir->branch_table->times[i]++;                                 \
-                if (cache_hot(rv->block_cache, PC))                           \
-                    goto end_op;                                              \
-            }                                                                 \
-        }                                                                     \
-        /* update branch history table */                                     \
-        int min_idx = 0;                                                      \
-        for (int i = 0; i < HISTORY_SIZE; i++) {                              \
-            if (!ir->branch_table->times[i]) {                                \
-                min_idx = i;                                                  \
-                break;                                                        \
-            } else if (ir->branch_table->times[min_idx] >                     \
-                       ir->branch_table->times[i]) {                          \
-                min_idx = i;                                                  \
-            }                                                                 \
-        }                                                                     \
-        ir->branch_table->times[min_idx] = 1;                                 \
-        ir->branch_table->PC[min_idx] = PC;                                   \
-        if (cache_hot(rv->block_cache, PC))                                   \
-            goto end_op;                                                      \
-        MUST_TAIL return block->ir_head->impl(rv, block->ir_head, cycle, PC); \
+#define LOOKUP_OR_UPDATE_BRANCH_HISTORY_TABLE()                                \
+    IIF(RV32_HAS(GDBSTUB)(if (!rv->debug_mode), ))                             \
+    {                                                                          \
+        block_t *block = cache_get(rv->block_cache, PC, true);                 \
+        if (block) {                                                           \
+            for (int i = 0; i < HISTORY_SIZE; i++) {                           \
+                if (ir->branch_table->PC[i] == PC) {                           \
+                    ir->branch_table->times[i]++;                              \
+                    if (cache_hot(rv->block_cache, PC))                        \
+                        goto end_op;                                           \
+                }                                                              \
+            }                                                                  \
+            /* update branch history table */                                  \
+            int min_idx = 0;                                                   \
+            for (int i = 0; i < HISTORY_SIZE; i++) {                           \
+                if (!ir->branch_table->times[i]) {                             \
+                    min_idx = i;                                               \
+                    break;                                                     \
+                } else if (ir->branch_table->times[min_idx] >                  \
+                           ir->branch_table->times[i]) {                       \
+                    min_idx = i;                                               \
+                }                                                              \
+            }                                                                  \
+            ir->branch_table->times[min_idx] = ir->branch_table->PC[min_idx] = \
+                PC;                                                            \
+            if (cache_hot(rv->block_cache, PC))                                \
+                goto end_op;                                                   \
+            MUST_TAIL return block->ir_head->impl(rv, block->ir_head, cycle,   \
+                                                  PC);                         \
+        }                                                                      \
     }
 #endif
 


### PR DESCRIPTION
In debug mode(gdbstub), we'll need one instruction/cycle per step for trace. For such usecase, using the block-based emulation will be too expensive which slow down the execution. Switch to instruction-based emulation for debug mode.