### PR TITLE
Fix Docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM alpine:3.19 AS base_gcc
 
-RUN apk add --update alpine-sdk git wget
+RUN apk add --update alpine-sdk git wget sdl2-dev sdl2_mixer-dev
 
 # copy in the source code
 WORKDIR /home/root/rv32emu
 COPY . .
 
 # generate execution file for rv32emu and rv_histogram
-RUN make ENABLE_SDL=0
+RUN make
 RUN make tool
 
 FROM alpine:3.19 AS final
@@ -15,7 +15,9 @@ FROM alpine:3.19 AS final
 # copy in elf files
 COPY ./build/*.elf /home/root/rv32emu/build/
 
-# get rv32emu and rv_histogram binaries
+# get rv32emu and rv_histogram binaries and lib of SDL2 and SDL2_mixer
+COPY --from=base_gcc /usr/include/SDL2/ /usr/include/SDL2/
+COPY --from=base_gcc /usr/lib/libSDL2* /usr/lib/
 COPY --from=base_gcc /home/root/rv32emu/build/rv32emu /home/root/rv32emu/build/rv32emu
 COPY --from=base_gcc /home/root/rv32emu/build/rv_histogram /home/root/rv32emu/build/rv_histogram
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19 AS base_gcc
+FROM alpine:3.21 AS base_gcc
 
 RUN apk add --update alpine-sdk git wget sdl2-dev sdl2_mixer-dev
 


### PR DESCRIPTION
Commit a40fd0b adds objects file that built with the lib of SDL2 and SDL2_mixer for linker when building rv_histogram, the current Docker image lacks of SDL2 and SDL2_mixer shared objects, so installing them to fix the missing shared objects.

The final Docker image size changes from around 4 MiB -> 28 MiB. 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances the Dockerfile for the rv_histogram application by upgrading to Alpine 3.21 and adding SDL2 libraries, addressing missing shared objects and increasing the image size from 4 MiB to 28 MiB.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily involve dependency updates, making the review process relatively simple.
</div>