### PR TITLE
Return error code -1 when closing file descriptors < 3 (stdin, stdout, stderr)

### DIFF
--- a/src/emulate.c
+++ b/src/emulate.c
@@ -1078,11 +1078,17 @@ void rv_step(void *arg)
         assert(block->satp == rv->csr_satp);
 #endif
 
-        /* After emulating the previous block, it is determined whether the
-         * branch is taken or not. The IR array of the current block is then
-         * assigned to either the branch_taken or branch_untaken pointer of
-         * the previous block.
-         */
+#if !RV32_HAS(SYSTEM)
+        /* on exit */
+        if (unlikely(block->ir_head->pc == PRIV(rv)->exit_addr))
+            PRIV(rv)->on_exit = true;
+#endif
+
+            /* After emulating the previous block, it is determined whether the
+             * branch is taken or not. The IR array of the current block is then
+             * assigned to either the branch_taken or branch_untaken pointer of
+             * the previous block.
+             */
 
 #if RV32_HAS(BLOCK_CHAINING)
         if (prev

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -434,6 +434,15 @@ riscv_t *rv_create(riscv_user_t rv_attr)
     if ((end = elf_get_symbol(elf, "_end")))
         attr->break_addr = end->st_value;
 
+#if !RV32_HAS(SYSTEM)
+    /* set not exiting */
+    attr->on_exit = false;
+
+    const struct Elf32_Sym *exit;
+    if ((exit = elf_get_symbol(elf, "exit")))
+        attr->exit_addr = exit->st_value;
+#endif
+
     assert(elf_load(elf, attr->mem));
 
     /* set the entry pc */

--- a/src/riscv.h
+++ b/src/riscv.h
@@ -548,6 +548,14 @@ typedef struct {
     /* the data segment break address */
     riscv_word_t break_addr;
 
+#if !RV32_HAS(SYSTEM)
+    /* the exit entry address */
+    riscv_word_t exit_addr;
+
+    /* flag to determine if the emulator exits the target program */
+    bool on_exit;
+#endif
+
     /* SBI timer */
     uint64_t timer;
 } vm_attr_t;


### PR DESCRIPTION
closes Issue #435

## Conflict in This Issue

1. Some user programs may need to close `stdout` or `stderr`.
2. rv32emu itself relies on `stdout` and `stderr` for its own output.

Because of these two needs, there is a conflict about how `close()` should behave when `fd < 3`.


### Solution : Do not actually close, but return an error code (-1)

**Advantages:**

- `stdout` and `stderr` remain open, so rv32emu can continue printing messages or logs.
- User programs get an error code, so they know the close operation was not successful. This avoids them thinking they successfully closed the output channels.
- After seeing the error, user programs can redirect output or do other error handling. This prevents confusion like “I thought it was closed, but it’s still printing.”

**Disadvantages:**

- This does not match real system behavior exactly. In a typical Unix-like system, calling `close(1)` or `close(2)` is allowed. Here, the emulator denies it to keep its own output working.

---

## Conclusion

To prevent a user program from thinking it closed `stdout` or `stderr` when it really did not, the simplest approach is **Solution **: do nothing but return an error code (`-1`). 

- This tells the user program that closing `fd < 3` failed, so it will not assume the channels are closed. 
- For most needs, where preserving emulator output is important (especially for debugging or analysis), this is a good compromise.

Since rv32emu is often used in teaching and research, being able to see the emulator’s own outputs is very helpful. Thus, returning `-1` is recommended by default. If needed, you can provide parameters or redirection mechanisms to allow truly closing the file descriptors in special cases. This maintains a good user experience while still letting people enable the more realistic behavior if they want.

PS: I save all details of implementation in this [document](https://hackmd.io/@KenHoryuKen/BJoTW9dYye). 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances the RISC-V emulator by modifying the syscall_close function to return an error code for standard file descriptors, preventing user programs from incorrectly assuming closure. Additional improvements to related functions support this behavior, enhancing the overall user experience.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>