### PR TITLE
Fix build failures and expand test coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,6 +82,7 @@ jobs:
             make distclean && make ENABLE_SDL=0 check -j$(nproc)
             make distclean && make ENABLE_Zicsr=0 check -j$(nproc)
             make distclean && make ENABLE_MOP_FUSION=0 check -j$(nproc)
+            make distclean && make ENABLE_BLOCK_CHAINING=0 check -j$(nproc)
     - name: misalignment test in block emulation
       env:
         CC: ${{ steps.install_cc.outputs.cc }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,6 +106,7 @@ jobs:
             make ENABLE_JIT=1 clean && make ENABLE_EXT_F=0 ENABLE_JIT=1 check -j$(nproc)
             make ENABLE_JIT=1 clean && make ENABLE_EXT_C=0 ENABLE_JIT=1 check -j$(nproc)
             make ENABLE_JIT=1 clean && make ENABLE_Zba=0 ENABLE_JIT=1 check -j$(nproc)
+            make ENABLE_JIT=1 clean && make ENABLE_Zbb=0 ENABLE_JIT=1 check -j$(nproc)
     - name: undefined behavior test
       run: |
             make clean && make ENABLE_UBSAN=1 check -j$(nproc)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,6 +80,7 @@ jobs:
             make distclean && make ENABLE_EXT_F=0 check -j$(nproc)
             make distclean && make ENABLE_EXT_C=0 check -j$(nproc)
             make distclean && make ENABLE_SDL=0 check -j$(nproc)
+            make distclean && make ENABLE_Zicsr=0 check -j$(nproc)
     - name: misalignment test in block emulation
       env:
         CC: ${{ steps.install_cc.outputs.cc }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,6 +105,7 @@ jobs:
             make ENABLE_JIT=1 clean && make ENABLE_EXT_A=0 ENABLE_JIT=1 check -j$(nproc)
             make ENABLE_JIT=1 clean && make ENABLE_EXT_F=0 ENABLE_JIT=1 check -j$(nproc)
             make ENABLE_JIT=1 clean && make ENABLE_EXT_C=0 ENABLE_JIT=1 check -j$(nproc)
+            make ENABLE_JIT=1 clean && make ENABLE_Zba=0 ENABLE_JIT=1 check -j$(nproc)
     - name: undefined behavior test
       run: |
             make clean && make ENABLE_UBSAN=1 check -j$(nproc)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,6 +87,7 @@ jobs:
             make distclean && make ENABLE_Zbb=0 check -j$(nproc)
             make distclean && make ENABLE_Zbc=0 check -j$(nproc)
             make distclean && make ENABLE_Zbs=0 check -j$(nproc)
+            make distclean && make ENABLE_Zifencei=0 check -j$(nproc)
     - name: misalignment test in block emulation
       env:
         CC: ${{ steps.install_cc.outputs.cc }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,6 +86,7 @@ jobs:
             make distclean && make ENABLE_Zba=0 check -j$(nproc)
             make distclean && make ENABLE_Zbb=0 check -j$(nproc)
             make distclean && make ENABLE_Zbc=0 check -j$(nproc)
+            make distclean && make ENABLE_Zbs=0 check -j$(nproc)
     - name: misalignment test in block emulation
       env:
         CC: ${{ steps.install_cc.outputs.cc }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,6 +120,7 @@ jobs:
             make ENABLE_JIT=1 clean && make ENABLE_Zbs=0 ENABLE_JIT=1 check -j$(nproc)
             make ENABLE_JIT=1 clean && make ENABLE_Zicsr=0 ENABLE_JIT=1 check -j$(nproc)
             make ENABLE_JIT=1 clean && make ENABLE_Zifencei=0 ENABLE_JIT=1 check -j$(nproc)
+            make ENABLE_JIT=1 clean && make ENABLE_MOP_FUSION=0 ENABLE_JIT=1 check -j$(nproc)
     - name: undefined behavior test
       run: |
             make clean && make ENABLE_UBSAN=1 check -j$(nproc)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,6 +107,7 @@ jobs:
             make ENABLE_JIT=1 clean && make ENABLE_EXT_C=0 ENABLE_JIT=1 check -j$(nproc)
             make ENABLE_JIT=1 clean && make ENABLE_Zba=0 ENABLE_JIT=1 check -j$(nproc)
             make ENABLE_JIT=1 clean && make ENABLE_Zbb=0 ENABLE_JIT=1 check -j$(nproc)
+            make ENABLE_JIT=1 clean && make ENABLE_Zbc=0 ENABLE_JIT=1 check -j$(nproc)
     - name: undefined behavior test
       run: |
             make clean && make ENABLE_UBSAN=1 check -j$(nproc)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,6 +119,7 @@ jobs:
             make ENABLE_JIT=1 clean && make ENABLE_Zbc=0 ENABLE_JIT=1 check -j$(nproc)
             make ENABLE_JIT=1 clean && make ENABLE_Zbs=0 ENABLE_JIT=1 check -j$(nproc)
             make ENABLE_JIT=1 clean && make ENABLE_Zicsr=0 ENABLE_JIT=1 check -j$(nproc)
+            make ENABLE_JIT=1 clean && make ENABLE_Zifencei=0 ENABLE_JIT=1 check -j$(nproc)
     - name: undefined behavior test
       run: |
             make clean && make ENABLE_UBSAN=1 check -j$(nproc)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,6 +81,7 @@ jobs:
             make distclean && make ENABLE_EXT_C=0 check -j$(nproc)
             make distclean && make ENABLE_SDL=0 check -j$(nproc)
             make distclean && make ENABLE_Zicsr=0 check -j$(nproc)
+            make distclean && make ENABLE_MOP_FUSION=0 check -j$(nproc)
     - name: misalignment test in block emulation
       env:
         CC: ${{ steps.install_cc.outputs.cc }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,10 @@ jobs:
   host-x64:
     needs: [detect-code-related-file-changes]
     if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [gcc, clang]
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
@@ -49,15 +53,27 @@ jobs:
             sudo chmod +x ./llvm.sh
             sudo ./llvm.sh 18
       shell: bash
+    - name: Install compiler
+      id: install_cc
+      uses: rlalik/setup-cpp-compiler@master
+      with:
+        compiler: ${{ matrix.compiler }}
     - name: default build
+      env:
+        CC: ${{ steps.install_cc.outputs.cc }}
       run: make -j$(nproc)
     - name: check + tests
+      env:
+        CC: ${{ steps.install_cc.outputs.cc }}
       run: |
+            make clean
             make check -j$(nproc)
             make tests -j$(nproc)
             make misalign -j$(nproc)
             make tool -j$(nproc)
     - name: diverse configurations
+      env:
+        CC: ${{ steps.install_cc.outputs.cc }}
       run: |
             make distclean && make ENABLE_EXT_M=0 check -j$(nproc)
             make distclean && make ENABLE_EXT_A=0 check -j$(nproc)
@@ -65,17 +81,25 @@ jobs:
             make distclean && make ENABLE_EXT_C=0 check -j$(nproc)
             make distclean && make ENABLE_SDL=0 check -j$(nproc)
     - name: misalignment test in block emulation
+      env:
+        CC: ${{ steps.install_cc.outputs.cc }}
       run: |
             make -C tests/system/alignment/
             make distclean && make ENABLE_ELF_LOADER=1 ENABLE_EXT_C=0 ENABLE_SYSTEM=1 misalign-in-blk-emu -j$(nproc)
     - name: MMU test
+      env:
+        CC: ${{ steps.install_cc.outputs.cc }}
       run: |
             make -C tests/system/mmu/
             make distclean && make ENABLE_ELF_LOADER=1 ENABLE_SYSTEM=1 mmu-test -j$(nproc)
     - name: gdbstub test
+      env:
+        CC: ${{ steps.install_cc.outputs.cc }}
       run: |
             make distclean && make ENABLE_GDBSTUB=1 gdbstub-test -j$(nproc)
     - name: JIT test
+      env:
+        CC: ${{ steps.install_cc.outputs.cc }}
       run: |
             make ENABLE_JIT=1 clean && make ENABLE_JIT=1 check -j$(nproc)
             make ENABLE_JIT=1 clean && make ENABLE_EXT_A=0 ENABLE_JIT=1 check -j$(nproc)
@@ -86,6 +110,8 @@ jobs:
             make clean && make ENABLE_UBSAN=1 check -j$(nproc)
             make ENABLE_JIT=1 clean && make ENABLE_JIT=1 ENABLE_UBSAN=1 check -j$(nproc)
     - name: boot Linux kernel test
+      env:
+        CC: ${{ steps.install_cc.outputs.cc }}
       run: |
             make clean && make ENABLE_SYSTEM=1 && make ENABLE_SYSTEM=1 artifact -j$(nproc)
             .ci/boot-linux.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,6 +118,7 @@ jobs:
             make ENABLE_JIT=1 clean && make ENABLE_Zbb=0 ENABLE_JIT=1 check -j$(nproc)
             make ENABLE_JIT=1 clean && make ENABLE_Zbc=0 ENABLE_JIT=1 check -j$(nproc)
             make ENABLE_JIT=1 clean && make ENABLE_Zbs=0 ENABLE_JIT=1 check -j$(nproc)
+            make ENABLE_JIT=1 clean && make ENABLE_Zicsr=0 ENABLE_JIT=1 check -j$(nproc)
     - name: undefined behavior test
       run: |
             make clean && make ENABLE_UBSAN=1 check -j$(nproc)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,6 +85,7 @@ jobs:
             make distclean && make ENABLE_BLOCK_CHAINING=0 check -j$(nproc)
             make distclean && make ENABLE_Zba=0 check -j$(nproc)
             make distclean && make ENABLE_Zbb=0 check -j$(nproc)
+            make distclean && make ENABLE_Zbc=0 check -j$(nproc)
     - name: misalignment test in block emulation
       env:
         CC: ${{ steps.install_cc.outputs.cc }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,6 +84,7 @@ jobs:
             make distclean && make ENABLE_MOP_FUSION=0 check -j$(nproc)
             make distclean && make ENABLE_BLOCK_CHAINING=0 check -j$(nproc)
             make distclean && make ENABLE_Zba=0 check -j$(nproc)
+            make distclean && make ENABLE_Zbb=0 check -j$(nproc)
     - name: misalignment test in block emulation
       env:
         CC: ${{ steps.install_cc.outputs.cc }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,6 +108,7 @@ jobs:
             make ENABLE_JIT=1 clean && make ENABLE_Zba=0 ENABLE_JIT=1 check -j$(nproc)
             make ENABLE_JIT=1 clean && make ENABLE_Zbb=0 ENABLE_JIT=1 check -j$(nproc)
             make ENABLE_JIT=1 clean && make ENABLE_Zbc=0 ENABLE_JIT=1 check -j$(nproc)
+            make ENABLE_JIT=1 clean && make ENABLE_Zbs=0 ENABLE_JIT=1 check -j$(nproc)
     - name: undefined behavior test
       run: |
             make clean && make ENABLE_UBSAN=1 check -j$(nproc)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,6 +121,7 @@ jobs:
             make ENABLE_JIT=1 clean && make ENABLE_Zicsr=0 ENABLE_JIT=1 check -j$(nproc)
             make ENABLE_JIT=1 clean && make ENABLE_Zifencei=0 ENABLE_JIT=1 check -j$(nproc)
             make ENABLE_JIT=1 clean && make ENABLE_MOP_FUSION=0 ENABLE_JIT=1 check -j$(nproc)
+            make ENABLE_JIT=1 clean && make ENABLE_BLOCK_CHAINING=0 ENABLE_JIT=1 check -j$(nproc)
     - name: undefined behavior test
       run: |
             make clean && make ENABLE_UBSAN=1 check -j$(nproc)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,6 +106,7 @@ jobs:
             make ENABLE_JIT=1 clean && make ENABLE_EXT_A=0 ENABLE_JIT=1 check -j$(nproc)
             make ENABLE_JIT=1 clean && make ENABLE_EXT_F=0 ENABLE_JIT=1 check -j$(nproc)
             make ENABLE_JIT=1 clean && make ENABLE_EXT_C=0 ENABLE_JIT=1 check -j$(nproc)
+            make ENABLE_JIT=1 clean && make ENABLE_EXT_M=0 ENABLE_JIT=1 check -j$(nproc)
             make ENABLE_JIT=1 clean && make ENABLE_Zba=0 ENABLE_JIT=1 check -j$(nproc)
             make ENABLE_JIT=1 clean && make ENABLE_Zbb=0 ENABLE_JIT=1 check -j$(nproc)
             make ENABLE_JIT=1 clean && make ENABLE_Zbc=0 ENABLE_JIT=1 check -j$(nproc)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,6 +83,7 @@ jobs:
             make distclean && make ENABLE_Zicsr=0 check -j$(nproc)
             make distclean && make ENABLE_MOP_FUSION=0 check -j$(nproc)
             make distclean && make ENABLE_BLOCK_CHAINING=0 check -j$(nproc)
+            make distclean && make ENABLE_Zba=0 check -j$(nproc)
     - name: misalignment test in block emulation
       env:
         CC: ${{ steps.install_cc.outputs.cc }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,7 @@ jobs:
       env:
         CC: ${{ steps.install_cc.outputs.cc }}
       run: make -j$(nproc)
+      if: ${{ always() }}
     - name: check + tests
       env:
         CC: ${{ steps.install_cc.outputs.cc }}
@@ -71,6 +72,7 @@ jobs:
             make tests -j$(nproc)
             make misalign -j$(nproc)
             make tool -j$(nproc)
+      if: ${{ always() }}
     - name: diverse configurations
       env:
         CC: ${{ steps.install_cc.outputs.cc }}
@@ -88,23 +90,27 @@ jobs:
             make distclean && make ENABLE_Zbc=0 check -j$(nproc)
             make distclean && make ENABLE_Zbs=0 check -j$(nproc)
             make distclean && make ENABLE_Zifencei=0 check -j$(nproc)
+      if: ${{ always() }}
     - name: misalignment test in block emulation
       env:
         CC: ${{ steps.install_cc.outputs.cc }}
       run: |
             make -C tests/system/alignment/
             make distclean && make ENABLE_ELF_LOADER=1 ENABLE_EXT_C=0 ENABLE_SYSTEM=1 misalign-in-blk-emu -j$(nproc)
+      if: ${{ always() }}
     - name: MMU test
       env:
         CC: ${{ steps.install_cc.outputs.cc }}
       run: |
             make -C tests/system/mmu/
             make distclean && make ENABLE_ELF_LOADER=1 ENABLE_SYSTEM=1 mmu-test -j$(nproc)
+      if: ${{ always() }}
     - name: gdbstub test
       env:
         CC: ${{ steps.install_cc.outputs.cc }}
       run: |
             make distclean && make ENABLE_GDBSTUB=1 gdbstub-test -j$(nproc)
+      if: ${{ always() }}
     - name: JIT test
       env:
         CC: ${{ steps.install_cc.outputs.cc }}
@@ -122,10 +128,12 @@ jobs:
             make ENABLE_JIT=1 clean && make ENABLE_Zifencei=0 ENABLE_JIT=1 check -j$(nproc)
             make ENABLE_JIT=1 clean && make ENABLE_MOP_FUSION=0 ENABLE_JIT=1 check -j$(nproc)
             make ENABLE_JIT=1 clean && make ENABLE_BLOCK_CHAINING=0 ENABLE_JIT=1 check -j$(nproc)
+      if: ${{ always() }}
     - name: undefined behavior test
       run: |
             make clean && make ENABLE_UBSAN=1 check -j$(nproc)
             make ENABLE_JIT=1 clean && make ENABLE_JIT=1 ENABLE_UBSAN=1 check -j$(nproc)
+      if: ${{ always() }}
     - name: boot Linux kernel test
       env:
         CC: ${{ steps.install_cc.outputs.cc }}
@@ -133,6 +141,7 @@ jobs:
             make clean && make ENABLE_SYSTEM=1 && make ENABLE_SYSTEM=1 artifact -j$(nproc)
             .ci/boot-linux.sh
             make ENABLE_SYSTEM=1 clean
+      if: ${{ always() }}
 
   host-arm64:
     needs: [detect-code-related-file-changes]

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BIN := $(OUT)/rv32emu
 CONFIG_FILE := $(OUT)/.config
 -include $(CONFIG_FILE)
 
-CFLAGS = -std=gnu99 -O2 -Wall -Wextra
+CFLAGS = -std=gnu99 -O2 -Wall -Wextra -Werror
 CFLAGS += -Wno-unused-label
 CFLAGS += -include src/common.h -Isrc/
 

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -83,7 +83,7 @@ $(CACHE_TEST_OUT): $(CACHE_TEST_TARGET)
 
 $(CACHE_TEST_TARGET): $(CACHE_TEST_OBJS)
 	$(VECHO) "  CC\t$@\n"
-	$(Q)$(CC) $^ -o $@
+	$(Q)$(CC) $^ -o $@ $(LDFLAGS)
 
 $(CACHE_TEST_OUTDIR)/%.o: $(CACHE_TEST_SRCDIR)/%.c
 	$(VECHO) "  CC\t$@\n"
@@ -95,7 +95,7 @@ $(MAP_TEST_OUT): $(MAP_TEST_TARGET)
 
 $(MAP_TEST_TARGET): $(MAP_TEST_OBJS)
 	$(VECHO) "  CC\t$@\n"
-	$(Q)$(CC) $^ -o $@
+	$(Q)$(CC) $^ -o $@ $(LDFLAGS)
 
 $(MAP_TEST_OUTDIR)/%.o: $(MAP_TEST_SRCDIR)/%.c
 	$(VECHO) "  CC\t$@\n"
@@ -107,7 +107,7 @@ $(PATH_TEST_OUT): $(PATH_TEST_TARGET)
 
 $(PATH_TEST_TARGET): $(PATH_TEST_OBJS)
 	$(VECHO) "  CC\t$@\n"
-	$(Q)$(CC) $^ -o $@
+	$(Q)$(CC) $^ -o $@ $(LDFLAGS)
 
 $(PATH_TEST_OUTDIR)/%.o: $(PATH_TEST_SRCDIR)/%.c
 	$(VECHO) "  CC\t$@\n"

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -558,7 +558,9 @@ FORCE_INLINE bool insn_is_unconditional_branch(uint8_t opcode)
     case rv_insn_jal:
     case rv_insn_jalr:
     case rv_insn_mret:
+#if RV32_HAS(Zicsr)
     case rv_insn_csrrw:
+#endif
 #if RV32_HAS(SYSTEM)
     case rv_insn_sret:
 #endif

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -705,6 +705,7 @@ static inline void remove_next_nth_ir(const riscv_t *rv,
     block->n_insn -= n;
 }
 
+#if RV32_HAS(MOP_FUSION)
 /* Check if instructions in a block match a specific pattern. If they do,
  * rewrite them as fused instructions.
  *
@@ -802,6 +803,7 @@ static void match_pattern(riscv_t *rv, block_t *block)
         }
     }
 }
+#endif
 
 typedef struct {
     bool is_constant[N_RV_REGS];

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -666,6 +666,7 @@ retranslate:
     block->ir_tail->next = NULL;
 }
 
+#if RV32_HAS(MOP_FUSION)
 #define COMBINE_MEM_OPS(RW)                                       \
     next_ir = ir->next;                                           \
     count = 1;                                                    \
@@ -705,7 +706,6 @@ static inline void remove_next_nth_ir(const riscv_t *rv,
     block->n_insn -= n;
 }
 
-#if RV32_HAS(MOP_FUSION)
 /* Check if instructions in a block match a specific pattern. If they do,
  * rewrite them as fused instructions.
  *

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -79,6 +79,7 @@ static void __trap_handler(riscv_t *rv);
     }
 
 /* FIXME: use more precise methods for updating time, e.g., RTC */
+#if RV32_HAS(Zicsr)
 static uint64_t ctr = 0;
 static inline void update_time(riscv_t *rv)
 {
@@ -86,7 +87,6 @@ static inline void update_time(riscv_t *rv)
     rv->csr_time[1] = ctr >> 32;
 }
 
-#if RV32_HAS(Zicsr)
 /* get a pointer to a CSR */
 static uint32_t *csr_get_ptr(riscv_t *rv, uint32_t csr)
 {

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -550,6 +550,7 @@ FORCE_INLINE bool insn_is_translatable(uint8_t opcode)
 }
 #endif
 
+#if RV32_HAS(BLOCK_CHAINING)
 FORCE_INLINE bool insn_is_unconditional_branch(uint8_t opcode)
 {
     switch (opcode) {
@@ -590,6 +591,7 @@ FORCE_INLINE bool insn_is_direct_branch(uint8_t opcode)
         return false;
     }
 }
+#endif
 
 FORCE_INLINE bool insn_is_indirect_branch(uint8_t opcode)
 {

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -42,7 +42,9 @@ extern struct target_ops gdbstub_ops;
 #define IF_imm(i, v) (i->imm == v)
 
 #if RV32_HAS(SYSTEM)
+#if !RV32_HAS(JIT)
 static bool need_clear_block_map = false;
+#endif
 static uint32_t reloc_enable_mmu_jalr_addr;
 static bool reloc_enable_mmu = false;
 bool need_retranslate = false;

--- a/src/jit.c
+++ b/src/jit.c
@@ -1690,6 +1690,7 @@ static void ra_load2(struct jit_state *state, int vm_reg_idx1, int vm_reg_idx2)
                   offsetof(riscv_t, X) + 4 * vm_reg_idx2);
 }
 
+#if RV32_HAS(EXT_M)
 static void ra_load2_sext(struct jit_state *state,
                           int vm_reg_idx1,
                           int vm_reg_idx2,
@@ -1733,6 +1734,7 @@ static void ra_load2_sext(struct jit_state *state,
                       offsetof(riscv_t, X) + 4 * vm_reg_idx2);
     }
 }
+#endif
 
 void parse_branch_history_table(struct jit_state *state, rv_insn_t *ir)
 {

--- a/src/jit.c
+++ b/src/jit.c
@@ -725,6 +725,7 @@ static inline void emit_alu64(struct jit_state *state, int op, int src, int dst)
 #endif
 }
 
+#if RV32_HAS(EXT_M)
 static inline void emit_alu64_imm8(struct jit_state *state,
                                    int op,
                                    int src UNUSED,
@@ -742,6 +743,7 @@ static inline void emit_alu64_imm8(struct jit_state *state,
     }
 #endif
 }
+#endif
 
 /* Register to register mov */
 static inline void emit_mov(struct jit_state *state, int src, int dst)

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -621,8 +621,10 @@ bool rv_has_halted(riscv_t *rv)
 void rv_delete(riscv_t *rv)
 {
     assert(rv);
-#if !RV32_HAS(JIT)
+#if !RV32_HAS(JIT) || (RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER))
     vm_attr_t *attr = PRIV(rv);
+#endif
+#if !RV32_HAS(JIT)
     map_delete(attr->fd_map);
     memory_delete(attr->mem);
     block_map_destroy(rv);

--- a/src/t2c.c
+++ b/src/t2c.c
@@ -74,8 +74,10 @@ FORCE_INLINE LLVMBasicBlockRef t2c_block_map_search(struct LLVM_block_map *map,
 T2C_LLVM_GEN_ADDR(rs1, X, ir->rs1);
 T2C_LLVM_GEN_ADDR(rs2, X, ir->rs2);
 T2C_LLVM_GEN_ADDR(rd, X, ir->rd);
+#if RV32_HAS(EXT_C)
 T2C_LLVM_GEN_ADDR(ra, X, rv_reg_ra);
 T2C_LLVM_GEN_ADDR(sp, X, rv_reg_sp);
+#endif
 T2C_LLVM_GEN_ADDR(PC, PC, 0);
 
 #define T2C_LLVM_GEN_STORE_IMM32(builder, val, addr) \

--- a/tools/gen-jit-template.py
+++ b/tools/gen-jit-template.py
@@ -107,8 +107,28 @@ INSN = {
         "sh2add",
         "sh1add",
     ],
+    "Zbb": [
+        "rev8",
+        "orcb",
+        "rori",
+        "ror",
+        "rol",
+        "zexth",
+        "sexth",
+        "sextb",
+        "minu",
+        "maxu",
+        "min",
+        "max",
+        "cpop",
+        "ctz",
+        "clz",
+        "xnor",
+        "orn",
+        "andn",
+    ],
 }
-EXT_LIST = ["Zifencei", "Zicsr", "EXT_M", "EXT_A", "EXT_F", "EXT_C", "SYSTEM", "Zba"]
+EXT_LIST = ["Zifencei", "Zicsr", "EXT_M", "EXT_A", "EXT_F", "EXT_C", "SYSTEM", "Zba", "Zbb"]
 SKIP_LIST = []
 # check enabled extension in Makefile
 

--- a/tools/gen-jit-template.py
+++ b/tools/gen-jit-template.py
@@ -132,8 +132,18 @@ INSN = {
         "clmulh",
         "clmul",
     ],
+    "Zbs": [
+        "bseti",
+        "bset",
+        "binvi",
+        "binv",
+        "bexti",
+        "bext",
+        "bclri",
+        "bclr",
+    ],
 }
-EXT_LIST = ["Zifencei", "Zicsr", "EXT_M", "EXT_A", "EXT_F", "EXT_C", "SYSTEM", "Zba", "Zbb", "Zbc"]
+EXT_LIST = ["Zifencei", "Zicsr", "EXT_M", "EXT_A", "EXT_F", "EXT_C", "SYSTEM", "Zba", "Zbb", "Zbc", "Zbs"]
 SKIP_LIST = []
 # check enabled extension in Makefile
 

--- a/tools/gen-jit-template.py
+++ b/tools/gen-jit-template.py
@@ -101,8 +101,9 @@ INSN = {
         "cflw",
         "cfsw",
     ],
+    "SYSTEM": ["sret"],
 }
-EXT_LIST = ["Zifencei", "Zicsr", "EXT_M", "EXT_A", "EXT_F", "EXT_C"]
+EXT_LIST = ["Zifencei", "Zicsr", "EXT_M", "EXT_A", "EXT_F", "EXT_C", "SYSTEM"]
 SKIP_LIST = []
 # check enabled extension in Makefile
 

--- a/tools/gen-jit-template.py
+++ b/tools/gen-jit-template.py
@@ -127,8 +127,13 @@ INSN = {
         "orn",
         "andn",
     ],
+    "Zbc": [
+        "clmulr",
+        "clmulh",
+        "clmul",
+    ],
 }
-EXT_LIST = ["Zifencei", "Zicsr", "EXT_M", "EXT_A", "EXT_F", "EXT_C", "SYSTEM", "Zba", "Zbb"]
+EXT_LIST = ["Zifencei", "Zicsr", "EXT_M", "EXT_A", "EXT_F", "EXT_C", "SYSTEM", "Zba", "Zbb", "Zbc"]
 SKIP_LIST = []
 # check enabled extension in Makefile
 

--- a/tools/gen-jit-template.py
+++ b/tools/gen-jit-template.py
@@ -102,8 +102,13 @@ INSN = {
         "cfsw",
     ],
     "SYSTEM": ["sret"],
+    "Zba": [
+        "sh3add",
+        "sh2add",
+        "sh1add",
+    ],
 }
-EXT_LIST = ["Zifencei", "Zicsr", "EXT_M", "EXT_A", "EXT_F", "EXT_C", "SYSTEM"]
+EXT_LIST = ["Zifencei", "Zicsr", "EXT_M", "EXT_A", "EXT_F", "EXT_C", "SYSTEM", "Zba"]
 SKIP_LIST = []
 # check enabled extension in Makefile
 

--- a/tools/gen-jit-template.py
+++ b/tools/gen-jit-template.py
@@ -15,7 +15,7 @@ INSN = {
         "csrrw",
         "csrrs",
         "csrrc",
-        "csrrw",
+        "csrrwi",
         "csrrsi",
         "csrrci"],
     "EXT_M": [


### PR DESCRIPTION
# Fix build issues and enhance build system tests
Improve our build system testing and fix various build issues discovered in the process

### CI Improvements
- Add compiler matrix to test with both gcc-latest and clang-latest
- Set warnings as errors to catch potential issues early
- Add diverse build configurations testing

### Build Fixes
- Fix linker error when using Clang by adding missing `$(LDFLAGS)`
- Resolve multiple compiler warning, including:
    - Enabling JIT with specific features disabled, such as Zba, Zbb, Zbc, Zbs, EXT_M, or Zicsr
    - Disabling Zicsr 
    - Disabling MOP_FUSIO
- Resolve multiple Clang-specific build errors, including:
    - Enabling JIT when EXT_M or EXT_C disabled
    - Disabling BLOCK_CHAINING
    - Disabling MOP FUSION
    - Disabling Zicsr

## Testing Done
- Test builds with various feature flags disabled
- Confirm CI pipeline runs successfully with all new test cases

