### PR TITLE
CI: Specify larger INITRD_SIZE for larger rootfs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -229,7 +229,7 @@ jobs:
       env:
         CC: ${{ steps.install_cc.outputs.cc }}
       run: |
-            make clean && make ENABLE_SYSTEM=1 && make ENABLE_SYSTEM=1 artifact -j$(nproc)
+            make distclean && make INITRD_SIZE=32 ENABLE_SYSTEM=1 -j$(nproc) && make ENABLE_SYSTEM=1 artifact -j$(nproc)
             .ci/boot-linux.sh
             make ENABLE_SYSTEM=1 clean
       if: ${{ always() }}


### PR DESCRIPTION
Since 515e011 enable the guestOS to run SDL-oriented applications, the artifacts for these applications must be prepared in the rootfs to ensure they can run, making the rootfs larger than before which exceeds the default 8 MiB INITRD_SIZE allocated for loading the rootfs.