### PR TITLE
Unify MMU translation APIs

### DIFF
--- a/src/riscv.h
+++ b/src/riscv.h
@@ -404,6 +404,20 @@ typedef void (*riscv_mem_write_s)(riscv_t *rv,
 typedef void (*riscv_mem_write_b)(riscv_t *rv,
                                   riscv_word_t addr,
                                   riscv_byte_t data);
+#if RV32_HAS(SYSTEM)
+/*
+ * VA2PA handler
+ * The MMU walkers and fault checkers are defined in system.c
+ * Thus, exporting this handler through function pointer
+ * preserves the encapsulation of MMU translation.
+ *
+ * ifetch do not leverage this translation because basic block
+ * might be retranslated and the corresponding PTE is NULL.
+ */
+typedef riscv_word_t (*riscv_mem_translate_t)(riscv_t *rv,
+                                              riscv_word_t vaddr,
+                                              bool rw);
+#endif
 
 /* system instruction handlers */
 typedef void (*riscv_on_ecall)(riscv_t *rv);
@@ -424,7 +438,9 @@ typedef struct {
     riscv_mem_write_s mem_write_s;
     riscv_mem_write_b mem_write_b;
 
-    /* TODO: add peripheral I/O interfaces */
+#if RV32_HAS(SYSTEM)
+    riscv_mem_translate_t mem_translate;
+#endif
 
     /* system */
     riscv_on_ecall on_ecall;


### PR DESCRIPTION
To enable guest OS to run SDL applications using bidirectional queues, the VMM or system emulator must access the guest OS's virtual memory, as the queues are defined there. This requires MMU translation. In addition, the queues event data size likely larger than a word (maybe a page), thus the existing rv->io.mem_{read,write}_w do not sufficient for such memory manipulation.

Export rv->io.mem_translate() to perform gVA2gPA translation. Unifying MMU translation logic by using 
rv->io.mem_translate(), eliminating redundant flows: mmu_walk -> check_pg_fault -> check_signal -> get_ppn_and_offset.
Also, this interface allowing src/syscall_sdl.c to handle virtual memory by first translating the gVA2gPA, followed by memory_{read/write} the chunk of data at once.

TODO: dTLB can be introduced in rv->io.mem_trans() to cache the gVA2gPA translation.

See: #310, #510