### PR TITLE
Advance timer properly during JIT execution

### DIFF
--- a/src/emulate.c
+++ b/src/emulate.c
@@ -82,11 +82,10 @@ static void __trap_handler(riscv_t *rv);
 
 /* FIXME: use more precise methods for updating time, e.g., RTC */
 #if RV32_HAS(Zicsr)
-static uint64_t ctr = 0;
 static inline void update_time(riscv_t *rv)
 {
-    rv->csr_time[0] = ctr & 0xFFFFFFFF;
-    rv->csr_time[1] = ctr >> 32;
+    rv->csr_time[0] = rv->timer & 0xFFFFFFFF;
+    rv->csr_time[1] = rv->timer >> 32;
 }
 
 /* get a pointer to a CSR */
@@ -379,7 +378,7 @@ static uint32_t peripheral_update_ctr = 64;
     static bool do_##inst(riscv_t *rv, const rv_insn_t *ir, uint64_t cycle, \
                           uint32_t PC)                                      \
     {                                                                       \
-        IIF(RV32_HAS(SYSTEM))(ctr++;, ) cycle++;                            \
+        IIF(RV32_HAS(SYSTEM))(rv->timer++;, ) cycle++;                      \
         code;                                                               \
         IIF(RV32_HAS(SYSTEM))                                               \
         (                                                                   \
@@ -1015,7 +1014,7 @@ static void rv_check_interrupt(riscv_t *rv)
             emu_update_uart_interrupts(rv);
     }
 
-    if (ctr > attr->timer)
+    if (rv->timer > attr->timer)
         rv->csr_sip |= RV_INT_STI;
     else
         rv->csr_sip &= ~RV_INT_STI;

--- a/src/riscv_private.h
+++ b/src/riscv_private.h
@@ -130,6 +130,8 @@ struct riscv_internal {
     riscv_word_t X[N_RV_REGS];
     riscv_word_t PC;
 
+    uint64_t timer; /* strictly increment timer */
+
 #if RV32_HAS(JIT) && RV32_HAS(SYSTEM)
     /*
      * Aarch64 encoder only accepts 9 bits signed offset. Do not put this


### PR DESCRIPTION
In the current implementation, the timer would not be updated until the control flow exits the JIT-ed code. This commit updates the timer correctly after every instruction has been dispatched. 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances the timer functionality in the JIT execution context by replacing the static counter with a dynamic timer variable. It introduces new methods for timer management in JIT compilation and T2C generation, improving the accuracy of time-related operations.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and well-defined, making the review process relatively simple.
</div>