### PR TITLE
Refine hard-coded memory layout for system emulation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
     - name: install-dependencies
       run: |
             sudo apt-get update -q -y
-            sudo apt-get install -q -y libsdl2-dev libsdl2-mixer-dev device-tree-compiler expect
+            sudo apt-get install -q -y libsdl2-dev libsdl2-mixer-dev device-tree-compiler expect bc
             .ci/riscv-toolchain-install.sh
             echo "${{ github.workspace }}/toolchain/bin" >> $GITHUB_PATH
             wget https://apt.llvm.org/llvm.sh
@@ -161,7 +161,7 @@ jobs:
         # No 'sudo' is available
         install: |
           apt-get update -q -y
-          apt-get install -q -y git build-essential libsdl2-dev libsdl2-mixer-dev lsb-release wget software-properties-common gnupg
+          apt-get install -q -y git build-essential libsdl2-dev libsdl2-mixer-dev lsb-release wget software-properties-common gnupg bc
           git config --global --add safe.directory ${{ github.workspace }}
           git config --global --add safe.directory ${{ github.workspace }}/src/softfloat
           git config --global --add safe.directory ${{ github.workspace }}/src/mini-gdbstub

--- a/mk/system.mk
+++ b/mk/system.mk
@@ -10,7 +10,7 @@ DTC ?= dtc
 BUILD_DTB := $(OUT)/minimal.dtb
 $(BUILD_DTB): $(DEV_SRC)/minimal.dts
 	$(VECHO) " DTC\t$@\n"
-	$(Q)$(DTC) $^ -o $@
+	$(Q)$(CC) -nostdinc -E -P -x assembler-with-cpp -undef $(CFLAGS_dt) $^ | $(DTC) - > $@
 
 BIN_TO_C := $(OUT)/bin2c
 $(BIN_TO_C): tools/bin2c.c

--- a/src/devices/minimal.dts
+++ b/src/devices/minimal.dts
@@ -12,8 +12,8 @@
     chosen {
         bootargs = "earlycon console=ttyS0";
         stdout-path = "serial0";
-        linux,initrd-start = <0x1f700000>; /* @403 MiB (503 * 1024 * 1024)     */
-        linux,initrd-end = <0x1fefffff>;   /* @511 MiB (511 * 1024 * 1024 - 1) */
+        linux,initrd-start = <INITRD_START>;
+        linux,initrd-end = <INITRD_END>;
     };
 
     cpus {
@@ -37,7 +37,7 @@
 
     sram: memory@0 {
         device_type = "memory";
-        reg = <0x00000000 0x20000000>;
+        reg = <MEM_START MEM_END>;
         reg-names = "sram0";
     };
 

--- a/src/main.c
+++ b/src/main.c
@@ -226,12 +226,6 @@ void indirect_rv_halt()
 }
 #endif
 
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
-/* forcely undefine MEM_SIZE to prevent any define in Makefile */
-#undef MEM_SIZE
-#define MEM_SIZE 512 * 1024 * 1024
-#endif
-
 int main(int argc, char **args)
 {
     if (argc == 1 || !parse_args(argc, args)) {

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -467,7 +467,7 @@ riscv_t *rv_create(riscv_user_t rv_attr)
     char *ram_loc = (char *) attr->mem->mem_base;
     map_file(&ram_loc, attr->data.system.kernel);
 
-    uint32_t dtb_addr = attr->mem->mem_size - (1 * 1024 * 1024);
+    uint32_t dtb_addr = attr->mem->mem_size - DTB_SIZE;
     ram_loc = ((char *) attr->mem->mem_base) + dtb_addr;
     load_dtb(&ram_loc, attr->data.system.bootargs);
     /*
@@ -475,7 +475,7 @@ riscv_t *rv_create(riscv_user_t rv_attr)
      * prevent kernel from overwritting it
      */
     if (attr->data.system.initrd) {
-        uint32_t initrd_addr = dtb_addr - (8 * 1024 * 1024);
+        uint32_t initrd_addr = dtb_addr - INITRD_SIZE;
         ram_loc = ((char *) attr->mem->mem_base) + initrd_addr;
         map_file(&ram_loc, attr->data.system.initrd);
     }


### PR DESCRIPTION
During the enhancement of guestOS to run SDL-based applications like Doom, the Doom artifacts (DOOM1.wad) occupy 4.0MiB, and the default rootfs.cpio also uses 4.0MiB, totaling 8MiB. When additional applications are added to rootfs.cpio, the hard-coded 8MiB limit for rootfs.cpio in map_file becomes insufficient. This commit refines the hard-coded memory layout variables and makes them configurable during the build.

The user can now define MEM_SIZE, DTB_SIZE, and INITRD_SIZE in MiB, while other memory offsets are calculated dynamically based on these values.

Related: #510