### PR TITLE
Support readonly feature of VirtIO block device

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ If `ENABLE_ARCH_TEST=1` was previously set, run `make distclean` before proceedi
 $ make ENABLE_SYSTEM=1 system
 ```
 
-Build using run using specified images:
+Build and run using specified images (`readonly` option makes the virtual block device read-only):
 ```shell
 $ make ENABLE_SYSTEM=1
-$ build/rv32emu -k <kernel_img_path> -i <rootfs_img_path> [-x vblk:<virtio_blk_img_path>]
+$ build/rv32emu -k <kernel_img_path> -i <rootfs_img_path> [-x vblk:<virtio_blk_img_path>[,readonly]]
 ```
 
 Build with a larger INITRD_SIZE (e.g., 64 MiB) to run SDL-oriented application because the default 8 MiB is insufficient for SDL-oriented application artifacts:

--- a/src/devices/virtio.h
+++ b/src/devices/virtio.h
@@ -33,6 +33,9 @@
 #define VIRTIO_BLK_S_IOERR 1
 #define VIRTIO_BLK_S_UNSUPP 2
 
+/* TODO: support more features */
+#define VIRTIO_BLK_F_RO (1 << 5)
+
 /* VirtIO MMIO registers */
 #define VIRTIO_REG_LIST                  \
     _(MagicValue, 0x000)        /* R */  \
@@ -87,6 +90,7 @@ typedef struct {
 
 typedef struct {
     /* feature negotiation */
+    uint32_t device_features;
     uint32_t device_features_sel;
     uint32_t driver_features;
     uint32_t driver_features_sel;
@@ -107,7 +111,9 @@ uint32_t virtio_blk_read(virtio_blk_state_t *vblk, uint32_t addr);
 
 void virtio_blk_write(virtio_blk_state_t *vblk, uint32_t addr, uint32_t value);
 
-uint32_t *virtio_blk_init(virtio_blk_state_t *vblk, char *disk_file);
+uint32_t *virtio_blk_init(virtio_blk_state_t *vblk,
+                          char *disk_file,
+                          bool readonly);
 
 virtio_blk_state_t *vblk_new();
 

--- a/src/main.c
+++ b/src/main.c
@@ -74,7 +74,8 @@ static void print_usage(const char *filename)
 #if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
         "  -k <image> : use <image> as kernel image\n"
         "  -i <image> : use <image> as rootfs\n"
-        "  -x vblk:<image> : use <image> as virtio-blk disk image\n"
+        "  -x vblk:<image>[,readonly] : use <image> as virtio-blk disk image "
+        "(default read and write)\n"
         "  -b <bootargs> : use customized <bootargs> for the kernel\n"
 #endif
         "  -d [filename]: dump registers as JSON to the "


### PR DESCRIPTION
## Why?
Enhances the security of the VirtIO block device by preventing unintended data corruption in the guest OS when accessing critical data.

## Test
1. Clone the repo:
```
$ git clone https://github.com/ChinYikMing/rv32emu.git -b virtio-blk-readonly --depth 1 && cd rv32emu
```

2. Get the prebuilt images and build:
```
$ make ENABLE_SYSTEM=1 INITRD_SIZE=32 -j100 && make ENABLE_SYSTEM=1 artifact
```

3. Prepare disk image:

macOS:
```bash
# Might need to install file system utility
$ brew install e2fsprogs

# Create a disk image
$ dd if=/dev/zero of=disk.img bs=4M count=32
$ $(brew --prefix e2fsprogs)/sbin/mkfs.ext4 disk.img
```

Linux
```bash
# Create a disk image
$ dd if=/dev/zero of=disk.img bs=4M count=32
$ mkfs.ext4 disk.img
```

4. Check the kernel boot log which should have something as the following:
```bash
$ build/rv32emu -k build/linux-image/Image -i build/linux-image/rootfs.cpio -x vblk:disk.img,readonly
```
Might see something similar:
```
...
...
[    0.583109] virtio_blk virtio0: 1/0/0 default/read/poll queues
[    0.584873] virtio_blk virtio0: [vda] 262144 512-byte logical blocks (134 MB/128 MiB)
...
...
```

5. Mount the virtio block device:
```bash
# mkdir mnt
# mount /dev/vda mnt
```
Might see something similar:
```
[   37.134323] /dev/vda: Can't open blockdev
[   37.135211] /dev/vda: Can't open blockdev
[   37.136593] EXT4-fs (vda): INFO: recovery required on readonly filesystem
[   37.136804] EXT4-fs (vda): write access unavailable, cannot proceed (try mounting with noload)
mount: mounting /dev/vda on mnt failed: Read-only file system
```
For ext4 image, to maintain the consistency of the file system, the ext4 does the journal replay (which is failed by this error log: "recovery required on readonly filesystem) and `mount` command default use read and write permission. Thus, it has to mount with noload option.

6. Remount the virtio block device and manipulate the device:
```bash
# mount -o noload /dev/vda mnt
```
Try to create a file which should fail on readonly mounted device:
```bash
# touch mnt/apple
touch: mnt/apple: Read-only file system
``` 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request introduces a readonly feature for the VirtIO block device, enhancing security by preventing unintended data corruption. Key changes include a readonly flag during initialization, updated function signatures, and improved command line options for usability.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>