### PR TITLE
Avoid to wrongly allocate memory in map_file()

### DIFF
--- a/src/riscv.c
+++ b/src/riscv.c
@@ -239,10 +239,6 @@ static void map_file(char **ram_loc, const char *name)
     if (*ram_loc == MAP_FAILED)
         goto cleanup;
 #else
-    /* calloc and load data to a memory region */
-    *ram_loc = calloc(st.st_size, sizeof(uint8_t));
-    if (!*ram_loc)
-        goto cleanup;
     if (read(fd, *ram_loc, st.st_size) != st.st_size) {
         free(*ram_loc);
         goto cleanup;


### PR DESCRIPTION
In the case that `HAVE_MMAP` is 0, the emulator crashes.

```
$ make ENABLE_SYSTEM=1 system
rv32emu: src/emulate.c:626: block_translate: Assertion `insn' failed.
Aborted
```

The `map_file()` logic when `HAVE_MMAP == 0` is weird as it allocates extra resources on the emulated memory. After this change, the aborting issue is gone, so I believe the original is not the correct implementation.