### PR TITLE
Enhance docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,18 @@
 FROM alpine:3.21 AS base_gcc
 
-RUN apk add --update alpine-sdk git wget sdl2-dev sdl2_mixer-dev
+RUN apk add --update alpine-sdk git wget sdl2-dev sdl2_mixer-dev dtc
 
 # copy in the source code
 WORKDIR /home/root/rv32emu
 COPY . .
 
-# generate execution file for rv32emu and rv_histogram
-RUN make
-RUN make tool
+# build and rename executables: rv32emu-user, rv32emu-system, and rv32emu-histogram
+RUN make -j"$(nproc)"
+RUN make tool -j"$(nproc)"
+RUN mv ./build/rv32emu ./build/rv32emu-user
+RUN mv ./build/rv_histogram ./build/rv32emu-histogram
+RUN make distclean
+RUN make ENABLE_SYSTEM=1 INITRD_SIZE=32 -j"$(nproc)"
 
 FROM alpine:3.21 AS final
 
@@ -18,8 +22,9 @@ COPY ./build/*.elf /home/root/rv32emu/build/
 # get rv32emu and rv_histogram binaries and lib of SDL2 and SDL2_mixer
 COPY --from=base_gcc /usr/include/SDL2/ /usr/include/SDL2/
 COPY --from=base_gcc /usr/lib/libSDL2* /usr/lib/
-COPY --from=base_gcc /home/root/rv32emu/build/rv32emu /home/root/rv32emu/build/rv32emu
-COPY --from=base_gcc /home/root/rv32emu/build/rv_histogram /home/root/rv32emu/build/rv_histogram
+COPY --from=base_gcc /home/root/rv32emu/build/rv32emu-user /home/root/rv32emu/build/rv32emu-user
+COPY --from=base_gcc /home/root/rv32emu/build/rv32emu /home/root/rv32emu/build/rv32emu-system
+COPY --from=base_gcc /home/root/rv32emu/build/rv32emu-histogram /home/root/rv32emu/build/rv32emu-histogram
 
 ENV PATH=/home/root/rv32emu/build:$PATH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 RUN make
 RUN make tool
 
-FROM alpine:3.19 AS final
+FROM alpine:3.21 AS final
 
 # copy in elf files
 COPY ./build/*.elf /home/root/rv32emu/build/

--- a/README.md
+++ b/README.md
@@ -143,6 +143,40 @@ The usage and limitations of Doom and Quake demo are listed in [docs/demo.md](do
 ### Docker image
 The image containing all the necessary tools for development and testing can be executed by `docker run -it sysprog21/rv32emu:latest`. It works for both x86-64 and aarch64 (e.g., Apple's M1 chip) machines.
 
+To keep the Docker image minimal, executables and prebuilt images are not embedded. Follow the steps below to fetch the required artifacts.
+
+##### User-Mode
+Fetch and extract the latest prebuilt user-mode ELF artifacts:
+```shell
+$ wget $(wget -qO- 'https://api.github.com/repos/sysprog21/rv32emu-prebuilt/releases?per_page=100' \
+  | grep browser_download_url | grep ELF | head -n 1 | cut -d '"' -f4)
+
+$ tar -xzvf rv32emu-prebuilt.tar.gz
+```
+To run `rv32emu-user`, consider the following examples:
+```shell
+# Run a local ELF program
+build/rv32emu-user build/hello.elf
+
+# Run a prebuilt user-mode program (e.g., pi)
+build/rv32emu-user rv32emu-prebuilt/riscv32/pi
+```
+
+##### System-Mode
+Fetch and extract the latest prebuilt system-mode Linux image artifacts:
+```shell
+$ wget $(wget -qO- 'https://api.github.com/repos/sysprog21/rv32emu-prebuilt/releases?per_page=100' \
+  | grep browser_download_url | grep Linux-Image | head -n 1 | cut -d '"' -f4)
+
+$ tar -xzvf rv32emu-linux-image-prebuilt.tar.gz
+```
+To run `rv32emu-system`, use the following:
+```shell
+$ build/rv32emu-system \
+  -k rv32emu-linux-image-prebuilt/linux-image/Image \
+  -i rv32emu-linux-image-prebuilt/linux-image/rootfs.cpio
+```
+
 ### Customization
 `rv32emu` is configurable, and you can override the below variable(s) to fit your expectations:
 * `ENABLE_RV32E`: RV32E Base Integer Instruction Set


### PR DESCRIPTION
This commit updates the Docker image to include the following executables:
- rv32emu-user: for user-mode emulation
- rv32emu-system: for system-mode emulation
- rv_histogram: for statistical analysis

To keep the image compact, build artifacts are excluded from the final image. Instructions for retrieving prebuilt binaries are added to the README.

Close #581