### PR TITLE
Trap guestOS to run SDL-oriented applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ $ make ENABLE_SYSTEM=1
 $ build/rv32emu -k <kernel_img_path> -i <rootfs_img_path>
 ```
 
+Build with a larger INITRD_SIZE (e.g., 64 MiB) to run SDL-oriented application because the default 8 MiB is insufficient for SDL-oriented application artifacts:
+```shell
+$ make system ENABLE_SYSTEM=1 ENABLE_SDL=1 INITRD_SIZE=64
+```
+Once login the guestOS, run `doom-riscv` or `quake` or `smolnes`. To terminate SDL-oriented applications, use the built-in exit utility, ctrl-c or the SDL window close button(X).
+
 #### Build Linux image
 An automated build script is provided to compile the RISC-V cross-compiler, Busybox, and Linux kernel from source. Please note that it only supports the Linux host environment. It can be found at tools/build-linux-image.sh.
 ```

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -1299,7 +1299,22 @@ void ecall_handler(riscv_t *rv)
     syscall_handler(rv);
 #elif RV32_HAS(SYSTEM)
     if (rv->priv_mode == RV_PRIV_U_MODE) {
-        SET_CAUSE_AND_TVAL_THEN_TRAP(rv, ECALL_U, 0);
+        switch (rv_get_reg(
+            rv,
+            rv_reg_a7)) { /* trap guestOS's SDL-oriented application syscall */
+        case 0xBEEF:
+        case 0xC0DE:
+        case 0xFEED:
+        case 0xBABE:
+        case 0xD00D:
+        case 93:
+            syscall_handler(rv);
+            rv->PC += 4;
+            break;
+        default:
+            SET_CAUSE_AND_TVAL_THEN_TRAP(rv, ECALL_U, 0);
+            break;
+        }
     } else if (rv->priv_mode ==
                RV_PRIV_S_MODE) { /* trap to SBI syscall handler */
         rv->PC += 4;

--- a/src/syscall.c
+++ b/src/syscall.c
@@ -132,9 +132,20 @@ error_handler:
     rv_set_reg(rv, rv_reg_a0, -1);
 }
 
-
 static void syscall_exit(riscv_t *rv)
 {
+#if RV32_HAS(SDL) && RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+    /*
+     * The guestOS may repeatedly open and close the SDL window,
+     * and the user could close the application using the application’s
+     * built-in exit function. Need to trap the built-in exit and
+     * ensure the SDL window and SDL mixer are destroyed properly.
+     */
+    extern void sdl_video_audio_cleanup();
+    sdl_video_audio_cleanup();
+    return;
+#endif
+
     /* simply halt cpu and save exit code.
      * the application decides the usage of exit code
      */

--- a/src/system.c
+++ b/src/system.c
@@ -118,8 +118,6 @@ enum SUPPORTED_MMIO {
     } while (0)
 #endif
 
-uint32_t ppn;
-uint32_t offset;
 static bool ppn_is_valid(riscv_t *rv, uint32_t ppn)
 {
     vm_attr_t *attr = PRIV(rv);
@@ -139,7 +137,7 @@ static bool ppn_is_valid(riscv_t *rv, uint32_t ppn)
  * @level: the level of which the PTE is located
  * @return: NULL if a not found or fault else the corresponding PTE
  */
-uint32_t *mmu_walk(riscv_t *rv, const uint32_t vaddr, uint32_t *level)
+pte_t *mmu_walk(riscv_t *rv, const uint32_t vaddr, uint32_t *level)
 {
     vm_attr_t *attr = PRIV(rv);
     uint32_t ppn = rv->csr_satp & MASK(22);
@@ -259,6 +257,8 @@ MMU_FAULT_CHECK_IMPL(ifetch, pagefault_insn)
 MMU_FAULT_CHECK_IMPL(read, pagefault_load)
 MMU_FAULT_CHECK_IMPL(write, pagefault_store)
 
+uint32_t ppn;
+uint32_t offset;
 #define get_ppn_and_offset()                                   \
     do {                                                       \
         assert(pte);                                           \


### PR DESCRIPTION
To trap the guest OS SDL applications, virtual memory translation should be handled when accessing the bidirectional event queues in syscall_sdl.c. Additionally, when using the guest OS, the SDL application might be launched and terminated multiple times. To enhance the user experience, it is heuristic to properly handle three main types of exits:
1, SDL application built-in exit: The source code of the SDL application should be modified to call the syscall_exit(syscall number: 93) somewhere when executing cleanup routine before exit().
2. Ctrl-c (SIGINT) exit: Detect the ctrl-c keycode.
3. SDL window Quit event: The source code of the SDL application should be modified to call the syscall_exit(syscall number: 93) when receiving SDL window Quit event.

The main reason for handling these three types of exits is that SDL2_Mixer may malfunction if not properly initialized and destroyed, as it runs on the host side not on the guest side. Additionally, when terminating an SDL application in the guest OS, the previous SDL window should be closed.

Moreover, the default audio backend of SDL2_Mixer(downloadable from brew or Linux distro pkg managers), FluidSynth, occasionally generates the warning: "fluidsynth: warning: Ringbuffer full, try increasing synth.polyphony!" This issue causes the audio to hang, leading to an unstable playback experience. Thus, dropping FluidSynth in favor of the Timidity backend, which provides a stable audio playback experience.

Known issue: Calling SDL_DestroyWindow() on macOS does not close the previous SDL window.

Close: #510

## Note that the following steps are conducted on Ubuntu 22.04 x86-64 machine

### Build SDL2_Mixer from source
1. Download [https://github.com/libsdl-org/SDL_mixer](https://github.com/libsdl-org/SDL_mixer) and checkout to commit `de7b2f4d2a7e78db363cb26a66df4da1f9524e25`

2. Disable FluidSynth
```diff
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ endif()
 
 option(SDL2MIXER_MIDI "Enable MIDI music" ON)
 
-cmake_dependent_option(SDL2MIXER_MIDI_FLUIDSYNTH "Support FluidSynth MIDI output" ON "SDL2MIXER_MIDI;NOT SDL2MIXER_VENDORED" OFF)
+cmake_dependent_option(SDL2MIXER_MIDI_FLUIDSYNTH "Support FluidSynth MIDI output" OFF "SDL2MIXER_MIDI;NOT SDL2MIXER_VENDORED" OFF)
 cmake_dependent_option(SDL2MIXER_MIDI_FLUIDSYNTH_SHARED "Dynamically load libfluidsynth" "${SDL2MIXER_DEPS_SHARED}" SDL2MIXER_MIDI_FLUIDSYNTH OFF)
 
 if(WIN32 OR APPLE OR HAIKU)
```
3. Build (note that this will override the pre-installed SDL2_Mixer)
**Might need to install some dependency library(see the error logs if it shows)**
```
$ mkdir -p build && cd build && cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_INCLUDEDIR=include && make -j$(nproc) && sudo make install 
```
4. Download [timidity's GUS patches](http://www.libsdl.org/projects/mixer/timidity/timidity.tar.gz) which from the [README](https://github.com/libsdl-org/SDL_mixer) of SDL2_Mixer.
5. Extract `timidity/*` into `/etc/` directory.

### Testing procedure
1. Unzip Image.zip and rootfs.cpio.zip to desired path.
[Image.zip](https://github.com/user-attachments/files/18625811/Image.zip)
[rootfs.cpio.zip](https://drive.google.com/file/d/19f8aZMyE6vN__QxwsvRLKVquKiNTPkpF/view?usp=sharing)

2. Build rv32emu
```
$ make INITRD_SIZE=64 ENABLE_SYSTEM=1 ENABLE_SDL=1 -j$(nproc)
```

3. Run rv32emu with provided Image and rootfs.cpio
```
$ build/rv32emu -k <kernel_img_path> -i <rootfs_img_path>
```
4. Run SDL-oriented application in guestOS (`doom-riscv` or `quake` or `smolnes`)
```
# doom-riscv
```

### Expectation
Three SDL-oriented applications should be runable and can be exited with all three types of exits without any crash.


## Update: (SDL2_mixer build from source on macOS/arm64)
The 1, 2, 4, 5 steps are same to Linux host, but a tiny change to step 3:
3. Build (note that this will override the pre-installed SDL2_Mixer)
**Might need to install some dependency library(see the error logs if it shows)**
```
$ mkdir -p build && cd build && cmake .. -DCMAKE_INSTALL_PREFIX=/opt/homebrew -DCMAKE_INSTALL_INCLUDEDIR=include && make -j$(sysctl -n hw.logicalcpu) && sudo make install 
```