### PR TITLE
Consolidate helper functions for pretty messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -408,14 +408,18 @@ endif
 endif
 
 clean:
-	$(RM) $(BIN) $(OBJS) $(DEV_OBJS) $(BUILD_DTB) $(BUILD_DTB2C) $(HIST_BIN) $(HIST_OBJS) $(deps) $(WEB_FILES) $(CACHE_OUT) src/rv32_jit.c
-	-$(RM) $(SOFTFLOAT_LIB)
+	$(VECHO) "Cleaning... "
+	$(Q)$(RM) $(BIN) $(OBJS) $(DEV_OBJS) $(BUILD_DTB) $(BUILD_DTB2C) $(HIST_BIN) $(HIST_OBJS) $(deps) $(WEB_FILES) $(CACHE_OUT) src/rv32_jit.c
+	$(Q)-$(RM) $(SOFTFLOAT_LIB)
+	$(Q)$(call notice, [OK])
 distclean: clean
-	$(RM) -r $(OUT)/id1
-	$(RM) -r $(DEMO_DIR)
-	$(RM) *.zip
-	$(RM) -r $(OUT)/mini-gdbstub
-	-$(RM) $(OUT)/.config
-	-$(RM) -r $(SOFTFLOAT_DUMMY_PLAT) $(OUT)/softfloat
+	$(VECHO) "Deleting all generated files... "
+	$(Q)$(RM) -r $(OUT)/id1
+	$(Q)$(RM) -r $(DEMO_DIR)
+	$(Q)$(RM) *.zip
+	$(Q)$(RM) -r $(OUT)/mini-gdbstub
+	$(Q)-$(RM) $(OUT)/.config
+	$(Q)-$(RM) -r $(SOFTFLOAT_DUMMY_PLAT) $(OUT)/softfloat
+	$(Q)$(call notice, [OK])
 
 -include $(deps)

--- a/mk/artifact.mk
+++ b/mk/artifact.mk
@@ -41,7 +41,7 @@ SHELL_HACK := $(shell mkdir -p $(BIN_DIR)/linux-x86-softfp $(BIN_DIR)/riscv32 $(
 # $(3): name showing in terminal
 define fetch-releases-tag
     $(if $(wildcard $(BIN_DIR)/$(2)), \
-        $(info $(3) is found. Skipping downloading.), \
+        $(info $(call warnx, $(3) is found. Skipping downloading.)), \
         $(eval LATEST_RELEASE := $(shell wget -q https://api.github.com/repos/sysprog21/rv32emu-prebuilt/releases -O- \
                                     | grep '"tag_name"' \
                                     | grep "$(1)" \
@@ -59,7 +59,7 @@ ifeq ($(call has, PREBUILT), 1)
     else ifeq ($(call has, ARCH_TEST), 1)
         $(call fetch-releases-tag,sail,rv32emu-prebuilt-sail-$(HOST_PLATFORM),Sail model)
     else
-        $(call fetch-releases-tag,ELF,rv32emu-prebuilt.tar.gz,Prebuilt benchmark)
+        $(call fetch-releases-tag,ELF,rv32emu-prebuilt.tar.gz,Prebuilt blob)
     endif
 
     PREBUILT_BLOB_URL = https://github.com/sysprog21/rv32emu-prebuilt/releases/download/$(LATEST_RELEASE)
@@ -112,14 +112,16 @@ endif
 
 ifeq ($(call has, ARCH_TEST), 1)
 	$(Q)if [ "$(RES)" = "1" ]; then \
-	    $(PRINTF) "\n$(YELLOW)SHA-1 verification failed! Re-fetching prebuilt binaries from \"rv32emu-prebuilt\" ...\n$(NO_COLOR)"; \
+	    $(call warn, SHA-1 verification failed!); \
+	    $(PRINTF) "Re-fetching prebuilt binaries from \"rv32emu-prebuilt\" ...\n"; \
 	    wget -q --show-progress $(PREBUILT_BLOB_URL)/$(RV32EMU_PREBUILT_TARBALL) -O build/$(RV32EMU_PREBUILT_TARBALL); \
 	else \
 	    $(call notice, [OK]); \
 	fi
 else
 	$(Q)if [ "$(RES)" = "1" ]; then \
-	    $(PRINTF) "\n$(YELLOW)SHA-1 verification failed! Re-fetching prebuilt binaries from \"rv32emu-prebuilt\" ...\n$(NO_COLOR)"; \
+	    $(call warn, SHA-1 verification failed!); \
+	    $(PRINTF) "Re-fetching prebuilt binaries from \"rv32emu-prebuilt\" ...\n"; \
 	    wget -q --show-progress $(PREBUILT_BLOB_URL)/$(RV32EMU_PREBUILT_TARBALL) -O build/$(RV32EMU_PREBUILT_TARBALL); \
 	    tar --strip-components=1 -zxf build/$(RV32EMU_PREBUILT_TARBALL) -C build; \
 	else \
@@ -172,14 +174,14 @@ ifeq ($(call has, SYSTEM), 1)
 		$(Q)wget -q -O $(BIN_DIR)/sha1sum-linux-image $(PREBUILT_BLOB_URL)/sha1sum-linux-image
 		$(Q)$(call notice, [OK])
     else
-		$(Q)$(PRINTF) "Skipped\n"
+		$(Q)$(call warn, skipped)
     endif
 else ifeq ($(call has, ARCH_TEST), 1)
     ifeq ($(wildcard $(BIN_DIR)/rv32emu-prebuilt-sail-$(HOST_PLATFORM)),)
 		$(Q)wget -q -O $(BIN_DIR)/rv32emu-prebuilt-sail-$(HOST_PLATFORM).sha $(PREBUILT_BLOB_URL)/rv32emu-prebuilt-sail-$(HOST_PLATFORM).sha
 		$(Q)$(call notice, [OK])
     else
-		$(Q)$(PRINTF) "Skipped\n"
+		$(Q)$(call warn, skipped)
     endif
 else
     ifeq ($(wildcard $(BIN_DIR)/rv32emu-prebuilt.tar.gz),)
@@ -187,7 +189,7 @@ else
 		$(Q)wget -q -O $(BIN_DIR)/sha1sum-riscv32 $(PREBUILT_BLOB_URL)/sha1sum-riscv32
 		$(Q)$(call notice, [OK])
     else
-		$(Q)$(PRINTF) "Skipped\n"
+		$(Q)$(call warn , skipped)
     endif
 endif
 endif

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -43,13 +43,15 @@ $(eval CFLAGS += -D RV32_FEATURE_$(strip $1)=$(call has, $1))
 endef
 
 # Test suite
-PASS_COLOR = \e[32;01m
-NO_COLOR = \e[0m
 GREEN = \033[32m
 YELLOW = \033[33m
 NC = \033[0m
 
-notice = $(PRINTF) "$(PASS_COLOR)$(strip $1)$(NO_COLOR)\n"
+notice = $(PRINTF) "$(GREEN)$(strip $1)$(NC)\n"
+noticex = $(shell echo "$(GREEN)$(strip $1)$(NC)\n")
+warn = $(PRINTF) "$(YELLOW)$(strip $1)$(NC)\n"
+# Used inside $(warning) or $(error)
+warnx = $(shell echo "$(YELLOW)$(strip $1)$(NC)\n")
 
 # File utilities
 SHA1SUM = sha1sum

--- a/mk/system.mk
+++ b/mk/system.mk
@@ -18,7 +18,8 @@ $(BIN_TO_C): tools/bin2c.c
 
 BUILD_DTB2C := src/minimal_dtb.h
 $(BUILD_DTB2C): $(BIN_TO_C) $(BUILD_DTB)
-	$(BIN_TO_C) $(BUILD_DTB) > $(BUILD_DTB2C)
+	$(VECHO) "  BIN2C\t$@\n"
+	$(Q)$(BIN_TO_C) $(BUILD_DTB) > $@
 
 $(DEV_OUT)/%.o: $(DEV_SRC)/%.c $(deps_emcc)
 	$(Q)mkdir -p $(DEV_OUT)

--- a/mk/wasm.mk
+++ b/mk/wasm.mk
@@ -81,16 +81,16 @@ FIREFOX_MAJOR := $(shell $(FIREFOX_MAJOR_VERSION_CHECK_CMD))
 
 # Chrome
 ifeq ($(shell echo $(CHROME_MAJOR)\>=$(CHROME_SUPPORT_TCO_AT_MAJOR) | bc), 1)
-    $(info $(shell echo "$(GREEN)$(CHROME_SUPPORT_TCO_INFO)$(NC)"))
+    $(info $(call noticex, $(CHROME_SUPPORT_TCO_INFO)))
 else
-    $(warning $(shell echo "$(YELLOW)$(CHROME_NO_SUPPORT_TCO_WARNING)$(NC)"))
+    $(warning $(call warnx, $(CHROME_NO_SUPPORT_TCO_WARNING)))
 endif
 
 # Firefox
 ifeq ($(shell echo $(FIREFOX_MAJOR)\>=$(FIREFOX_SUPPORT_TCO_AT_MAJOR) | bc), 1)
-    $(info $(shell echo "$(GREEN)$(FIREFOX_SUPPORT_TCO_INFO)$(NC)"))
+    $(info $(call noticex, $(FIREFOX_SUPPORT_TCO_INFO)))
 else
-    $(warning $(shell echo "$(YELLOW)$(FIREFOX_NO_SUPPORT_TCO_WARNING)$(NC)"))
+    $(warning $(call warnx, $(FIREFOX_NO_SUPPORT_TCO_WARNING)))
 endif
 
 # Safari
@@ -100,9 +100,9 @@ SAFARI_VERSION := $(shell $(SAFARI_VERSION_CHECK_CMD))
 SAFARI_MAJOR := $(shell echo $(SAFARI_VERSION) | cut -f1 -d.)
 SAFARI_MINOR := $(shell echo $(SAFARI_VERSION) | cut -f2 -d.)
 ifeq ($(shell echo "$(SAFARI_MAJOR).$(SAFARI_MINOR)>=$(SAFARI_SUPPORT_TCO_AT_MAJOR_MINOR)" | bc), 1)
-    $(info $(shell echo "$(GREEN)$(SAFARI_SUPPORT_TCO_INFO)$(NC)"))
+    $(info $(call noticex, $(SAFARI_SUPPORT_TCO_INFO)))
 else
-    $(warning $(shell echo "$(YELLOW)$(SAFARI_NO_SUPPORT_TCO_WARNING)$(NC)"))
+    $(warning $(call warnx, $(SAFARI_NO_SUPPORT_TCO_WARNING)))
 endif
 endif
 


### PR DESCRIPTION
This commit provides variants of 'notice' function:
  - notice(x) : colored as green
  - warn(x) : colored as yellow

The suffix 'x' indicates the use as function calls in Makefile. 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR implements a unified message formatting system for build output, introducing color-coded helper functions for standardized notice and warning messages. The changes consolidate multiple printf statements into consistent notice and warning functions, with support for both regular and shell-specific variants. The implementation uses green coloring for notices and yellow for warnings, improving build output readability.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>