### PR TITLE
Fix build with clang by using llvm-ar

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,7 @@ jobs:
             wget https://apt.llvm.org/llvm.sh
             sudo chmod +x ./llvm.sh
             sudo ./llvm.sh 18
+            echo "/usr/lib/llvm-18/bin" >> $GITHUB_PATH
       shell: bash
     - name: Install compiler
       id: install_cc
@@ -319,6 +320,7 @@ jobs:
           PARALLEL: ${{ env.PARALLEL }}
         # Append custom commands here
         run: |
+          export PATH=/usr/lib/llvm-18/bin:$PATH
           make artifact
           make $PARALLEL
           make check $PARALLEL
@@ -342,6 +344,7 @@ jobs:
              brew install make dtc expect sdl2 sdl2_mixer bc e2fsprogs p7zip llvm@18 dcfldd
              .ci/riscv-toolchain-install.sh
              echo "${{ github.workspace }}/toolchain/bin" >> $GITHUB_PATH
+             echo "$(brew --prefix llvm@18)/bin" >> $GITHUB_PATH
      - name: Install compiler
        id: install_cc
        uses: rlalik/setup-cpp-compiler@master

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,9 @@ ENABLE_EXT_F ?= 1
 $(call set-feature, EXT_F)
 ifeq ($(call has, EXT_F), 1)
 AR := ar
+ifeq ("$(CC_IS_CLANG)", "1")
+AR = llvm-ar
+endif
 ifeq ("$(CC_IS_EMCC)", "1")
 AR = emar
 endif


### PR DESCRIPTION
When building with clang and RV32F enabled, linking fails with undefined references to SoftFloat functions. For example:

$ make CC=clang-18

/usr/bin/ld: /tmp/lto-llvm-28abb9.o: in function `do_fmadds':
emulate.c:(.text.do_fmadds+0x3c): undefined reference to `f32_mulAdd'
/usr/bin/ld: /tmp/lto-llvm-28abb9.o: in function `do_fadds':
emulate.c:(.text.do_fadds+0x31): undefined reference to `f32_add'

This happens because GNU ar cannot correctly archive objects compiled with clang. Switch to llvm-ar when CC is clang, ensuring the SoftFloat library is archived correctly and the build succeeds.