### PR TITLE
Allow macOS build

### DIFF
--- a/mk/common.mk
+++ b/mk/common.mk
@@ -10,6 +10,8 @@ ifeq ($(UNAME_M),x86_64)
     HOST_PLATFORM := x86
 else ifeq ($(UNAME_M),aarch64)
     HOST_PLATFORM := aarch64
+else ifeq ($(UNAME_M),arm64) # macOS
+    HOST_PLATFORM := arm64
 else
     $(error Unsupported platform.)
 endif


### PR DESCRIPTION
Commit 2ab8a68 failed to detect macOS/Arm64 properly, and commit 2e87a75 relied on the `.SHELLSTATUS` feature introduced in GNU make 4.2 (released on 2016-05-22). However, macOS ships with GNU make 3.81 by default, lacking of `.SHELLSTATUS`.

This commit fixes the macOS/Arm64 detection issue and reworks the build commands to run everything in a single shell invocation, capturing both the exit code and program output without relying on `.SHELLSTATUS`. 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR enhances macOS build compatibility through two main changes: implementing ARM64 architecture detection and refactoring Makefile command execution for better compatibility with macOS GNU make 3.81. The changes focus on maintaining existing functionality while improving cross-platform support.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>