### PR TITLE
CI: Bump prebuilt GNU Toolchains

### DIFF
--- a/.ci/riscv-toolchain-install.sh
+++ b/.ci/riscv-toolchain-install.sh
@@ -9,12 +9,12 @@ check_platform
 mkdir -p toolchain
 
 if [[ "$#" == "0" ]] || [[ "$1" != "riscv-collab" ]]; then
-    GCC_VER=14.2.0-2
+    GCC_VER=14.2.0-3
     TOOLCHAIN_REPO=https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack
     TOOLCHAIN_URL=${TOOLCHAIN_REPO}/releases/download/v${GCC_VER}/xpack-riscv-none-elf-gcc-${GCC_VER}-linux-x64.tar.gz
 else
     UBUNTU_VER=`lsb_release -r | cut -f2`
-    GCC_VER=2024.11.22
+    GCC_VER=2025.01.20
     TOOLCHAIN_REPO=https://github.com/riscv-collab/riscv-gnu-toolchain
     TOOLCHAIN_URL=${TOOLCHAIN_REPO}/releases/download/${GCC_VER}/riscv32-elf-ubuntu-${UBUNTU_VER}-gcc-nightly-${GCC_VER}-nightly.tar.xz
 fi


### PR DESCRIPTION
xPack GNU RISC-V Embedded GCC v14.2.0-3 release adds two new multilibs, rv32ec/ilp32e and rv32imc/ilp32.

In addition, recent riscv-collab builds use 'gc' to replace 'imafdc' in multilib.