### PR TITLE
Ensure Compatibility with BSD sha1sum implementation

### DIFF
--- a/mk/external.mk
+++ b/mk/external.mk
@@ -68,7 +68,7 @@ define verify
                 | sort \
                 | $(SHA1SUM) \
                 | cut -f 1 -d ' ' > $(SHA1_FILE2) && cmp $(SHA1_FILE1) $(SHA1_FILE2))), \
-            ($(eval VERIFIER := echo "$(strip $(1))  $(strip $(2))" | $(SHA1SUM) -c)) \
+            ($(eval VERIFIER := (ls $(2) >/dev/null 2>&1 || echo FAILED) && echo "$(strip $(1))  $(strip $(2))" | $(SHA1SUM) -c -)) \
     ))
     $(eval _ := $(shell $(VERIFIER) 2>&1))
     $(eval _ := \


### PR DESCRIPTION
Recent macOS updates introduced `/sbin/sha1sum`, which is not GNU's `sha1sum` and is incompatible with its implementation. This causes the sha1sum test in `make artifact` to always pass because the test currently relies on detecting the string "FAILED" in the stderr output.

Apple's `sha1sum` does not support the -c (checksum verification) option, making it unsuitable for verifying artifact integrity. Below is a demonstration of the differences between Apple's and GNU's `sha1sum`:
```shell
MACOS$ echo "CONTENT" > file
MACOS$ sha1sum file
7a2ed3b06b4ecf87d3a31966d8c17a9afb6634d9  file
MACOS$ echo "NOT ORIGINAL CONTENT" > file
MACOS$ echo "7a2ed3b06b4ecf87d3a31966d8c17a9afb6634d9  file" | sha1sum -c
usage: sha1sum [-bctwz] [files ...]
MACOS$ sha1sum --version
sha1sum (Darwin) 1.0
MACOS$ gsha1sum --version # by brew install coreutils
gsha1sum --version
sha1sum (GNU coreutils) 9.6
Copyright (C) 2025 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Ulrich Drepper, Scott Miller, and David Madore.
```
```shell
LINUX$ echo "CONTENT" > file
LINUX$ sha1sum file
7a2ed3b06b4ecf87d3a31966d8c17a9afb6634d9  file
LINUX$ echo "NOT ORIGINAL CONTENT" > file
LINUX$ echo "7a2ed3b06b4ecf87d3a31966d8c17a9afb6634d9  file" | sha1sum -c
file: FAILED
sha1sum: WARNING: 1 computed checksum did NOT match
LINUX$ sha1sum --version
sha1sum (GNU coreutils) 9.4
Copyright (C) 2023 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Ulrich Drepper, Scott Miller, and David Madore.
```