### PR TITLE
Correct the filename of Linux image when verification

### DIFF
--- a/mk/artifact.mk
+++ b/mk/artifact.mk
@@ -84,7 +84,7 @@ ifeq ($(call has, SYSTEM), 1)
 	$(Q)$(eval PREBUILT_LINUX_IMAGE_FILENAME := $(shell cat $(BIN_DIR)/sha1sum-linux-image | awk '{  print $$2 };'))
 
 	$(Q)$(eval $(foreach FILE,$(PREBUILT_LINUX_IMAGE_FILENAME), \
-	    $(call verify,$(SHA1SUM),$(shell grep -w $(FILE) $(BIN_DIR)/sha1sum-linux-image | awk '{ print $$1 };'),$(BIN_DIR)/linux-image/$(FILE),RES) \
+	    $(call verify,$(SHA1SUM),$(shell grep -w $(FILE) $(BIN_DIR)/sha1sum-linux-image | awk '{ print $$1 };'),$(BIN_DIR)/$(FILE),RES) \
 	))
 
 	$(Q)$(eval RV32EMU_PREBUILT_TARBALL := rv32emu-linux-image-prebuilt.tar.gz)


### PR DESCRIPTION
Due to the previous manually update the prebuilt Linux image, the filename is correct (without linux-image/ parent directory). But the recent Linux image [prebuilt](https://github.com/sysprog21/rv32emu-prebuilt/releases/tag/2025.02.27-Linux-Image) has been done which has different filename as expected (with linux-image parent directory).
Note that: I have manually remove the  linux-image/  parent for this [prebuilt](https://github.com/sysprog21/rv32emu-prebuilt/releases/tag/2025.02.27-Linux-Image).

This commit fixes the filename for future pre-building. 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request corrects the filename verification process for the pre-built Linux image by removing the 'linux-image/' parent directory. This adjustment ensures future pre-builds maintain the correct filename format, enhancing consistency in the build process.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>