### PR TITLE
Suppress logging outputs to honor -q option

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -273,6 +273,9 @@ int main(int argc, char **args)
     attr.data.user.elf_program = opt_prog_name;
 #endif
 
+    /* enable or disable the logging outputs */
+    rv_log_set_quiet(opt_quiet_outputs);
+
     /* create the RISC-V runtime */
     rv = rv_create(&attr);
     if (!rv) {

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -417,9 +417,6 @@ riscv_t *rv_create(riscv_user_t rv_attr)
     rv_log_set_level(attr->log_level);
     rv_log_info("Log level: %s", rv_log_level_string(attr->log_level));
 
-    /* enable the log */
-    rv_log_set_quiet(false);
-
 #if !RV32_HAS(SYSTEM) || (RV32_HAS(SYSTEM) && RV32_HAS(ELF_LOADER))
     elf_t *elf = elf_new();
     assert(elf);


### PR DESCRIPTION
After introducing log.[ch] in 2e87a75, the behavior of -q option is not honored. This fix it.

Close #561 
 <div id='description'>
<h3>Summary by Bito</h3>
Bug fix implementation for the quiet mode (-q) option by relocating logging control from riscv.c to main.c. The change removes hardcoded logging in riscv.c and implements proper control through the opt_quiet_outputs flag in main.c, ensuring the -q command-line option functions correctly.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>