### PR TITLE
Enable installing xPack toolchain on macOS/arm64

### DIFF
--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -1,20 +1,22 @@
-# Expect host is Linux/x86_64
+# Expect host is Linux/x86_64, Linux/aarch64, macOS/arm64
+
+MACHINE_TYPE=$(uname -m)
+OS_TYPE=$(uname -s)
+
 check_platform()
 {
-    MACHINE_TYPE=`uname -m`
-    OS_TYPE=`uname -s`
-
     case "${MACHINE_TYPE}/${OS_TYPE}" in
-        x86_64/Linux | aarch64/Linux)
-            ;;
-        Arm64/Darwin)
-            echo "Apple Silicon is not supported yet"
-            exit 1
+        x86_64/Linux | aarch64/Linux | arm64/Darwin)
             ;;
         *)
             echo "Unsupported platform: ${MACHINE_TYPE}/${OS_TYPE}"
             exit 1
             ;;
     esac
-
 }
+
+if [[ "${OS_TYPE}" == "Linux" ]]; then
+  PARALLEL=-j$(nproc)
+else
+  PARALLEL=-j$(sysctl -n hw.logicalcpu)
+fi

--- a/.ci/riscv-tests.sh
+++ b/.ci/riscv-tests.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+. .ci/common.sh
+
 set -e -u -o pipefail
 
 # Install RISCOF
@@ -7,9 +9,7 @@ pip3 install -r requirements.txt
 
 set -x
 
-export PATH=`pwd`/toolchain/bin:$PATH
-
-PARALLEL=-j$(nproc)
+export PATH=$(pwd)/toolchain/bin:$PATH
 
 make distclean
 # Rebuild with all RISC-V extensions

--- a/.ci/riscv-toolchain-install.sh
+++ b/.ci/riscv-toolchain-install.sh
@@ -5,20 +5,26 @@ set -e -u -o pipefail
 . .ci/common.sh
 
 check_platform
-
 mkdir -p toolchain
 
 if [[ "$#" == "0" ]] || [[ "$1" != "riscv-collab" ]]; then
     GCC_VER=14.2.0-3
     TOOLCHAIN_REPO=https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack
 
-    if [[ ${MACHINE_TYPE} == "x86_64" ]]; then
-        TOOLCHAIN_URL=${TOOLCHAIN_REPO}/releases/download/v${GCC_VER}/xpack-riscv-none-elf-gcc-${GCC_VER}-linux-x64.tar.gz
-    elif [[ ${MACHINE_TYPE} == "aarch64" ]]; then
-        TOOLCHAIN_URL=${TOOLCHAIN_REPO}/releases/download/v${GCC_VER}/xpack-riscv-none-elf-gcc-${GCC_VER}-linux-arm64.tar.gz
+    if [[ "${OS_TYPE}" == "Linux" ]]; then
+        case "${MACHINE_TYPE}" in
+            "x86_64")
+                TOOLCHAIN_URL=${TOOLCHAIN_REPO}/releases/download/v${GCC_VER}/xpack-riscv-none-elf-gcc-${GCC_VER}-linux-x64.tar.gz
+                ;;
+            "aarch64")
+                TOOLCHAIN_URL=${TOOLCHAIN_REPO}/releases/download/v${GCC_VER}/xpack-riscv-none-elf-gcc-${GCC_VER}-linux-arm64.tar.gz
+                ;;
+        esac
+    else # Darwin
+        TOOLCHAIN_URL=${TOOLCHAIN_REPO}/releases/download/v${GCC_VER}/xpack-riscv-none-elf-gcc-${GCC_VER}-darwin-arm64.tar.gz
     fi
 else
-    UBUNTU_VER=`lsb_release -r | cut -f2`
+    UBUNTU_VER=$(lsb_release -r | cut -f2)
     GCC_VER=2025.01.20
     TOOLCHAIN_REPO=https://github.com/riscv-collab/riscv-gnu-toolchain
     TOOLCHAIN_URL=${TOOLCHAIN_REPO}/releases/download/${GCC_VER}/riscv32-elf-ubuntu-${UBUNTU_VER}-gcc-nightly-${GCC_VER}-nightly.tar.xz


### PR DESCRIPTION
Darwin and arm64 are used to identify the operating system and ISA of Apple's dominant computer.

In addition, enhance shell compatibility by using $() instead of backticks for command execution. Furthermore, abstract common variables such as PARALLEL in .ci/common.sh. 

Related: #519 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR implements macOS/arm64 platform support in the toolchain infrastructure, updating platform detection logic and toolchain URL handling. The changes modernize shell script syntax and centralize common variables in common.sh. The modifications improve cross-platform compatibility and maintainability of the build system.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>