### PR TITLE
CI: Add missing JIT system emulation test on macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -480,6 +480,14 @@ jobs:
              bash -c "${BOOT_LINUX_TEST}"
              make ENABLE_SYSTEM=1 clean
        if: ${{ always() }}
+     - name: boot Linux kernel test (JIT)
+       env:
+         CC: ${{ steps.install_cc.outputs.cc }}
+       run: |
+             make distclean && make INITRD_SIZE=32 ENABLE_SYSTEM=1 ENABLE_JIT=1 ENABLE_T2C=0 ENABLE_MOP_FUSION=0 $PARALLEL && make ENABLE_SYSTEM=1 artifact $PARALLEL
+             bash -c "${BOOT_LINUX_TEST}"
+             make ENABLE_SYSTEM=1 ENABLE_JIT=1 ENABLE_T2C=0 ENABLE_MOP_FUSION=0 clean
+       if: ${{ always() }}
      - name: Architecture test
        env:
          CC: ${{ steps.install_cc.outputs.cc }}


### PR DESCRIPTION
PR #569 introduced the macOS CI runner following PR #521 but forgot to include the JIT system emulation verification test. This commit adds the missing test.