### PR TITLE
Enhance CI formatting checks for Python files

### DIFF
--- a/.ci/check-format.sh
+++ b/.ci/check-format.sh
@@ -21,4 +21,14 @@ for file in ${SH_SOURCES}; do
 done
 SH_MISMATCH_FILE_CNT=$(shfmt -l ${SH_SOURCES})
 
-exit $((C_MISMATCH_LINE_CNT + SH_MISMATCH_FILE_CNT))
+PY_SOURCES=$(find "${REPO_ROOT}" | egrep "\.py$")
+for file in ${PY_SOURCES}; do
+    echo "Checking Python file: ${file}"
+    black --diff "${file}"
+done
+PY_MISMATCH_FILE_CNT=0
+if [ -n "${PY_SOURCES}" ]; then
+    PY_MISMATCH_FILE_CNT=$(echo "$(black --check ${PY_SOURCES} 2>&1)" | grep -c "^would reformat ")
+fi
+
+exit $((C_MISMATCH_LINE_CNT + SH_MISMATCH_FILE_CNT + PY_MISMATCH_FILE_CNT))

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -505,7 +505,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: coding convention
       run: |
-            sudo apt-get install -q=2 clang-format-18 shfmt
+            sudo apt-get install -q=2 clang-format-18 shfmt python3-pip
+            pip3 install black==25.1.0
             .ci/check-newline.sh
             .ci/check-format.sh
       shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,7 @@ However, participation requires adherence to fundamental ground rules:
   While there is some flexibility in basic style, it is crucial to stick to the current coding standards.
   Complex algorithmic constructs without proper comments will not be accepted.
 * Shell scripts must be formatted before submission. Use consistent flags across the project to ensure uniform formatting.
+* Python scripts must be formatted before submission. Use consistent flags across the project to ensure uniform formatting.
 * External pull requests should include thorough documentation in the pull request comments for consideration.
 * When composing documentation, code comments, and other materials in English,
   please adhere to the American English (`en_US`) dialect.
@@ -48,9 +49,12 @@ However, participation requires adherence to fundamental ground rules:
 Software requirement:
 * [clang-format](https://clang.llvm.org/docs/ClangFormat.html) version 18 or later.
 * [shfmt](https://github.com/mvdan/sh).
+* [black](https://github.com/psf/black) version 25.1.0.
 
-This repository consistently contains an up-to-date `.clang-format` file with rules that match the explained ones and uses shell script formatting supported by `shfmt`.
-For maintaining a uniform coding style, execute the command `clang-format -i *.{c,h}` and `shfmt -w $(find . -type f -name "*.sh")`.
+To maintain a uniform style across languages, run:
+* `clang-format -i *.{c,h}` to apply the project’s C/C++ formatting rules from the up-to-date .clang-format file.
+* `shfmt -w $(find . -type f -name "*.sh")` to clean and standardize all shell scripts.
+* `black .` to enforce a consistent, idiomatic layout for Python code.
 
 ## Coding Style for Shell Script
 
@@ -64,6 +68,19 @@ Shell scripts must be clean, consistent, and portable. The following `shfmt` rul
 * Indent `case` statements within `switch` blocks.
 * Add spaces around redirection operators (e.g., `>`, `>>`).
 * Place binary operators (e.g., `&&`, `|`) on the next line when breaking lines.
+
+## Coding Style for Python
+
+Python scripts must be clean, consistent, and adhere to modern Python best practices. The following formatting rules are enforced project-wide using `black`:
+
+* Use 4 spaces for indentation (never tabs).
+* Limit lines to 80 characters maximum.
+* Use double quotes for strings (unless single quotes avoid escaping).
+* Use trailing commas in multi-line constructs.
+* Format imports according to PEP 8 guidelines.
+* Use Unix-style line endings (LF).
+* Remove trailing whitespace at the end of lines.
+* Ensure files end with a newline.
 
 ## Coding Style for Modern C
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.black]
+line-length = 80
+target-version = ['py39', 'py310', 'py311','py312','py313']
+include = '\.pyi?$'

--- a/tests/arch-test-target/constants.py
+++ b/tests/arch-test-target/constants.py
@@ -1,19 +1,19 @@
 import os
 
-dutname = 'rv32emu'
-refname = 'sail_cSim'
+dutname = "rv32emu"
+refname = "sail_cSim"
 
 root = os.path.abspath(os.path.dirname(__file__))
 cwd = os.getcwd()
 
-misa_A = (1 << 0)
-misa_C = (1 << 2)
-misa_E = (1 << 4)
-misa_F = (1 << 5)
-misa_I = (1 << 8)
-misa_M = (1 << 12)
+misa_A = 1 << 0
+misa_C = 1 << 2
+misa_E = 1 << 4
+misa_F = 1 << 5
+misa_I = 1 << 8
+misa_M = 1 << 12
 
-config_temp = '''[RISCOF]
+config_temp = """[RISCOF]
 ReferencePlugin={0}
 ReferencePluginPath={1}
 DUTPlugin={2}
@@ -29,4 +29,4 @@ target_run=1
 [{0}]
 pluginpath={1}
 path={1}
-'''
+"""

--- a/tests/arch-test-target/sail_cSim/riscof_sail_cSim.py
+++ b/tests/arch-test-target/sail_cSim/riscof_sail_cSim.py
@@ -15,6 +15,7 @@ from riscv_isac.isac import isac
 
 logger = logging.getLogger()
 
+
 class sail_cSim(pluginTemplate):
     __model__ = "sail_c_simulator"
     __version__ = "0.5.0"
@@ -22,109 +23,162 @@ class sail_cSim(pluginTemplate):
     def __init__(self, *args, **kwargs):
         sclass = super().__init__(*args, **kwargs)
 
-        config = kwargs.get('config')
+        config = kwargs.get("config")
         if config is None:
             logger.error("Config node for sail_cSim missing.")
             raise SystemExit(1)
-        self.num_jobs = str(config['jobs'] if 'jobs' in config else 1)
-        self.pluginpath = os.path.abspath(config['pluginpath'])
-        self.sail_exe = { '32' : os.path.join(config['PATH'] if 'PATH' in config else "","riscv_sim_RV32"),
-                '64' : os.path.join(config['PATH'] if 'PATH' in config else "","riscv_sim_RV64")}
-        self.isa_spec = os.path.abspath(config['ispec']) if 'ispec' in config else ''
-        self.platform_spec = os.path.abspath(config['pspec']) if 'ispec' in config else ''
-        self.make = config['make'] if 'make' in config else 'make'
-        logger.debug("SAIL CSim plugin initialised using the following configuration.")
+        self.num_jobs = str(config["jobs"] if "jobs" in config else 1)
+        self.pluginpath = os.path.abspath(config["pluginpath"])
+        self.sail_exe = {
+            "32": os.path.join(
+                config["PATH"] if "PATH" in config else "", "riscv_sim_RV32"
+            ),
+            "64": os.path.join(
+                config["PATH"] if "PATH" in config else "", "riscv_sim_RV64"
+            ),
+        }
+        self.isa_spec = (
+            os.path.abspath(config["ispec"]) if "ispec" in config else ""
+        )
+        self.platform_spec = (
+            os.path.abspath(config["pspec"]) if "ispec" in config else ""
+        )
+        self.make = config["make"] if "make" in config else "make"
+        logger.debug(
+            "SAIL CSim plugin initialised using the following configuration."
+        )
         for entry in config:
-            logger.debug(entry+' : '+config[entry])
+            logger.debug(entry + " : " + config[entry])
         return sclass
 
     def initialise(self, suite, work_dir, archtest_env):
         self.suite = suite
         self.work_dir = work_dir
-        self.objdump_cmd = os.getenv("CROSS_COMPILE") + 'objdump -D {0} > {2};'
-        self.compile_cmd = os.getenv("CROSS_COMPILE") + 'gcc -march={0} \
+        self.objdump_cmd = os.getenv("CROSS_COMPILE") + "objdump -D {0} > {2};"
+        self.compile_cmd = (
+            os.getenv("CROSS_COMPILE")
+            + "gcc -march={0} \
          -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles\
-         -T '+self.pluginpath+'/env/link.ld\
-         -I '+self.pluginpath+'/env/\
-         -I ' + archtest_env
+         -T "
+            + self.pluginpath
+            + "/env/link.ld\
+         -I "
+            + self.pluginpath
+            + "/env/\
+         -I "
+            + archtest_env
+        )
 
     def build(self, isa_yaml, platform_yaml):
-        ispec = utils.load_yaml(isa_yaml)['hart0']
-        self.xlen = ('64' if 64 in ispec['supported_xlen'] else '32')
-        self.isa = 'rv' + self.xlen
-        if 'E' not in ispec['ISA']:
-            self.compile_cmd = self.compile_cmd+' -mabi='+('lp64 ' if 64 in ispec['supported_xlen'] else 'ilp32 ')
+        ispec = utils.load_yaml(isa_yaml)["hart0"]
+        self.xlen = "64" if 64 in ispec["supported_xlen"] else "32"
+        self.isa = "rv" + self.xlen
+        if "E" not in ispec["ISA"]:
+            self.compile_cmd = (
+                self.compile_cmd
+                + " -mabi="
+                + ("lp64 " if 64 in ispec["supported_xlen"] else "ilp32 ")
+            )
         else:
-            self.compile_cmd = self.compile_cmd+' -mabi='+('lp64e ' if 64 in ispec['supported_xlen'] else 'ilp32e ')
+            self.compile_cmd = (
+                self.compile_cmd
+                + " -mabi="
+                + ("lp64e " if 64 in ispec["supported_xlen"] else "ilp32e ")
+            )
             self.compile_cmd += "-D RV32E "
         if "I" in ispec["ISA"]:
-            self.isa += 'i'
+            self.isa += "i"
         if "E" in ispec["ISA"]:
-            self.isa += 'e'
+            self.isa += "e"
         if "M" in ispec["ISA"]:
-            self.isa += 'm'
+            self.isa += "m"
         if "C" in ispec["ISA"]:
-            self.isa += 'c'
+            self.isa += "c"
         if "F" in ispec["ISA"]:
-            self.isa += 'f'
+            self.isa += "f"
         if "D" in ispec["ISA"]:
-            self.isa += 'd'
+            self.isa += "d"
         objdump = os.getenv("CROSS_COMPILE") + "objdump".format(self.xlen)
         if shutil.which(objdump) is None:
-            logger.error(objdump+": executable not found. Please check environment setup.")
+            logger.error(
+                objdump
+                + ": executable not found. Please check environment setup."
+            )
             raise SystemExit(1)
         compiler = os.getenv("CROSS_COMPILE") + "gcc".format(self.xlen)
         if shutil.which(compiler) is None:
-            logger.error(compiler+": executable not found. Please check environment setup.")
+            logger.error(
+                compiler
+                + ": executable not found. Please check environment setup."
+            )
             raise SystemExit(1)
         if shutil.which(self.sail_exe[self.xlen]) is None:
-            logger.error(self.sail_exe[self.xlen]+ ": executable not found. Please check environment setup.")
+            logger.error(
+                self.sail_exe[self.xlen]
+                + ": executable not found. Please check environment setup."
+            )
             raise SystemExit(1)
         if shutil.which(self.make) is None:
-            logger.error(self.make+": executable not found. Please check environment setup.")
+            logger.error(
+                self.make
+                + ": executable not found. Please check environment setup."
+            )
             raise SystemExit(1)
 
-
     def runTests(self, testList, cgf_file=None):
-        if os.path.exists(self.work_dir+ "/Makefile." + self.name[:-1]):
-            os.remove(self.work_dir+ "/Makefile." + self.name[:-1])
-        make = utils.makeUtil(makefilePath=os.path.join(self.work_dir, "Makefile." + self.name[:-1]))
-        make.makeCommand = self.make + ' -j' + self.num_jobs
+        if os.path.exists(self.work_dir + "/Makefile." + self.name[:-1]):
+            os.remove(self.work_dir + "/Makefile." + self.name[:-1])
+        make = utils.makeUtil(
+            makefilePath=os.path.join(
+                self.work_dir, "Makefile." + self.name[:-1]
+            )
+        )
+        make.makeCommand = self.make + " -j" + self.num_jobs
         for file in testList:
             testentry = testList[file]
-            test = testentry['test_path']
-            test_dir = testentry['work_dir']
-            test_name = test.rsplit('/',1)[1][:-2]
+            test = testentry["test_path"]
+            test_dir = testentry["work_dir"]
+            test_name = test.rsplit("/", 1)[1][:-2]
 
-            elf = 'ref.elf'
+            elf = "ref.elf"
 
-            execute = "@cd "+testentry['work_dir']+";"
+            execute = "@cd " + testentry["work_dir"] + ";"
 
-            cmd = self.compile_cmd.format(testentry['isa'].lower(), self.xlen) + ' ' + test + ' -o ' + elf
-            compile_cmd = cmd + ' -D' + " -D".join(testentry['macros'])
-            execute+=compile_cmd+";"
+            cmd = (
+                self.compile_cmd.format(testentry["isa"].lower(), self.xlen)
+                + " "
+                + test
+                + " -o "
+                + elf
+            )
+            compile_cmd = cmd + " -D" + " -D".join(testentry["macros"])
+            execute += compile_cmd + ";"
 
-            execute += self.objdump_cmd.format(elf, self.xlen, 'ref.disass')
+            execute += self.objdump_cmd.format(elf, self.xlen, "ref.disass")
             sig_file = os.path.join(test_dir, self.name[:-1] + ".signature")
 
-            execute += self.sail_exe[self.xlen] + ' --test-signature={0} {1} > {2}.log 2>&1;'.format(sig_file, elf, test_name)
+            execute += self.sail_exe[
+                self.xlen
+            ] + " --test-signature={0} {1} > {2}.log 2>&1;".format(
+                sig_file, elf, test_name
+            )
 
-            cov_str = ' '
-            for label in testentry['coverage_labels']:
-                cov_str+=' -l '+label
+            cov_str = " "
+            for label in testentry["coverage_labels"]:
+                cov_str += " -l " + label
 
             if cgf_file is not None:
-                coverage_cmd = 'riscv_isac --verbose info coverage -d \
+                coverage_cmd = "riscv_isac --verbose info coverage -d \
                         -t {0}.log --parser-name c_sail -o coverage.rpt  \
                         --sig-label begin_signature  end_signature \
                         --test-label rvtest_code_begin rvtest_code_end \
-                        -e ref.elf -c {1} -x{2} {3};'.format(\
-                        test_name, ' -c '.join(cgf_file), self.xlen, cov_str)
+                        -e ref.elf -c {1} -x{2} {3};".format(
+                    test_name, " -c ".join(cgf_file), self.xlen, cov_str
+                )
             else:
-                coverage_cmd = ''
+                coverage_cmd = ""
 
-
-            execute+=coverage_cmd
+            execute += coverage_cmd
 
             make.add_target(execute)
         make.execute_all(self.work_dir)

--- a/tests/arch-test-target/setup.py
+++ b/tests/arch-test-target/setup.py
@@ -2,62 +2,64 @@ import constants
 import argparse
 import ruamel.yaml
 
+
 # setup the ISA config file
 def setup_testlist(riscv_device, hw_data_misaligned_support):
     # ISA config file path
-    ispec = constants.root + '/rv32emu/rv32emu_isa.yaml'
+    ispec = constants.root + "/rv32emu/rv32emu_isa.yaml"
     misa = 0x40000000
-    ISA = 'RV32'
+    ISA = "RV32"
 
     if not riscv_device:
-        raise AssertionError('There is not any ISA.')
+        raise AssertionError("There is not any ISA.")
 
-    if 'E' in riscv_device:
+    if "E" in riscv_device:
         misa |= constants.misa_E
-        ISA += 'E'
+        ISA += "E"
     else:
         misa |= constants.misa_I
-        ISA += 'I'
-    if 'M' in riscv_device:
+        ISA += "I"
+    if "M" in riscv_device:
         misa |= constants.misa_M
-        ISA += 'M'
-    if 'A' in riscv_device:
+        ISA += "M"
+    if "A" in riscv_device:
         misa |= constants.misa_A
-        ISA += 'A'
-    if 'F' in riscv_device:
+        ISA += "A"
+    if "F" in riscv_device:
         misa |= constants.misa_F
-        ISA += 'F'
-    if 'C' in riscv_device:
+        ISA += "F"
+    if "C" in riscv_device:
         misa |= constants.misa_C
-        ISA += 'C'
-    if 'Zba' in riscv_device:
-        ISA += '_Zba' if 'Z' in ISA else 'Zba'
-    if 'Zbb' in riscv_device:
-        ISA += '_Zbb' if 'Z' in ISA else 'Zbb'
-    if 'Zbc' in riscv_device:
-        ISA += '_Zbc' if 'Z' in ISA else 'Zbc'
-    if 'Zbs' in riscv_device:
-        ISA += '_Zbs' if 'Z' in ISA else 'Zbs'
-    if 'Zicsr' in riscv_device:
-        ISA += '_Zicsr' if 'Z' in ISA else 'Zicsr'
-    if 'Zifencei' in riscv_device:
-        ISA += '_Zifencei' if 'Z' in ISA else 'Zifencei'
-    
-    with open(ispec, 'r') as file:
+        ISA += "C"
+    if "Zba" in riscv_device:
+        ISA += "_Zba" if "Z" in ISA else "Zba"
+    if "Zbb" in riscv_device:
+        ISA += "_Zbb" if "Z" in ISA else "Zbb"
+    if "Zbc" in riscv_device:
+        ISA += "_Zbc" if "Z" in ISA else "Zbc"
+    if "Zbs" in riscv_device:
+        ISA += "_Zbs" if "Z" in ISA else "Zbs"
+    if "Zicsr" in riscv_device:
+        ISA += "_Zicsr" if "Z" in ISA else "Zicsr"
+    if "Zifencei" in riscv_device:
+        ISA += "_Zifencei" if "Z" in ISA else "Zifencei"
+
+    with open(ispec, "r") as file:
         try:
-            file = ruamel.yaml.YAML(typ='safe', pure=True).load(file)
+            file = ruamel.yaml.YAML(typ="safe", pure=True).load(file)
         except ruamel.yaml.YAMLError as msg:
             print(msg)
             raise SystemExit(1)
 
-    file['hart0']['ISA'] = ISA
-    file['hart0']['hw_data_misaligned_support'] = (
+    file["hart0"]["ISA"] = ISA
+    file["hart0"]["hw_data_misaligned_support"] = (
         True if hw_data_misaligned_support == "1" else False
     )
-    file['hart0']['misa']['reset-val'] = misa
+    file["hart0"]["misa"]["reset-val"] = misa
 
-    with open(ispec, 'w+') as outfile:
-        ruamel.yaml.YAML(typ='unsafe', pure=True).dump(file, outfile)
+    with open(ispec, "w+") as outfile:
+        ruamel.yaml.YAML(typ="unsafe", pure=True).dump(file, outfile)
+
 
 # setup the riscof config file
 def setup_config():
@@ -67,15 +69,20 @@ def setup_config():
     dutname = constants.dutname
 
     # create config file
-    configfile = open(root + '/config.ini','w')
-    configfile.write(constants.config_temp.format(refname, \
-            root+'/'+refname, dutname, root+'/'+dutname, cwd))
+    configfile = open(root + "/config.ini", "w")
+    configfile.write(
+        constants.config_temp.format(
+            refname, root + "/" + refname, dutname, root + "/" + dutname, cwd
+        )
+    )
     configfile.close()
 
-if __name__=="__main__":
+
+if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('--riscv_device', help='the ISA will test',
-                        default='IMACZicsrZifencei')
+    parser.add_argument(
+        "--riscv_device", help="the ISA will test", default="IMACZicsrZifencei"
+    )
     parser.add_argument(
         "--hw_data_misaligned_support",
         help="whether the hardware data misalgnment is implemented or not",

--- a/tests/bench-aggregator.py
+++ b/tests/bench-aggregator.py
@@ -3,6 +3,7 @@
 import json
 import subprocess
 
+
 def run_benchmark(b):
     interp = None
     if "sh" in b:
@@ -12,23 +13,19 @@ def run_benchmark(b):
 
     subprocess.run(args=[interp, b], shell=False, check=True)
 
+
 def load_benchmark(file):
     f = open(file, "r")
     return json.load(f)
 
+
 # run benchmarks
-benchmarks = [
-    "tests/dhrystone.sh",
-    "tests/coremark.py"
-]
+benchmarks = ["tests/dhrystone.sh", "tests/coremark.py"]
 for b in benchmarks:
     run_benchmark(b)
 
 # combine benchmarks output data
-benchmarks_output = [
-    "dhrystone_output.json",
-    "coremark_output.json"
-]
+benchmarks_output = ["dhrystone_output.json", "coremark_output.json"]
 benchmark_data = [load_benchmark(bo) for bo in benchmarks_output]
 
 benchmark_output = "benchmark_output.json"

--- a/tests/coremark.py
+++ b/tests/coremark.py
@@ -8,13 +8,14 @@ import json
 iter = 1
 coremark_param = "0x0 0x0 0x66 30000 7 1 2000"
 res = []
-file_exist = os.path.exists('build/rv32emu')
+file_exist = os.path.exists("build/rv32emu")
 if not file_exist:
     print("Please compile before running test")
     exit(1)
 print("Start Test CoreMark benchmark")
 comp_proc = subprocess.check_output(
-    "build/rv32emu build/riscv32/coremark {}".format(coremark_param), shell=True).decode("utf-8")
+    "build/rv32emu build/riscv32/coremark {}".format(coremark_param), shell=True
+).decode("utf-8")
 if not comp_proc or comp_proc.find("Error") != -1:
     print("Test Error")
     exit(1)
@@ -24,28 +25,35 @@ else:
 for i in range(iter):
     print("Running CoreMark benchmark - Run #{}".format(i + 1))
     comp_proc = subprocess.check_output(
-        "build/rv32emu build/riscv32/coremark {}".format(coremark_param), shell=True).decode("utf-8")
+        "build/rv32emu build/riscv32/coremark {}".format(coremark_param),
+        shell=True,
+    ).decode("utf-8")
     if not comp_proc:
         print("Fail\n")
         exit(1)
     else:
-        res.append(float(re.findall(
-            r'Iterations/Sec   : [0-9]+.[0-9]+', comp_proc)[0][19:]))
+        res.append(
+            float(
+                re.findall(r"Iterations/Sec   : [0-9]+.[0-9]+", comp_proc)[0][
+                    19:
+                ]
+            )
+        )
 
 mean = numpy.mean(res, dtype=numpy.float64)
 deviation = numpy.std(res, dtype=numpy.float64)
 for n in res:
-    if (abs(n - mean) > (deviation * 2)):
+    if abs(n - mean) > (deviation * 2):
         res.remove(n)
 
 print("{:.3f}".format(numpy.mean(res, dtype=numpy.float64)))
 
-#save Average Iterations/Sec in JSON format for benchmark action workflow
+# save Average Iterations/Sec in JSON format for benchmark action workflow
 benchmark_output = "coremark_output.json"
 benchmark_data = {
-    "name":"Coremark", 
-    "unit":"Average iterations/sec over 10 runs", 
-    "value":float("{:.3f}".format(numpy.mean(res, dtype=numpy.float64)))
+    "name": "Coremark",
+    "unit": "Average iterations/sec over 10 runs",
+    "value": float("{:.3f}".format(numpy.mean(res, dtype=numpy.float64))),
 }
 f = open(benchmark_output, "w")
 f.write(json.dumps(benchmark_data))

--- a/tools/gen-elf-list-js.py
+++ b/tools/gen-elf-list-js.py
@@ -13,7 +13,9 @@ def list_files(d, ignore_list=None):
                 for f in os.listdir(d)
                 if os.path.isfile(os.path.join(d, f))
                 and f.endswith(".elf")
-                and not any(f.endswith(ign) or f.startswith(ign) for ign in ignore_list)
+                and not any(
+                    f.endswith(ign) or f.startswith(ign) for ign in ignore_list
+                )
             ]
         else:
             parent_dir = os.path.dirname(d)


### PR DESCRIPTION
- Update `.ci/check-format.sh` to include checks for Python files using Black.
- Modify `.github/workflows/main.yml` to install Python dependencies for formatting.
- Add Python-specific settings to `.editorconfig` to enforce consistent formatting rules.

This ensures that both shell scripts and Python files adhere to defined coding standards. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances CI formatting checks by integrating support for Python files using the Black formatter. It updates CI scripts and GitHub Actions to include Python-specific checks and dependencies, while refactoring existing Python code for improved readability and maintainability. Additionally, the JIT template generation logic has been refactored for enhanced clarity.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>