### PR TITLE
CI: Make apt-get more quiet

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -67,9 +67,9 @@ jobs:
           submodules: 'true'
       - name: Install dependencies
         run: |
-          sudo apt-get update -q -y
-          sudo apt-get upgrade -q -y
-          sudo apt-get install -q -y build-essential git
+          sudo apt-get update -q=2
+          sudo apt-get upgrade -q=2
+          sudo apt-get install -q=2 build-essential git
       - name: Build Linux image
         run: |
           make build-linux-image
@@ -107,9 +107,9 @@ jobs:
           submodules: 'true'
       - name: Install dependencies
         run: |
-          sudo apt-get update -q -y
-          sudo apt-get upgrade -q -y
-          sudo apt-get install -q -y gcc-multilib g++-multilib
+          sudo apt-get update -q=2
+          sudo apt-get upgrade -q=2
+          sudo apt-get install -q=2 gcc-multilib g++-multilib
           .ci/riscv-toolchain-install.sh
           echo "$PWD/toolchain/bin" >> $GITHUB_PATH
       - name: Build binaries

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,8 +45,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: install-dependencies
       run: |
-            sudo apt-get update -q -y
-            sudo apt-get install -q -y libsdl2-dev libsdl2-mixer-dev device-tree-compiler expect bc p7zip-full
+            sudo apt-get update -q=2
+            sudo apt-get install -q=2 libsdl2-dev libsdl2-mixer-dev device-tree-compiler expect bc p7zip-full
             .ci/riscv-toolchain-install.sh
             echo "${{ github.workspace }}/toolchain/bin" >> $GITHUB_PATH
             wget https://apt.llvm.org/llvm.sh
@@ -258,8 +258,8 @@ jobs:
         distro: ubuntu24.04
         # No 'sudo' is available
         install: |
-          apt-get update -q -y
-          apt-get install -q -y make git clang python3 python3-pip build-essential libsdl2-dev libsdl2-mixer-dev lsb-release wget software-properties-common gnupg bc
+          apt-get update -q=2
+          apt-get install -q=2 make git clang python3 python3-pip build-essential libsdl2-dev libsdl2-mixer-dev lsb-release wget software-properties-common gnupg bc
           git config --global --add safe.directory ${{ github.workspace }}
           git config --global --add safe.directory ${{ github.workspace }}/src/softfloat
           git config --global --add safe.directory ${{ github.workspace }}/src/mini-gdbstub
@@ -285,7 +285,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: coding convention
       run: |
-            sudo apt-get install -q -y clang-format-18
+            sudo apt-get install -q=2 clang-format-18
             .ci/check-newline.sh
             .ci/check-format.sh
       shell: bash
@@ -299,12 +299,12 @@ jobs:
     # LLVM static analysis
     - name: set up scan-build
       run: |
-            sudo apt-get update -q -y
-            sudo apt-get install -q -y libsdl2-dev libsdl2-mixer-dev
+            sudo apt-get update -q=2
+            sudo apt-get install -q=2 libsdl2-dev libsdl2-mixer-dev
             wget https://apt.llvm.org/llvm.sh
             chmod +x ./llvm.sh
             sudo ./llvm.sh 18
-            sudo apt-get install -q -y clang-18 clang-tools-18
+            sudo apt-get install -q=2 clang-18 clang-tools-18
       shell: bash
     - name: run scan-build without JIT
       run: make distclean && scan-build-18 -v -o ~/scan-build --status-bugs --use-cc=clang-18 --force-analyze-debug-code --show-description -analyzer-config stable-report-filename=true -enable-checker valist,nullability make ENABLE_EXT_F=0 ENABLE_SDL=0 ENABLE_JIT=0


### PR DESCRIPTION
Quote apt-get manual:
> use -q=# to set the quiet level ... quiet level 2 implies -y

The condensed apt-get messages will make troubleshooting problems easier to diagnose. 
 <div id='description'>
<h3>Summary by Bito</h3>
Implementation of quiet mode in CI pipeline configuration to reduce apt-get output verbosity. Added documentation comments and modified apt-get parameters to use quiet level 2, resulting in more concise and manageable CI logs for improved troubleshooting efficiency.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>