### PR TITLE
Update mini-gdbstub with the API changes

### DIFF
--- a/src/emulate.c
+++ b/src/emulate.c
@@ -247,7 +247,6 @@ void rv_debug(riscv_t *rv)
     if (!gdbstub_init(&rv->gdbstub, &gdbstub_ops,
                       (arch_info_t){
                           .reg_num = 33,
-                          .reg_byte = 4,
                           .target_desc = TARGET_RV32,
                       },
                       GDBSTUB_COMM)) {


### PR DESCRIPTION
To support register >64bits(e.g. AVX register on x86), the corresponding interface changes are made on mini-gdbstub. Synchronize the library and interface to the latest version to facilitate future development. This may also be helpful if we had  Vector Extensions in the future. 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances the mini-gdbstub's register handling to support registers larger than 64 bits, including AVX registers on x86 architectures. It modifies relevant function signatures and implementations, and synchronizes the subproject commit with the latest library version for improved future development.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>