### PR TITLE
CI: Build check with various optimization levels

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,16 +58,107 @@ jobs:
       uses: rlalik/setup-cpp-compiler@master
       with:
         compiler: ${{ matrix.compiler }}
-    - name: default build
+    - name: default build with -g
       env:
         CC: ${{ steps.install_cc.outputs.cc }}
-      run: make -j$(nproc)
+      run: make OPT_LEVEL=-g -j$(nproc)
+      if: ${{ always() }}
+    - name: default build with -Og
+      env:
+        CC: ${{ steps.install_cc.outputs.cc }}
+      run: |
+            make distclean
+            make OPT_LEVEL=-Og -j$(nproc)
+      if: ${{ always() }}
+    - name: default build with -O0
+      env:
+        CC: ${{ steps.install_cc.outputs.cc }}
+      run: |
+            make distclean
+            make OPT_LEVEL=-O0 -j$(nproc)
+      if: ${{ always() }}
+    - name: default build with -O1
+      env:
+        CC: ${{ steps.install_cc.outputs.cc }}
+      run: |
+            make distclean
+            make OPT_LEVEL=-O1 -j$(nproc)
+      if: ${{ always() }}
+    - name: default build with -O2
+      env:
+        CC: ${{ steps.install_cc.outputs.cc }}
+      run: |
+            make distclean
+            make OPT_LEVEL=-O2 -j$(nproc)
+      if: ${{ always() }}
+    - name: default build with -O3
+      env:
+        CC: ${{ steps.install_cc.outputs.cc }}
+      run: |
+            make distclean
+            make OPT_LEVEL=-O3 -j$(nproc)
+      if: ${{ always() }}
+    - name: default build with -Ofast
+      env:
+        CC: ${{ steps.install_cc.outputs.cc }}
+      run: |
+            make distclean
+            make OPT_LEVEL=-Ofast -j$(nproc)
+      if: ${{ always() }}
+    - name: default build for system emulation with -g
+      env:
+        CC: ${{ steps.install_cc.outputs.cc }}
+      run: |
+            make distclean
+            make OPT_LEVEL=-g ENABLE_SYSTEM=1 -j$(nproc)
+      if: ${{ always() }}
+    - name: default build for system emulation with -Og
+      env:
+        CC: ${{ steps.install_cc.outputs.cc }}
+      run: |
+            make distclean
+            make OPT_LEVEL=-Og ENABLE_SYSTEM=1 -j$(nproc)
+      if: ${{ always() }}
+    - name: default build for system emulation with -O0
+      env:
+        CC: ${{ steps.install_cc.outputs.cc }}
+      run: |
+            make distclean
+            make OPT_LEVEL=-O0 ENABLE_SYSTEM=1 -j$(nproc)
+      if: ${{ always() }}
+    - name: default build for system emulation with -O1
+      env:
+        CC: ${{ steps.install_cc.outputs.cc }}
+      run: |
+            make distclean
+            make OPT_LEVEL=-O1 ENABLE_SYSTEM=1 -j$(nproc)
+      if: ${{ always() }}
+    - name: default build for system emulation with -O2
+      env:
+        CC: ${{ steps.install_cc.outputs.cc }}
+      run: |
+            make distclean
+            make OPT_LEVEL=-O2 ENABLE_SYSTEM=1 -j$(nproc)
+      if: ${{ always() }}
+    - name: default build for system emulation with -O3
+      env:
+        CC: ${{ steps.install_cc.outputs.cc }}
+      run: |
+            make distclean
+            make OPT_LEVEL=-O3 ENABLE_SYSTEM=1 -j$(nproc)
+      if: ${{ always() }}
+    - name: default build for system emulation with -Ofast
+      env:
+        CC: ${{ steps.install_cc.outputs.cc }}
+      run: |
+            make distclean
+            make OPT_LEVEL=-Ofast ENABLE_SYSTEM=1 -j$(nproc)
       if: ${{ always() }}
     - name: check + tests
       env:
         CC: ${{ steps.install_cc.outputs.cc }}
       run: |
-            make clean
+            make distclean
             make check -j$(nproc)
             make tests -j$(nproc)
             make misalign -j$(nproc)

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@ BIN := $(OUT)/rv32emu
 CONFIG_FILE := $(OUT)/.config
 -include $(CONFIG_FILE)
 
-CFLAGS = -std=gnu99 -O2 -Wall -Wextra -Werror
+OPT_LEVEL ?= -O2
+
+CFLAGS = -std=gnu99 $(OPT_LEVEL) -Wall -Wextra -Werror
 CFLAGS += -Wno-unused-label
 CFLAGS += -include src/common.h -Isrc/
 

--- a/mk/system.mk
+++ b/mk/system.mk
@@ -28,7 +28,7 @@ DEV_OBJS := $(patsubst $(DEV_SRC)/%.c, $(DEV_OUT)/%.o, $(wildcard $(DEV_SRC)/*.c
 deps := $(DEV_OBJS:%.o=%.o.d)
 
 OBJS_EXT += system.o
-OBJS_EXT += dtc/libfdt/fdt.o dtc/libfdt/fdt_ro.o dtc/libfdt/fdt_rw.o
+OBJS_EXT += dtc/libfdt/fdt.o dtc/libfdt/fdt_ro.o dtc/libfdt/fdt_rw.o dtc/libfdt/fdt_wip.o
 
 # system target execution by using default dependencies
 LINUX_IMAGE_DIR := linux-image


### PR DESCRIPTION
The submodules are built locally, which may lead to build failures. Specifically, the dtc submodule fails to build when using GCC versions 11.4.0 or 12.3.0 with optimization levels set to -O0 or with debug flag -g. This is a critical issue, as it can disable the debug mode. To address this, optimization levels and debug level build are introduced to stabilize the pull request changes.

The compiled error:
/usr/bin/ld: /tmp/cc2eaHdM.ltrans0.ltrans.o: in function fdt_del_node': <artificial>:(.text+0x279f0): undefined reference to fdt_node_end_offset_' collect2: error: ld returned 1 exit status

Note: I have only used gcc 11.4.0 and gcc 12.3.0 to test this out. Github runners should test other compilers.

After bisecting, the original cause was found after #534.