### PR TITLE
Remove misleading TRACE log comment

### DIFF
--- a/src/riscv.c
+++ b/src/riscv.c
@@ -469,7 +469,6 @@ riscv_t *rv_create(riscv_user_t rv_attr)
                        },
                        3);
 
-    /* set the log level to TRACE, everything is captured */
     rv_log_set_level(attr->log_level);
     rv_log_info("Log level: %s", rv_log_level_string(attr->log_level));
 


### PR DESCRIPTION
log_level is dynamic (attr->log_level) 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request clarifies the logging functionality in the RISC-V implementation by removing a misleading comment. It updates the documentation to accurately reflect the dynamic nature of the log level based on the provided attribute, enhancing code clarity.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>