### PR TITLE
Remove redundant break

### DIFF
--- a/src/devices/uart.c
+++ b/src/devices/uart.c
@@ -106,7 +106,6 @@ uint32_t u8250_read(u8250_state_t *uart, uint32_t addr)
         return uart->lcr;
     case U8250_MCR:
         return uart->mcr;
-        break;
     case U8250_LSR:
         /* LSR = no error, TX done & ready */
         return (0x60 | (uint8_t) uart->in_ready);


### PR DESCRIPTION
<div id='description'>
<h3>Summary by Bito</h3>
This pull request improves code quality by removing a redundant break statement in the uart.c file, enhancing clarity without changing functionality. It contributes to cleaner and more maintainable code.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>