### PR TITLE
CI: Use upstream Run-On-Arch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -302,7 +302,7 @@ jobs:
             echo "PARALLEL=-j$(nproc)" >> "$GITHUB_ENV"
     - name: build artifact
       # The GitHub Action for non-x86 CPU
-      uses: allinurl/run-on-arch-action@master
+      uses: uraimo/run-on-arch-action@v3
       with:
         arch: aarch64
         distro: ubuntu24.04


### PR DESCRIPTION
The upstream Run-On-Arch GitHub Action [1] finally supports Ubuntu 24.04, and we don't have to rely on customizations anymore.

[1] https://github.com/uraimo/run-on-arch-action