### PR TITLE
Allow emcc build and validate in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,11 @@ jobs:
       uses: rlalik/setup-cpp-compiler@master
       with:
         compiler: ${{ matrix.compiler }}
+    - name: Setup emsdk
+      uses: mymindstorm/setup-emsdk@v14
+      with:
+        version: 3.1.51
+        actions-cache-folder: 'emsdk-cache'
     - name: fetch artifact first to reduce HTTP requests
       env:
         CC: ${{ steps.install_cc.outputs.cc }}
@@ -65,6 +70,23 @@ jobs:
             make artifact
             make ENABLE_SYSTEM=1 artifact
             make ENABLE_ARCH_TEST=1 artifact
+            # Hack Cloudflare 403 Forbidden on GitHub Runner for Doom artifact download
+            wget --header="User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:122.0) Gecko/20100101 Firefox/122.0" \
+                 --header="Referer: https://www.doomworld.com/" \
+                 --header="Accept-Language: en-US,en;q=0.9" \
+                 -O build/shareware_doom_iwad.zip \
+                 "https://www.doomworld.com/3ddownloads/ports/shareware_doom_iwad.zip"
+            unzip -d build/ build/shareware_doom_iwad.zip
+      if: ${{ always() }}
+    - name: default build using emcc
+      run: |
+            make CC=emcc -j$(nproc)
+      if: ${{ always() }}
+    - name: default build for system emulation using emcc
+      run: |
+            make distclean
+            make CC=emcc ENABLE_SYSTEM=1 -j$(nproc)
+            make distclean ENABLE_SYSTEM=1
       if: ${{ always() }}
     - name: default build with -g
       env:

--- a/mk/system.mk
+++ b/mk/system.mk
@@ -12,9 +12,17 @@ $(BUILD_DTB): $(DEV_SRC)/minimal.dts
 	$(VECHO) " DTC\t$@\n"
 	$(Q)$(CC) -nostdinc -E -P -x assembler-with-cpp -undef $(CFLAGS_dt) $^ | $(DTC) - > $@
 
+# Assume the system has either GCC or Clang
+NATIVE_CC := $(shell which gcc || which clang)
+
 BIN_TO_C := $(OUT)/bin2c
 $(BIN_TO_C): tools/bin2c.c
+# emcc generates wasm but not executable, so fallback to use GCC or Clang
+ifeq ("$(CC_IS_EMCC)", "1")
+	$(Q)$(NATIVE_CC) -Wall -o $@ $^
+else
 	$(Q)$(CC) -Wall -o $@ $^
+endif
 
 BUILD_DTB2C := src/minimal_dtb.h
 $(BUILD_DTB2C): $(BIN_TO_C) $(BUILD_DTB)

--- a/mk/toolchain.mk
+++ b/mk/toolchain.mk
@@ -52,6 +52,10 @@ else ifneq ($(shell $(CC) --version | grep "Free Software Foundation"),)
      CC_IS_GCC := 1
 endif
 
+ifeq ("$(CC_IS_CLANG)$(CC_IS_GCC)$(CC_IS_EMCC)", "")
+$(error "Only supported GCC/Clang/Emcc")
+endif
+
 CFLAGS_NO_CET :=
 processor := $(shell uname -m)
 ifeq ($(processor),$(filter $(processor),i386 x86_64))


### PR DESCRIPTION
### What changes?
Allow emcc build for both ISA or system emulation. Additionally, add emcc build check to CI.

### How to reproduce emcc build fail for system emulation?
```
$ source ~/emsdk/emsdk_env.sh
$ make CC=emcc ENABLE_SYSTEM=1 -j8
```
Will see the error like the following:
```
BIN2C	src/minimal_dtb.h
/bin/sh: 1: build/bin2c: Permission denied
make: *** [mk/system.mk:22: src/minimal_dtb.h] Error 126
```

The reason is that the `bin2c` is compiled to Wasm by `emcc`  instead of native executable which cannot build the device tree blob to C application. 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances the build system by introducing support for emcc, enabling ISA and system emulation. It includes checks for GCC or Clang usage when emcc is unsuitable and implements error handling for unsupported compilers, improving robustness.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>