### PR TITLE
Fix declaration error when using clang

### DIFF
--- a/src/emulate.c
+++ b/src/emulate.c
@@ -1122,11 +1122,12 @@ void rv_step_debug(void *arg)
     rv_check_interrupt(rv);
 #endif
 
-retranslate:
-    /* fetch the next instruction */
     rv_insn_t ir;
+
+retranslate:
     memset(&ir, 0, sizeof(rv_insn_t));
 
+    /* fetch the next instruction */
     uint32_t insn = rv->io.mem_ifetch(rv, rv->PC);
 #if RV32_HAS(SYSTEM)
     if (!insn && need_retranslate) {


### PR DESCRIPTION
When compile the rv32emu using clang, the error log shows the following:
```
src/emulate.c:1127:5: error: expected expression
    rv_insn_t ir;
```

According to [1], syntax of labeled-statement stated in the following:

labeled-statement:
    identifier : statement
    case constant-expression : statement
    default : statement

Obviously, only the statement is valid after labeled-statement. When refering to [2], the following are the valid statements, excluding the declaration.

statement:
    labeled-statement
    compound-statement
    expression-statement
    selection-statement
    iteration-statement
    jump-statement

Thus, move the declaration of ir before the labeled-statement eliminates the clang compile error.

[1] C99 6.8.1 Labeled statements
[2] C99 6.8 Statement and blocks