### PR TITLE
Fix F register count to 32 for RV32E with F extension

### DIFF
--- a/src/riscv_private.h
+++ b/src/riscv_private.h
@@ -131,7 +131,7 @@ struct riscv_internal {
 
 #if RV32_HAS(EXT_F)
     /* float registers */
-    riscv_float_t F[N_RV_REGS];
+    riscv_float_t F[32];
     uint32_t csr_fcsr;
 #endif
 


### PR DESCRIPTION
According to RV32E Base Integer Instruction Set, Version 1.9 [1]:

RV32E can be combined with all current standard extensions. Defining the F, D, and Q extensions as having a 16-entry floating point register file when combined with RV32E was considered but decided against.

When RV32E is used with floating-point extensions, the floating-point register file should have 32 entries instead of N_RV_REGS (16).

Adjust array size accordingly.

[1] https://five-embeddev.com/riscv-user-isa-manual/Priv-v1.12/rv32e.html#rv32e 
 <div id='description'>
<h3>Summary by Bito</h3>
Fixed a critical bug in RISC-V implementation where floating-point register array size was incorrectly set to 16 for RV32E with F extension. Updated riscv_private.h to maintain 32 floating-point register entries as per RISC-V specification when RV32E is combined with floating-point extensions.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>