### PR TITLE
Support multiple virtio block devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ Mount the virtual block device and create a test file after booting, note that r
 ```
 Reboot and re-mount the virtual block device, the written file should remain existing.
 
+To specify multiple virtual block devices, pass multiple `-x vblk` options when launching the emulator. Each option can point to either a disk image or a hostOS block device, with optional read-only mode. For example:
+```shell
+$ build/rv32emu -k <kernel_img_path> -i <rootfs_img_path> -x vblk:disk.img -x vblk:/dev/loop22,readonly
+```
+Note that the /dev/vdx device order in guestOS is assigned in reverse: the first `-x vblk` argument corresponds to the device with the highest letter, while subsequent arguments receive lower-lettered device names.
+
 #### Customize bootargs
 Build and run with customized bootargs to boot the guestOS. Otherwise, the default bootargs defined in `src/devices/minimal.dts` will be used.
 ```shell

--- a/src/devices/minimal.dts
+++ b/src/devices/minimal.dts
@@ -66,10 +66,14 @@
             clock-frequency = <5000000>; /* the baudrate divisor is ignored */
         };
 
-        blk0: virtio@4200000 {
+        /*
+         * Virtio block example subnode
+         * The actual subnode are generated dynamically depends on the CLI -x vblk option
+         */
+        /*blk0: virtio@4100000 {
             compatible = "virtio,mmio";
-            reg = <0x4200000 0x200>;
-            interrupts = <3>;
-        };
+            reg = <0x4100000 0x200>;
+            interrupts = <2>;
+        };*/
     };
 };

--- a/src/devices/virtio.h
+++ b/src/devices/virtio.h
@@ -76,8 +76,7 @@ struct virtq_desc {
     uint16_t next;
 };
 
-#define IRQ_VBLK_SHIFT 3
-#define IRQ_VBLK_BIT (1 << IRQ_VBLK_SHIFT)
+#define IRQ_VBLK_BIT(base, i) (1 << (base + i))
 
 typedef struct {
     uint32_t queue_num;

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -318,10 +318,10 @@ static void load_dtb(char **ram_loc, vm_attr_t *attr)
         node = fdt_path_offset(dtb_buf, "/chosen");
         assert(node > 0);
 
-        len = strlen(bootargs) + 1;
-        buf = malloc(len);
+        len = strlen(bootargs);
+        buf = malloc(len + 1);
         assert(buf);
-        memcpy(buf, bootargs, len - 1);
+        memcpy(buf, bootargs, len);
         buf[len] = 0;
         err = fdt_setprop(dtb_buf, node, "bootargs", buf, len + 1);
         if (err == -FDT_ERR_NOSPACE) {

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -293,17 +293,29 @@ static void load_dtb(char **ram_loc, vm_attr_t *attr)
 {
 #include "minimal_dtb.h"
     char *bootargs = attr->data.system.bootargs;
-    char *vblk = attr->data.system.vblk_device;
+    char **vblk = attr->data.system.vblk_device;
     char *blob = *ram_loc;
     char *buf;
     size_t len;
     int node, err;
     int totalsize;
 
-    memcpy(blob, minimal, sizeof(minimal));
+#define DTB_EXPAND_SIZE 1024 /* or more if needed */
+
+    /* Allocate enough memory for DTB + extra room */
+    size_t minimal_len = ARRAY_SIZE(minimal);
+    void *dtb_buf = calloc(minimal_len + DTB_EXPAND_SIZE, sizeof(uint8_t));
+    assert(dtb_buf);
+
+    /* Expand it to a usable DTB blob */
+    err = fdt_open_into(minimal, dtb_buf, minimal_len + DTB_EXPAND_SIZE);
+    if (err < 0) {
+        rv_log_error("fdt_open_into fails\n");
+        exit(EXIT_FAILURE);
+    }
 
     if (bootargs) {
-        node = fdt_path_offset(blob, "/chosen");
+        node = fdt_path_offset(dtb_buf, "/chosen");
         assert(node > 0);
 
         len = strlen(bootargs) + 1;
@@ -311,26 +323,79 @@ static void load_dtb(char **ram_loc, vm_attr_t *attr)
         assert(buf);
         memcpy(buf, bootargs, len - 1);
         buf[len] = 0;
-        err = fdt_setprop(blob, node, "bootargs", buf, len + 1);
+        err = fdt_setprop(dtb_buf, node, "bootargs", buf, len + 1);
         if (err == -FDT_ERR_NOSPACE) {
-            blob = realloc_property(blob, node, "bootargs", len);
-            err = fdt_setprop(blob, node, "bootargs", buf, len);
+            dtb_buf = realloc_property(dtb_buf, node, "bootargs", len);
+            err = fdt_setprop(dtb_buf, node, "bootargs", buf, len);
         }
         free(buf);
         assert(!err);
     }
 
-    /* remove the vblk node from soc if it is not specified */
-    if (!vblk) {
-        int subnode;
-        node = fdt_path_offset(blob, "/soc@F0000000");
+    if (vblk) {
+        int node = fdt_path_offset(dtb_buf, "/soc@F0000000");
         assert(node >= 0);
 
-        subnode = fdt_subnode_offset(blob, node, "virtio@4200000");
-        assert(subnode >= 0);
+        uint32_t base_addr = 0x4000000;
+        uint32_t addr_offset = 0x100000;
+        uint32_t size = 0x200;
 
-        assert(fdt_del_node(blob, subnode) == 0);
+        uint32_t next_addr = base_addr;
+        uint32_t next_irq = 1;
+
+        /* scan existing nodes to get next addr and irq */
+        int subnode;
+        fdt_for_each_subnode(subnode, dtb_buf, node)
+        {
+            const char *name = fdt_get_name(dtb_buf, subnode, NULL);
+            assert(name);
+
+            uint32_t addr = strtoul(name + 7, NULL, 16);
+            if (addr == next_addr)
+                next_addr = addr + addr_offset;
+
+            const fdt32_t *irq_prop =
+                fdt_getprop(dtb_buf, subnode, "interrupts", NULL);
+            if (irq_prop) {
+                uint32_t irq = fdt32_to_cpu(*irq_prop);
+                if (irq == next_irq)
+                    next_irq = irq + 1;
+            }
+        }
+        /* set IRQ for virtio block, see devices/virtio.h */
+        attr->vblk_irq_base = next_irq;
+
+        /* adding new virtio block nodes */
+        for (int i = 0; i < attr->vblk_cnt; i++) {
+            uint32_t new_addr = next_addr + i * addr_offset;
+            uint32_t new_irq = next_irq + i;
+
+            char node_name[32];
+            snprintf(node_name, sizeof(node_name), "virtio@%x", new_addr);
+
+            int subnode = fdt_add_subnode(dtb_buf, node, node_name);
+            if (subnode == -FDT_ERR_NOSPACE) {
+                rv_log_warn("add subnode no space!\n");
+            }
+            assert(subnode >= 0);
+
+            /* compatible = "virtio,mmio" */
+            assert(fdt_setprop_string(dtb_buf, subnode, "compatible",
+                                      "virtio,mmio") == 0);
+
+            /* reg = <new_addr size> */
+            uint32_t reg[2] = {cpu_to_fdt32(new_addr), cpu_to_fdt32(size)};
+            assert(fdt_setprop(dtb_buf, subnode, "reg", reg, sizeof(reg)) == 0);
+
+            /* interrupts = <new_irq> */
+            uint32_t irq = cpu_to_fdt32(new_irq);
+            assert(fdt_setprop(dtb_buf, subnode, "interrupts", &irq,
+                               sizeof(irq)) == 0);
+        }
     }
+
+    memcpy(blob, dtb_buf, minimal_len + DTB_EXPAND_SIZE);
+    free(dtb_buf);
 
     totalsize = fdt_totalsize(blob);
     *ram_loc += totalsize;
@@ -406,28 +471,36 @@ static void rv_fsync_device()
      *
      * vblk is optional, so it could be NULL
      */
-    if (attr->vblk) {
-        if (attr->vblk->disk_fd >= 3) {
-            if (attr->vblk->device_features & VIRTIO_BLK_F_RO) /* readonly */
-                goto end;
+    if (attr->vblk_cnt) {
+        for (int i = 0; i < attr->vblk_cnt; i++) {
+            virtio_blk_state_t *vblk = attr->vblk[i];
+            if (vblk->disk_fd >= 3) {
+                if (vblk->device_features & VIRTIO_BLK_F_RO) /* readonly */
+                    goto end;
 
-            if (pwrite(attr->vblk->disk_fd, attr->vblk->disk,
-                       attr->vblk->disk_size, 0) == -1) {
-                rv_log_error("pwrite block device failed: %s", strerror(errno));
-                return;
+                if (pwrite(vblk->disk_fd, vblk->disk, vblk->disk_size, 0) ==
+                    -1) {
+                    rv_log_error("pwrite block device failed: %s",
+                                 strerror(errno));
+                    return;
+                }
+
+                if (fsync(vblk->disk_fd) == -1) {
+                    rv_log_error("fsync block device failed: %s",
+                                 strerror(errno));
+                    return;
+                }
+                rv_log_info("Sync block device OK");
+
+            end:
+                close(vblk->disk_fd);
             }
 
-            if (fsync(attr->vblk->disk_fd) == -1) {
-                rv_log_error("fsync block device failed: %s", strerror(errno));
-                return;
-            }
-            rv_log_info("Sync block device OK");
-
-        end:
-            close(attr->vblk->disk_fd);
+            vblk_delete(vblk);
         }
 
-        vblk_delete(attr->vblk);
+        free(attr->vblk);
+        free(attr->disk);
     }
 }
 #endif /* RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER) */
@@ -548,6 +621,9 @@ riscv_t *rv_create(riscv_user_t rv_attr)
      * *----------------*----------------*-------*
      */
 
+    /* load_dtb needs the count to add the virtio block subnode dynamically */
+    attr->vblk_cnt = attr->data.system.vblk_device_cnt;
+
     char *ram_loc = (char *) attr->mem->mem_base;
     map_file(&ram_loc, attr->data.system.kernel);
     rv_log_info("Kernel loaded");
@@ -590,36 +666,47 @@ riscv_t *rv_create(riscv_user_t rv_attr)
     attr->uart->out_fd = attr->fd_stdout;
 
     /* setup virtio-blk */
-    attr->vblk = NULL;
-    if (attr->data.system.vblk_device) {
+    attr->vblk_mmio_base_hi = 0x41;
+    attr->vblk_mmio_max_hi = attr->vblk_mmio_base_hi + attr->vblk_cnt;
+
+    attr->vblk = malloc(sizeof(virtio_blk_state_t *) * attr->vblk_cnt);
+    assert(attr->vblk);
+    attr->disk = malloc(sizeof(uint32_t *) * attr->vblk_cnt);
+    assert(attr->disk);
+
+    if (attr->vblk_cnt) {
+        for (int i = 0; i < attr->vblk_cnt; i++) {
 /* Currently, only used for block image path and permission */
 #define MAX_OPTS 2
-        char *vblk_opts[MAX_OPTS] = {NULL};
-        int vblk_opt_idx = 0;
-        char *opt = strtok(attr->data.system.vblk_device, ",");
-        while (opt) {
-            if (vblk_opt_idx == MAX_OPTS) {
-                rv_log_error("Too many arguments for vblk");
-                break;
+            char *vblk_device_str = attr->data.system.vblk_device[i];
+            char *vblk_opts[MAX_OPTS] = {NULL};
+            int vblk_opt_idx = 0;
+            char *opt = strtok(vblk_device_str, ",");
+            while (opt) {
+                if (vblk_opt_idx == MAX_OPTS) {
+                    rv_log_error("Too many arguments for vblk");
+                    break;
+                }
+                vblk_opts[vblk_opt_idx++] = opt;
+                opt = strtok(NULL, ",");
             }
-            vblk_opts[vblk_opt_idx++] = opt;
-            opt = strtok(NULL, ",");
-        }
-        char *vblk_device = vblk_opts[0];
-        char *vblk_readonly = vblk_opts[1];
+            char *vblk_device = vblk_opts[0];
+            char *vblk_readonly = vblk_opts[1];
 
-        bool readonly = false;
-        if (vblk_readonly) {
-            if (strcmp(vblk_readonly, "readonly") != 0) {
-                rv_log_error("Unknown vblk option: %s", vblk_readonly);
-                exit(EXIT_FAILURE);
+            bool readonly = false;
+            if (vblk_readonly) {
+                if (strcmp(vblk_readonly, "readonly") != 0) {
+                    rv_log_error("Unknown vblk option: %s", vblk_readonly);
+                    exit(EXIT_FAILURE);
+                }
+                readonly = true;
             }
-            readonly = true;
-        }
 
-        attr->vblk = vblk_new();
-        attr->vblk->ram = (uint32_t *) attr->mem->mem_base;
-        attr->disk = virtio_blk_init(attr->vblk, vblk_device, readonly);
+            attr->vblk[i] = vblk_new();
+            attr->vblk[i]->ram = (uint32_t *) attr->mem->mem_base;
+            attr->disk[i] =
+                virtio_blk_init(attr->vblk[i], vblk_device, readonly);
+        }
     }
 
     capture_keyboard_input();

--- a/src/riscv.h
+++ b/src/riscv.h
@@ -461,7 +461,8 @@ typedef struct {
     char *kernel;
     char *initrd;
     char *bootargs;
-    char *vblk_device;
+    char **vblk_device;
+    int vblk_device_cnt;
 } vm_system_t;
 #endif /* RV32_HAS(SYSTEM) */
 
@@ -483,8 +484,13 @@ typedef struct {
     plic_t *plic;
 
     /* virtio-blk device */
-    uint32_t *disk;
-    virtio_blk_state_t *vblk;
+    uint32_t **disk;
+    virtio_blk_state_t **vblk;
+    virtio_blk_state_t *vblk_curr;
+    uint32_t vblk_mmio_base_hi;
+    uint32_t vblk_mmio_max_hi;
+    int vblk_irq_base;
+    int vblk_cnt;
 #endif /* RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER) */
 
     /* vm memory object */

--- a/src/system.c
+++ b/src/system.c
@@ -22,11 +22,13 @@ void emu_update_uart_interrupts(riscv_t *rv)
 void emu_update_vblk_interrupts(riscv_t *rv)
 {
     vm_attr_t *attr = PRIV(rv);
-    if (attr->vblk->interrupt_status)
-        attr->plic->active |= IRQ_VBLK_BIT;
-    else
-        attr->plic->active &= ~IRQ_VBLK_BIT;
-    plic_update_interrupts(attr->plic);
+    for (int i = 0; i < attr->vblk_cnt; i++) {
+        if (attr->vblk[i]->interrupt_status)
+            attr->plic->active |= IRQ_VBLK_BIT(attr->vblk_irq_base, i);
+        else
+            attr->plic->active &= ~IRQ_VBLK_BIT(attr->vblk_irq_base, i);
+        plic_update_interrupts(attr->plic);
+    }
 }
 #endif
 


### PR DESCRIPTION
# Demo Video

https://github.com/user-attachments/assets/f0000cc2-f667-4566-a6e4-6a03d1507f10



# Problem Statement

Previously, https://github.com/sysprog21/rv32emu/pull/539 set VBLK_DEV_CNT_MAX to 1, limiting the virtual
machine to a single block device. This commit introduces support for
multiple block devices by switching from statically allocated storage to
dynamic allocation based on CLI input.

Key changes:
1. Dynamic Allocation
Virtio block related fields are now dynamically allocated based on the
number of -x vblk options provided.

2. Device Tree Generation
The prewritten virtio@ subnode for block device in device/minimal.dts is
commented and it can be an example subnode for future reference.
load_dtb() dynamically appends virtio@ subnodes under the SoC node
based on the number of block devices.

3. MMIO Handling
Instead of hardcoding switch cases for each MMIO region of block device,
the code now checks whether the accessed MMIO address falls within the
valid range of any block device.

Note:
The /dev/vdx device order is assigned in reverse: the first -x vblk
argument corresponds to the device with the highest letter, while
subsequent arguments receive lower-lettered device names.

# Testing Procedure
0. Clone the branch
```
$ git clone https://github.com/ChinYikMing/rv32emu.git -b multiple-vblk --depth 1 && cd rv32emu
```

1. Create 2 disk images (more than 2 is also OK, just adjusting the -x vblk option)
```bash
$ dd if=/dev/zero of=disk1.img bs=4M count=32
$ mkfs.ext4 disk1.img

$ dd if=/dev/zero of=disk2.img bs=4M count=32
$ mkfs.ext4 disk2.img
```

2. Build the emulator
```bash
$ make ENABLE_SYSTEM=1 INITRD_SIZE=32 -j8
```

3. Fetch Linux Image artifact
```
$ make artifact ENABLE_SYSTEM=1
```

4. Boot the guestOS with 2 block devices
```bash
$ build/rv32emu -k build/linux-image/Image -i build/linux-image/rootfs.cpio -x vblk:disk1.img -x vblk:disk2.img
```

5. Show multiple block devices in guestOS
```bash
# ls /dev/vd*
```

6. Mount both block devices in guestOS
```bash
# mkdir -p mnt && mount /dev/vda mnt
# mkdir -p mnt2 && mount /dev/vdb mnt2
```

7. Write some data into the block devices
```bash
# echo "rv32emu" > mnt/emu.txt
# echo "rv32emu" > mnt2/emu.txt
```

8. Cat the written data in the block devices
```bash
# cat mnt/emu.txt
# cat mnt2/emu.txt
```

# Expected Result
```bash
# ls /dev/vd*
/dev/vda  /dev/vdb
# mkdir -p mnt && mount /dev/vda mnt
[   30.911107] EXT4-fs (vda): mounted filesystem with ordered data mode. Quota mode: disabled.
# mkdir -p mnt2 && mount /dev/vdb mnt2
[   39.067705] EXT4-fs (vdb): mounted filesystem with ordered data mode. Quota mode: disabled.
# echo "rv32emu" > mnt/emu.txt
# echo "rv32emu" > mnt2/emu.txt
# cat mnt/emu.txt
rv32emu
# cat mnt2/emu.txt
rv32emu
#
```