### PR TITLE
Address linter issues on Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19 as base_gcc
+FROM alpine:3.19 AS base_gcc
 
 RUN apk add --update alpine-sdk git wget
 
@@ -10,7 +10,7 @@ COPY . .
 RUN make ENABLE_SDL=0
 RUN make tool
 
-FROM alpine:3.19 as final
+FROM alpine:3.19 AS final
 
 # copy in elf files
 COPY ./build/*.elf /home/root/rv32emu/build/

--- a/docker/Dockerfile-gcc
+++ b/docker/Dockerfile-gcc
@@ -1,6 +1,6 @@
 # we align the version used in riscv-toolchain-install.sh
 
-FROM ubuntu:24.04 as base
+FROM ubuntu:24.04 AS base
 
 # for x86-64, we can optimize this part and take the upstream (nightly) build directly
 # for aarch64, we need to build from scratch because the upstream toolchain is only built for x86-64
@@ -16,7 +16,7 @@ RUN cd riscv-gnu-toolchain && \
     make -j$(nproc) newlib && \
     make clean
 
-FROM ubuntu:24.04 as final
+FROM ubuntu:24.04 AS final
 
 # Keep the GNU Toolchain files only
 COPY --from=base /opt/riscv/ /opt/riscv/

--- a/docker/Dockerfile-sail
+++ b/docker/Dockerfile-sail
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04 as base
+FROM ubuntu:24.04 AS base
 
 # The upstream reference emulator is built for x86-64, and the releases are pretty out of date
 # Thus, we build it ourselves for both x86-64 and aarch64
@@ -21,7 +21,7 @@ RUN cd sail-riscv && \
     make && \
     ARCH=RV32 make 
 
-FROM ubuntu:24.04 as final
+FROM ubuntu:24.04 AS final
 
 # keep the emulator only
 COPY --from=base /sail-riscv/c_emulator/riscv_sim_RV32 /home/root/riscv_sim_RV32


### PR DESCRIPTION
FromAsCasing: 'as' and 'FROM' keywords' casing do not match

More info: https://docs.docker.com/go/dockerfile/rule/from-as-casing/ 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request standardizes the casing of the 'as' keyword to 'AS' in multiple Dockerfiles, enhancing consistency with the 'FROM' keyword. Changes are made across the root Dockerfile, Dockerfile-gcc, and Dockerfile-sail, aligning with Docker's style guidelines and improving readability.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>