### PR TITLE
jit: Add architecture test

### DIFF
--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -2,12 +2,19 @@
 check_platform()
 {
     MACHINE_TYPE=`uname -m`
-    if [ ${MACHINE_TYPE} != 'x86_64' ]; then
-        exit 1
-    fi
-
     OS_TYPE=`uname -s`
-    if [ ${OS_TYPE} != 'Linux' ]; then
-        exit 1
-    fi
+
+    case "${MACHINE_TYPE}/${OS_TYPE}" in
+        x86_64/Linux | aarch64/Linux)
+            ;;
+        Arm64/Darwin)
+            echo "Apple Silicon is not supported yet"
+            exit 1
+            ;;
+        *)
+            echo "Unsupported platform: ${MACHINE_TYPE}/${OS_TYPE}"
+            exit 1
+            ;;
+    esac
+
 }

--- a/.ci/riscv-tests.sh
+++ b/.ci/riscv-tests.sh
@@ -17,12 +17,22 @@ make distclean
 # necessary. We need to investigate why full 4 GiB memory access is required
 # for this purpose, although the emulator can run all selected benchmarks with
 # much smaller memory mapping regions.
-make ENABLE_EXT_M=1 ENABLE_EXT_A=1 ENABLE_EXT_F=1 ENABLE_EXT_C=1 \
+make ENABLE_ARCH_TEST=1 ENABLE_EXT_M=1 ENABLE_EXT_A=1 ENABLE_EXT_F=1 ENABLE_EXT_C=1 \
      ENABLE_Zicsr=1 ENABLE_Zifencei=1 ENABLE_FULL4G=1 $PARALLEL
-make arch-test RISCV_DEVICE=IMAFCZicsrZifencei $PARALLEL || exit 1
-make arch-test RISCV_DEVICE=FCZicsr $PARALLEL || exit 1
-make arch-test RISCV_DEVICE=IMZbaZbbZbcZbs $PARALLEL || exit 1
+make arch-test RISCV_DEVICE=IMAFCZicsrZifencei hw_data_misaligned_support=1 $PARALLEL || exit 1
+make arch-test RISCV_DEVICE=FCZicsr hw_data_misaligned_support=1 $PARALLEL || exit 1
+make arch-test RISCV_DEVICE=IMZbaZbbZbcZbs hw_data_misaligned_support=1 $PARALLEL || exit 1
 
+# Rebuild with RV32E
 make distclean
-make ENABLE_RV32E=1 ENABLE_FULL4G=1 $PARALLEL
+make ENABLE_ARCH_TEST=1 ENABLE_RV32E=1 ENABLE_FULL4G=1 $PARALLEL
 make arch-test RISCV_DEVICE=E $PARALLEL || exit 1
+
+# Rebuild with JIT
+# Do not run the architecture test with "Zicsr" extension. It ignores
+# the hardware misalignment (hw_data_misaligned_support) option.
+make distclean
+make ENABLE_ARCH_TEST=1 ENABLE_JIT=1 ENABLE_T2C=0 \
+     ENABLE_EXT_M=1 ENABLE_EXT_A=1 ENABLE_EXT_F=1 ENABLE_EXT_C=1 \
+     ENABLE_Zicsr=1 ENABLE_Zifencei=1 ENABLE_FULL4G=1 $PARALLEL
+make arch-test RISCV_DEVICE=IMC hw_data_misaligned_support=0 $PARALLEL || exit 1

--- a/.ci/riscv-toolchain-install.sh
+++ b/.ci/riscv-toolchain-install.sh
@@ -11,7 +11,12 @@ mkdir -p toolchain
 if [[ "$#" == "0" ]] || [[ "$1" != "riscv-collab" ]]; then
     GCC_VER=14.2.0-3
     TOOLCHAIN_REPO=https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack
-    TOOLCHAIN_URL=${TOOLCHAIN_REPO}/releases/download/v${GCC_VER}/xpack-riscv-none-elf-gcc-${GCC_VER}-linux-x64.tar.gz
+
+    if [[ ${MACHINE_TYPE} == "x86_64" ]]; then
+        TOOLCHAIN_URL=${TOOLCHAIN_REPO}/releases/download/v${GCC_VER}/xpack-riscv-none-elf-gcc-${GCC_VER}-linux-x64.tar.gz
+    elif [[ ${MACHINE_TYPE} == "aarch64" ]]; then
+        TOOLCHAIN_URL=${TOOLCHAIN_REPO}/releases/download/v${GCC_VER}/xpack-riscv-none-elf-gcc-${GCC_VER}-linux-arm64.tar.gz
+    fi
 else
     UBUNTU_VER=`lsb_release -r | cut -f2`
     GCC_VER=2025.01.20

--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -110,7 +110,6 @@ jobs:
           sudo apt-get update -q -y
           sudo apt-get upgrade -q -y
           sudo apt-get install -q -y gcc-multilib g++-multilib
-          sudo apt-get install -q -y opam build-essential libgmp-dev z3 pkg-config zlib1g-dev
           .ci/riscv-toolchain-install.sh
           echo "$PWD/toolchain/bin" >> $GITHUB_PATH
       - name: Build binaries
@@ -120,19 +119,6 @@ jobs:
           mv build/sha1sum-linux-x86-softfp /tmp
           mv build/sha1sum-riscv32 /tmp
           mv build/linux-x86-softfp build/riscv32 /tmp/rv32emu-prebuilt
-      - name: Build Sail model
-        run: |
-          cd /tmp
-          opam init -y --disable-sandboxing
-          opam switch create ocaml-base-compiler.4.06.1
-          opam install sail -y
-          eval $(opam config env)
-          git clone https://github.com/riscv/sail-riscv.git
-          cd sail-riscv
-          git checkout 9547a30bf84572c458476591b569a95f5232c1c7
-          ARCH=RV32 make -j
-          mkdir -p /tmp/rv32emu-prebuilt/sail_cSim
-          mv c_emulator/riscv_sim_RV32 /tmp/rv32emu-prebuilt/sail_cSim
       - name: Create tarball
         run: |
           cd /tmp

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -233,6 +233,12 @@ jobs:
             .ci/boot-linux.sh
             make ENABLE_SYSTEM=1 clean
       if: ${{ always() }}
+    - name: Architecture test
+      env:
+        CC: ${{ steps.install_cc.outputs.cc }}
+      run: |
+            .ci/riscv-tests.sh
+      if: ${{ always() }}
 
   host-arm64:
     needs: [detect-code-related-file-changes]
@@ -254,7 +260,7 @@ jobs:
         install: |
           apt-get update -q -y
           apt-get dist-upgrade -q -y
-          apt-get install -q -y make git clang libsdl2-dev libsdl2-mixer-dev lsb-release wget software-properties-common gnupg bc
+          apt-get install -q -y make git clang python3 python3-pip build-essential libsdl2-dev libsdl2-mixer-dev lsb-release wget software-properties-common gnupg bc
           git config --global --add safe.directory ${{ github.workspace }}
           git config --global --add safe.directory ${{ github.workspace }}/src/softfloat
           git config --global --add safe.directory ${{ github.workspace }}/src/mini-gdbstub
@@ -269,6 +275,8 @@ jobs:
           make ENABLE_JIT=1 clean && make ENABLE_EXT_A=0 ENABLE_JIT=1 check -j$(nproc)
           make ENABLE_JIT=1 clean && make ENABLE_EXT_F=0 ENABLE_JIT=1 check -j$(nproc)
           make ENABLE_JIT=1 clean && make ENABLE_EXT_C=0 ENABLE_JIT=1 check -j$(nproc)
+          .ci/riscv-toolchain-install.sh && export PATH=$PWD/toolchain/bin:$PATH
+          .ci/riscv-tests.sh
 
   coding-style:
     needs: [detect-code-related-file-changes]
@@ -304,21 +312,6 @@ jobs:
     - name: run scan-build with JIT
       run: |
           make ENABLE_JIT=1 distclean && scan-build-18 -v -o ~/scan-build --status-bugs --use-cc=clang-18 --force-analyze-debug-code --show-description -analyzer-config stable-report-filename=true -enable-checker valist,nullability make ENABLE_EXT_F=0 ENABLE_SDL=0 ENABLE_JIT=1
-
-  compliance-test:
-    needs: [detect-code-related-file-changes]
-    if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: install-dependencies
-      run: |
-            .ci/riscv-toolchain-install.sh
-      shell: bash
-    - name: architectural test
-      run: |
-            .ci/riscv-tests.sh
-      shell: bash
 
   # https://docs.docker.com/build/ci/github-actions/multi-platform/
   docker-hub-build-and-publish:

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,9 @@ CFLAGS += -DMEM_SIZE=0x$(REAL_MEM_SIZE) -DDTB_SIZE=0x$(REAL_DTB_SIZE) -DINITRD_S
 endif
 endif
 
+ENABLE_ARCH_TEST ?= 0
+$(call set-feature, ARCH_TEST)
+
 # Enable link-time optimization (LTO)
 ENABLE_LTO ?= 1
 ifeq ($(call has, LTO), 1)

--- a/mk/artifact.mk
+++ b/mk/artifact.mk
@@ -39,9 +39,12 @@ SHELL_HACK := $(shell mkdir -p $(BIN_DIR)/linux-x86-softfp $(BIN_DIR)/riscv32 $(
 ifeq ($(call has, PREBUILT), 1)
 ifeq ($(call has, SYSTEM), 1)
   LATEST_RELEASE := $(shell wget -q https://api.github.com/repos/sysprog21/rv32emu-prebuilt/releases -O- | grep '"tag_name"' | grep "Linux-Image" | head -n 1 | sed -E 's/.*"tag_name": "([^"]+)".*/\1/')
+else ifeq ($(call has, ARCH_TEST), 1)
+  LATEST_RELEASE := $(shell wget -q https://api.github.com/repos/sysprog21/rv32emu-prebuilt/releases -O- | grep '"tag_name"' | grep "sail" | head -n 1 | sed -E 's/.*"tag_name": "([^"]+)".*/\1/')
 else
   LATEST_RELEASE := $(shell wget -q https://api.github.com/repos/sysprog21/rv32emu-prebuilt/releases -O- | grep '"tag_name"' | grep "ELF" | head -n 1 | sed -E 's/.*"tag_name": "([^"]+)".*/\1/')
 endif
+  PREBUILT_BLOB_URL = https://github.com/sysprog21/rv32emu-prebuilt/releases/download/$(LATEST_RELEASE)
 else
   # Since rv32emu only supports the dynamic binary translation of integer instruction in tiered compilation currently,
   # we disable the hardware floating-point and the related SIMD operation of x86.
@@ -67,6 +70,14 @@ ifeq ($(call has, SYSTEM), 1)
 	))
 
 	$(Q)$(eval RV32EMU_PREBUILT_TARBALL := rv32emu-linux-image-prebuilt.tar.gz)
+else ifeq ($(call has, ARCH_TEST), 1)
+	$(Q)$(eval PREBUILT_SAIL_FILENAME := $(shell cat $(BIN_DIR)/rv32emu-prebuilt-sail-$(HOST_PLATFORM).sha | awk '{  print $$2 };'))
+
+	$(Q)$(eval $(foreach FILE,$(PREBUILT_SAIL_FILENAME), \
+	    $(call verify,$(shell grep -w $(FILE) $(BIN_DIR)/rv32emu-prebuilt-sail-$(HOST_PLATFORM).sha | awk '{ print $$1 };'),$(BIN_DIR)/$(FILE),RES) \
+	))
+
+	$(Q)$(eval RV32EMU_PREBUILT_TARBALL := rv32emu-prebuilt-sail-$(HOST_PLATFORM))
 else
 	$(Q)$(eval PREBUILT_X86_FILENAME := $(shell cat $(BIN_DIR)/sha1sum-linux-x86-softfp | awk '{  print $$2 };'))
 	$(Q)$(eval PREBUILT_RV32_FILENAME := $(shell cat $(BIN_DIR)/sha1sum-riscv32 | awk '{ print $$2 };'))
@@ -81,12 +92,21 @@ else
 	$(Q)$(eval RV32EMU_PREBUILT_TARBALL := rv32emu-prebuilt.tar.gz)
 endif
 
+ifeq ($(call has, ARCH_TEST), 1)
 	$(Q)if [ "$(RES)" = "1" ]; then \
-	    $(PRINTF) "\n$(YELLOW)SHA-1 verification fails! Re-fetching prebuilt binaries from \"rv32emu-prebuilt\" ...\n$(NO_COLOR)"; \
-	    wget -q --show-progress https://github.com/sysprog21/rv32emu-prebuilt/releases/download/$(LATEST_RELEASE)/$(RV32EMU_PREBUILT_TARBALL) -O- | tar -C build --strip-components=1 -xz; \
+	    $(PRINTF) "\n$(YELLOW)SHA-1 verification failed! Re-fetching prebuilt binaries from \"rv32emu-prebuilt\" ...\n$(NO_COLOR)"; \
+	    wget -q --show-progress $(PREBUILT_BLOB_URL)/$(RV32EMU_PREBUILT_TARBALL) -O build/$(RV32EMU_PREBUILT_TARBALL);\
 	else \
 	    $(call notice, [OK]); \
 	fi
+else
+	$(Q)if [ "$(RES)" = "1" ]; then \
+	    $(PRINTF) "\n$(YELLOW)SHA-1 verification failed! Re-fetching prebuilt binaries from \"rv32emu-prebuilt\" ...\n$(NO_COLOR)"; \
+	    wget -q --show-progress $(PREBUILT_BLOB_URL)/$(RV32EMU_PREBUILT_TARBALL) -O- | tar -C build --strip-components=1 -xz; \
+	else \
+	    $(call notice, [OK]); \
+	fi
+endif
 else
 ifeq ($(call has, SYSTEM), 1)
 	$(Q)(cd $(BIN_DIR) && $(SHA1SUM) linux-image/Image >> sha1sum-linux-image)
@@ -127,13 +147,15 @@ endif
 
 fetch-checksum:
 ifeq ($(call has, PREBUILT), 1)
-	$(Q)$(PRINTF) "Fetching SHA-1 of prebuilt binaries ... "
+	$(Q)$(PRINTF) "Fetching SHA-1 of prebuilt binaries ...\n"
 ifeq ($(call has, SYSTEM), 1)
-	$(Q)wget -q -O $(BIN_DIR)/sha1sum-linux-image https://github.com/sysprog21/rv32emu-prebuilt/releases/download/$(LATEST_RELEASE)/sha1sum-linux-image
+	$(Q)wget -q -O $(BIN_DIR)/sha1sum-linux-image $(PREBUILT_BLOB_URL)/sha1sum-linux-image
 	$(Q)$(call notice, [OK])
+else ifeq ($(call has, ARCH_TEST), 1)
+	$(Q)wget -q -O $(BIN_DIR)/rv32emu-prebuilt-sail-$(HOST_PLATFORM).sha $(PREBUILT_BLOB_URL)/rv32emu-prebuilt-sail-$(HOST_PLATFORM).sha
 else
-	$(Q)wget -q -O $(BIN_DIR)/sha1sum-linux-x86-softfp https://github.com/sysprog21/rv32emu-prebuilt/releases/download/$(LATEST_RELEASE)/sha1sum-linux-x86-softfp
-	$(Q)wget -q -O $(BIN_DIR)/sha1sum-riscv32 https://github.com/sysprog21/rv32emu-prebuilt/releases/download/$(LATEST_RELEASE)/sha1sum-riscv32
+	$(Q)wget -q -O $(BIN_DIR)/sha1sum-linux-x86-softfp $(PREBUILT_BLOB_URL)/sha1sum-linux-x86-softfp
+	$(Q)wget -q -O $(BIN_DIR)/sha1sum-riscv32 $(PREBUILT_BLOB_URL)/sha1sum-riscv32
 	$(Q)$(call notice, [OK])
 endif
 endif

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -5,6 +5,15 @@ else
     PRINTF = env printf
 endif
 
+UNAME_M := $(shell uname -m)
+ifeq ($(UNAME_M),x86_64)
+    HOST_PLATFORM := x86
+else ifeq ($(UNAME_M),aarch64)
+    HOST_PLATFORM := aarch64
+else
+    $(error Unsupported platform.)
+endif
+
 # Control the build verbosity
 # 'make V=1' equals to 'make VERBOSE=1'
 ifeq ("$(origin V)", "command line")

--- a/mk/riscv-arch-test.mk
+++ b/mk/riscv-arch-test.mk
@@ -20,8 +20,9 @@ ifeq ($(CROSS_COMPILE),)
 	$(error GNU Toolchain for RISC-V is required to build architecture tests. Please check package installation)
 endif
 	git submodule update --init $(dir $(ARCH_TEST_DIR))
-	$(Q)cp $(OUT)/sail_cSim/riscv_sim_RV32 tests/arch-test-target/sail_cSim/riscv_sim_RV32
-	$(Q)python3 -B $(RISCV_TARGET)/setup.py --riscv_device=$(RISCV_DEVICE)
+	$(Q)cp $(OUT)/rv32emu-prebuilt-sail-$(HOST_PLATFORM) tests/arch-test-target/sail_cSim/riscv_sim_RV32
+	$(Q)chmod +x tests/arch-test-target/sail_cSim/riscv_sim_RV32
+	$(Q)python3 -B $(RISCV_TARGET)/setup.py --riscv_device=$(RISCV_DEVICE) --hw_data_misaligned_support=$(hw_data_misaligned_support)
 	$(Q)riscof run --work-dir=$(WORK) \
 			--config=$(RISCV_TARGET)/config.ini \
 			--suite=$(ARCH_TEST_SUITE) \

--- a/src/feature.h
+++ b/src/feature.h
@@ -113,5 +113,10 @@
 #define RV32_FEATURE_LOG_COLOR 1
 #endif
 
+/* Architecture test */
+#ifndef RV32_FEATURE_ARCH_TEST
+#define RV32_FEATURE_ARCH_TEST 0
+#endif
+
 /* Feature test macro */
 #define RV32_HAS(x) RV32_FEATURE_##x

--- a/src/jit.c
+++ b/src/jit.c
@@ -773,7 +773,7 @@ static inline void emit_alu64_imm32(struct jit_state *state,
 static inline void emit_cmp_imm32(struct jit_state *state, int dst, int32_t imm)
 {
 #if defined(__x86_64__)
-    emit_alu64_imm32(state, 0x81, 7, dst, imm);
+    emit_alu32_imm32(state, 0x81, 7, dst, imm);
 #elif defined(__aarch64__)
     emit_load_imm(state, R10, imm);
     emit_addsub_register(state, false, AS_SUBS, RZ, dst, R10);
@@ -823,6 +823,10 @@ static inline void emit_jcc_offset(struct jit_state *state, int code)
 #endif
 }
 
+static inline void emit_load_imm(struct jit_state *state,
+                                 int dst,
+                                 uint32_t imm);
+
 /* Load [src + offset] into dst.
  *
  * If the offset is non-zero, it restores the vm register to the host register
@@ -835,6 +839,18 @@ static inline void emit_load(struct jit_state *state,
                              int dst,
                              int32_t offset)
 {
+    for (int i = 0; i < n_host_regs; i++) {
+        if (register_map[i].reg_idx != dst)
+            continue;
+        if (register_map[i].vm_reg_idx != 0)
+            continue;
+
+        /* if dst is x0, load 0x0 into host register */
+        emit_load_imm(state, dst, 0x0);
+        set_dirty(dst, true);
+        return;
+    }
+
 #if defined(__x86_64__)
     if (src & 8 || dst & 8)
         emit_basic_rex(state, 0, dst, src);
@@ -875,6 +891,18 @@ static inline void emit_load_sext(struct jit_state *state,
                                   int dst,
                                   int32_t offset)
 {
+    for (int i = 0; i < n_host_regs; i++) {
+        if (register_map[i].reg_idx != dst)
+            continue;
+        if (register_map[i].vm_reg_idx != 0)
+            continue;
+
+        /* if dst is x0, load 0x0 into host register */
+        emit_load_imm(state, dst, 0x0);
+        set_dirty(dst, true);
+        return;
+    }
+
 #if defined(__x86_64__)
     if (size == S8 || size == S16) {
         if (src & 8 || dst & 8)
@@ -908,8 +936,28 @@ static inline void emit_load_sext(struct jit_state *state,
     set_dirty(dst, !offset);
 }
 
+/* Load 32-bit immediate into register (zero-extend) */
+static inline void emit_load_imm(struct jit_state *state, int dst, uint32_t imm)
+{
+#if defined(__x86_64__)
+    if (dst & 8)
+        emit_basic_rex(state, 0, 0, dst);
+    emit1(state, 0xb8 | (dst & 7));
+    emit4(state, imm);
+
+    set_dirty(dst, true);
+#elif defined(__aarch64__)
+    if ((int32_t) imm == imm)
+        emit_movewide_imm(state, false, dst, imm);
+    else
+        emit_movewide_imm(state, true, dst, imm);
+#endif
+}
+
 /* Load sign-extended immediate into register */
-static inline void emit_load_imm(struct jit_state *state, int dst, int64_t imm)
+static inline void emit_load_imm_sext(struct jit_state *state,
+                                      int dst,
+                                      int64_t imm)
 {
 #if defined(__x86_64__)
     if ((int32_t) imm == imm)
@@ -942,6 +990,38 @@ static inline void emit_store(struct jit_state *state,
                               int dst,
                               int32_t offset)
 {
+    for (int i = 0; i < n_host_regs; i++) {
+        if (register_map[i].reg_idx != src)
+            continue;
+        if (register_map[i].vm_reg_idx != 0)
+            continue;
+
+        /* if src is x0, write 0x0 into destination */
+        if (size == S16)
+            emit1(state, 0x66); /* 16-bit override */
+        if (dst & 8)
+            emit_rex(state, 0, 0, 0, !!(dst & 8));
+        emit1(state, size == S8 ? 0xc6 : 0xc7);
+        emit1(state, 0x80 | (dst & 0x7));
+        emit4(state, offset);
+        switch (size) {
+        case S8:
+            emit1(state, 0x0);
+            break;
+        case S16:
+            emit1(state, 0x0);
+            emit1(state, 0x0);
+            break;
+        case S32:
+            emit4(state, 0x0);
+            break;
+        default:
+            assert(NULL);
+            __UNREACHABLE;
+        }
+        set_dirty(src, false);
+        return;
+    }
 #if defined(__x86_64__)
     if (size == S16)
         emit1(state, 0x66); /* 16-bit override */
@@ -990,7 +1070,7 @@ static inline void unmap_vm_reg(int);
 static inline void emit_call(struct jit_state *state, intptr_t target)
 {
 #if defined(__x86_64__)
-    emit_load_imm(state, RAX, target);
+    emit_load_imm_sext(state, RAX, target);
     /* callq *%rax */
     emit1(state, 0xff);
     /* ModR/M byte: b11010000b = xd0, rax is register 0 */
@@ -1129,7 +1209,7 @@ static void muldivmod(struct jit_state *state,
 
     if (div || mod) {
         if (sign) {
-            emit_load_imm(state, RDX, -1);
+            emit_load_imm_sext(state, RDX, -1);
             /* compare divisor with -1 for overflow checking */
             emit_cmp32(state, RDX, RCX);
             /* Save the result of the comparision */
@@ -1165,7 +1245,7 @@ static void muldivmod(struct jit_state *state,
 
         if (div) {
             /* Set the dividend to zero if the divisor was zero. */
-            emit_load_imm(state, RCX, -1);
+            emit_load_imm_sext(state, RCX, -1);
 
             /* Store 0 in RAX if the divisor was zero. */
             /* Use conditional move to avoid a branch. */
@@ -1795,7 +1875,8 @@ static void do_fuse3(struct jit_state *state, riscv_t *rv, rv_insn_t *ir)
     opcode_fuse_t *fuse = ir->fuse;
     for (int i = 0; i < ir->imm2; i++) {
         vm_reg[0] = ra_load(state, fuse[i].rs1);
-        emit_load_imm(state, temp_reg, (intptr_t) (m->mem_base + fuse[i].imm));
+        emit_load_imm_sext(state, temp_reg,
+                           (intptr_t) (m->mem_base + fuse[i].imm));
         emit_alu64(state, 0x01, vm_reg[0], temp_reg);
         vm_reg[1] = ra_load(state, fuse[i].rs2);
         emit_store(state, S32, vm_reg[1], temp_reg, 0);
@@ -1808,7 +1889,8 @@ static void do_fuse4(struct jit_state *state, riscv_t *rv, rv_insn_t *ir)
     opcode_fuse_t *fuse = ir->fuse;
     for (int i = 0; i < ir->imm2; i++) {
         vm_reg[0] = ra_load(state, fuse[i].rs1);
-        emit_load_imm(state, temp_reg, (intptr_t) (m->mem_base + fuse[i].imm));
+        emit_load_imm_sext(state, temp_reg,
+                           (intptr_t) (m->mem_base + fuse[i].imm));
         emit_alu64(state, 0x01, vm_reg[0], temp_reg);
         vm_reg[1] = map_vm_reg(state, fuse[i].rd);
         emit_load(state, S32, temp_reg, vm_reg[1], 0);

--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -68,7 +68,8 @@
  * |                 src, dst, imm; | store the result into dst.             |
  * | alu[32|64], op, src, dst;      | Do ALU operation on src and dst and    |
  * |                                | store the result into dst.             |
- * | ldimm, dst, imm;               | Load immediate into dst.               |
+ * | ldimm, dst, imm32;             | Load immediate into dst. (zero-extend) |
+ * | ldimms, dst, imm;              | Load immediate into dst.               |
  * | lds, size, src, dst,           | Load data of a specified size from     |
  * |          offset;               | memory and sign-extend it into the dst,|
  * |                                | using the memory address calculated as |
@@ -601,7 +602,7 @@ RVOP(
     GEN({
         mem;
         rald, VR0, rs1;
-        ldimm, TMP, mem;
+        ldimms, TMP, mem;
         alu64, 0x01, VR0, TMP;
         map, VR1, rd;
         lds, S8, TMP, VR1, 0;
@@ -618,7 +619,7 @@ RVOP(
     GEN({
         mem;
         rald, VR0, rs1;
-        ldimm, TMP, mem;
+        ldimms, TMP, mem;
         alu64, 0x01, VR0, TMP;
         map, VR1, rd;
         lds, S16, TMP, VR1, 0;
@@ -635,7 +636,7 @@ RVOP(
     GEN({
         mem;
         rald, VR0, rs1;
-        ldimm, TMP, mem;
+        ldimms, TMP, mem;
         alu64, 0x01, VR0, TMP;
         map, VR1, rd;
         ld, S32, TMP, VR1, 0;
@@ -651,7 +652,7 @@ RVOP(
     GEN({
         mem;
         rald, VR0, rs1;
-        ldimm, TMP, mem;
+        ldimms, TMP, mem;
         alu64, 0x01, VR0, TMP;
         map, VR1, rd;
         ld, S8, TMP, VR1, 0;
@@ -668,7 +669,7 @@ RVOP(
     GEN({
         mem;
         rald, VR0, rs1;
-        ldimm, TMP, mem;
+        ldimms, TMP, mem;
         alu64, 0x01, VR0, TMP;
         map, VR1, rd;
         ld, S16, TMP, VR1, 0;
@@ -690,7 +691,7 @@ RVOP(
     GEN({
         mem;
         rald, VR0, rs1;
-        ldimm, TMP, mem;
+        ldimms, TMP, mem;
         alu64, 0x01, VR0, TMP;
         rald, VR1, rs2;
         st, S8, VR1, TMP, 0;
@@ -707,7 +708,7 @@ RVOP(
     GEN({
         mem;
         rald, VR0, rs1;
-        ldimm, TMP, mem;
+        ldimms, TMP, mem;
         alu64, 0x01, VR0, TMP;
         rald, VR1, rs2;
         st, S16, VR1, TMP, 0;
@@ -724,7 +725,7 @@ RVOP(
     GEN({
         mem;
         rald, VR0, rs1;
-        ldimm, TMP, mem;
+        ldimms, TMP, mem;
         alu64, 0x01, VR0, TMP;
         rald, VR1, rs2;
         st, S32, VR1, TMP, 0;
@@ -2034,7 +2035,7 @@ RVOP(
     GEN({
         mem;
         rald, VR0, rs1;
-        ldimm, TMP, mem;
+        ldimms, TMP, mem;
         alu64, 0x01, VR0, TMP;
         map, VR1, rd;
         ld, S32, TMP, VR1, 0;
@@ -2055,7 +2056,7 @@ RVOP(
     GEN({
         mem;
         rald, VR0, rs1;
-        ldimm, TMP, mem;
+        ldimms, TMP, mem;
         alu64, 0x01, VR0, TMP;
         rald, VR1, rs2;
         st, S32, VR1, TMP, 0;
@@ -2443,7 +2444,7 @@ RVOP(
     GEN({
         mem;
         rald, VR0, rv_reg_sp;
-        ldimm, TMP, mem;
+        ldimms, TMP, mem;
         alu64, 0x01, VR0, TMP;
         map, VR1, rd;
         ld, S32, TMP, VR1, 0;
@@ -2552,7 +2553,7 @@ RVOP(
     GEN({
         mem;
         rald, VR0, rv_reg_sp;
-        ldimm, TMP, mem;
+        ldimms, TMP, mem;
         alu64, 0x01, VR0, TMP;
         rald, VR1, rs2;
         st, S32, VR1, TMP, 0;

--- a/tests/arch-test-target/setup.py
+++ b/tests/arch-test-target/setup.py
@@ -3,7 +3,7 @@ import argparse
 import ruamel.yaml
 
 # setup the ISA config file
-def setup_testlist(riscv_device):
+def setup_testlist(riscv_device, hw_data_misaligned_support):
     # ISA config file path
     ispec = constants.root + '/rv32emu/rv32emu_isa.yaml'
     misa = 0x40000000
@@ -51,6 +51,9 @@ def setup_testlist(riscv_device):
             raise SystemExit(1)
 
     file['hart0']['ISA'] = ISA
+    file['hart0']['hw_data_misaligned_support'] = (
+        True if hw_data_misaligned_support == "1" else False
+    )
     file['hart0']['misa']['reset-val'] = misa
 
     with open(ispec, 'w+') as outfile:
@@ -73,7 +76,12 @@ if __name__=="__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--riscv_device', help='the ISA will test',
                         default='IMACZicsrZifencei')
+    parser.add_argument(
+        "--hw_data_misaligned_support",
+        help="whether the hardware data misalgnment is implemented or not",
+        default="1",
+    )
     args = parser.parse_args()
 
-    setup_testlist(args.riscv_device)
+    setup_testlist(args.riscv_device, args.hw_data_misaligned_support)
     setup_config()

--- a/tools/gen-jit-template.py
+++ b/tools/gen-jit-template.py
@@ -218,14 +218,21 @@ for i in range(len(op)):
                 asm = "emit_alu32(state, {}, {}, {});".format(
                     items[1], items[2], items[3])
             elif items[0] == "ldimm":
-                if items[2] == "mem":
-                    asm = "emit_load_imm(state, {}, (intptr_t) (m->mem_base + ir->imm));".format(
-                        items[1])
-                elif len(items) == 4:
+                if len(items) == 4:
                     asm = "emit_load_imm(state, {}, {} + {});".format(
                         items[1], items[2], items[3])
                 else:
                     asm = "emit_load_imm(state, {}, {});".format(
+                        items[1], items[2])
+            elif items[0] == "ldimms":
+                if items[2] == "mem":
+                    asm = "emit_load_imm_sext(state, {}, (intptr_t) (m->mem_base + ir->imm));".format(
+                        items[1])
+                elif len(items) == 4:
+                    asm = "emit_load_imm_sext(state, {}, {} + {});".format(
+                        items[1], items[2], items[3])
+                else:
+                    asm = "emit_load_imm_sext(state, {}, {});".format(
                         items[1], items[2])
             elif items[0] == "lds":
                 if (items[3] == "X"):


### PR DESCRIPTION
The JIT architecture test enables `ARCH_TEST` feature, and the build process of Sail RISC-V model is removed from the GitHub Actions.

The 32-bit immediate value that relates to PC should be interpreted as the unsigned number and be zero-extended to the length of the width of host register. Others which relate to the memory address or negative immediate value should be sign-extended to `__SIZEOF_POINTER__`.

To keep consistence, the load/store instruction to/from the x0 register should be explicitly set to zero value. 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR implements architecture testing support for the JIT compiler by introducing ARCH_TEST feature and improving immediate value handling. The changes include proper handling of sign/zero extension for immediate values and explicit handling of x0 register operations. The build system has been enhanced to support aarch64/Linux platforms and handle prebuilt artifacts more efficiently. Testing infrastructure expanded to include RV32E and JIT-specific test scenarios.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 4
</div>