### PR TITLE
CI: Add curl-or-wget wrapper and shared download functions

### DIFF
--- a/.ci/boot-linux-prepare.sh
+++ b/.ci/boot-linux-prepare.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-. .ci/common.sh
+# Get the directory of this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${SCRIPT_DIR}/common.sh"
 
 check_platform
 

--- a/.ci/boot-linux.sh
+++ b/.ci/boot-linux.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-. .ci/common.sh
+# Get the directory of this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${SCRIPT_DIR}/common.sh"
 
 check_platform
 

--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -20,3 +20,131 @@ if [[ "${OS_TYPE}" == "Linux" ]]; then
 else
     PARALLEL=-j$(sysctl -n hw.logicalcpu)
 fi
+
+# Universal download utility with curl/wget compatibility
+# Provides consistent interface regardless of which tool is available
+
+# Detect available download tool (lazy initialization)
+detect_download_tool()
+{
+    if [ -n "${DOWNLOAD_TOOL:-}" ]; then
+        return 0
+    fi
+
+    if command -v curl > /dev/null 2>&1; then
+        DOWNLOAD_TOOL="curl"
+    elif command -v wget > /dev/null 2>&1; then
+        DOWNLOAD_TOOL="wget"
+    else
+        echo "Error: Neither curl nor wget is available" >&2
+        return 1
+    fi
+}
+
+# Download to stdout
+# Usage: download_to_stdout <url>
+download_to_stdout()
+{
+    detect_download_tool || return 1
+    local url="$1"
+    case "$DOWNLOAD_TOOL" in
+        curl)
+            curl -fsSL "$url"
+            ;;
+        wget)
+            wget -qO- "$url"
+            ;;
+    esac
+}
+
+# Download to file
+# Usage: download_to_file <url> <output_file>
+download_to_file()
+{
+    detect_download_tool || return 1
+    local url="$1"
+    local output="$2"
+    case "$DOWNLOAD_TOOL" in
+        curl)
+            curl -fsSL -o "$output" "$url"
+            ;;
+        wget)
+            wget -q -O "$output" "$url"
+            ;;
+    esac
+}
+
+# Download with headers (for API calls)
+# Usage: download_with_headers <url> <header1> <header2> ...
+download_with_headers()
+{
+    detect_download_tool || return 1
+    local url="$1"
+    shift
+    local headers=()
+
+    case "$DOWNLOAD_TOOL" in
+        curl)
+            for header in "$@"; do
+                headers+=(-H "$header")
+            done
+            curl -fsSL "${headers[@]}" "$url"
+            ;;
+        wget)
+            for header in "$@"; do
+                headers+=(--header="$header")
+            done
+            wget -qO- "${headers[@]}" "$url"
+            ;;
+    esac
+}
+
+# Download silently (no progress, suitable for CI)
+# Usage: download_silent <url>
+download_silent()
+{
+    detect_download_tool || return 1
+    local url="$1"
+    case "$DOWNLOAD_TOOL" in
+        curl)
+            curl -fsSL "$url"
+            ;;
+        wget)
+            wget -qO- "$url"
+            ;;
+    esac
+}
+
+# Download with progress bar (for interactive use)
+# Usage: download_with_progress <url> <output_file>
+download_with_progress()
+{
+    detect_download_tool || return 1
+    local url="$1"
+    local output="$2"
+    case "$DOWNLOAD_TOOL" in
+        curl)
+            curl -fL -# -o "$output" "$url"
+            ;;
+        wget)
+            wget -O "$output" "$url"
+            ;;
+    esac
+}
+
+# Check if URL is accessible
+# Usage: check_url <url>
+# Returns: 0 if accessible, 1 otherwise
+check_url()
+{
+    detect_download_tool || return 1
+    local url="$1"
+    case "$DOWNLOAD_TOOL" in
+        curl)
+            curl -fsSL --head "$url" > /dev/null 2>&1
+            ;;
+        wget)
+            wget --spider -q "$url" 2> /dev/null
+            ;;
+    esac
+}

--- a/.ci/riscv-tests.sh
+++ b/.ci/riscv-tests.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-. .ci/common.sh
+# Get the directory of this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${SCRIPT_DIR}/common.sh"
 
 set -e -u -o pipefail
 

--- a/.ci/riscv-toolchain-install.sh
+++ b/.ci/riscv-toolchain-install.sh
@@ -2,7 +2,9 @@
 
 set -e -u -o pipefail
 
-. .ci/common.sh
+# Get the directory of this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${SCRIPT_DIR}/common.sh"
 
 check_platform
 mkdir -p toolchain
@@ -30,4 +32,16 @@ else
     TOOLCHAIN_URL=${TOOLCHAIN_REPO}/releases/download/${GCC_VER}/riscv32-elf-ubuntu-${UBUNTU_VER}-gcc-nightly-${GCC_VER}-nightly.tar.xz
 fi
 
-wget ${TOOLCHAIN_URL} -O- | tar -xz --strip-components=1 -C toolchain
+# Detect compression type and extract accordingly
+case "${TOOLCHAIN_URL}" in
+    *.tar.xz)
+        download_to_stdout "${TOOLCHAIN_URL}" | tar -xJ --strip-components=1 -C toolchain
+        ;;
+    *.tar.gz)
+        download_to_stdout "${TOOLCHAIN_URL}" | tar -xz --strip-components=1 -C toolchain
+        ;;
+    *)
+        echo "Error: Unknown archive format for ${TOOLCHAIN_URL}" >&2
+        exit 1
+        ;;
+esac

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -369,29 +369,31 @@ jobs:
        env:
          CC: ${{ steps.install_cc.outputs.cc }}
        run: |
-             LATEST_RELEASE=$(wget --header="Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -q \
-                                   https://api.github.com/repos/sysprog21/rv32emu-prebuilt/releases -O- \
+             . .ci/common.sh
+             LATEST_RELEASE=$(download_with_headers "https://api.github.com/repos/sysprog21/rv32emu-prebuilt/releases" \
+                                                    "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
                                      | grep '"tag_name"' \
                                      | grep "ELF" \
                                      | head -n 1 \
                                      | sed -E 's/.*"tag_name": "([^"]+)".*/\1/')
              make LATEST_RELEASE=$LATEST_RELEASE artifact
-             LATEST_RELEASE=$(wget --header="Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -q \
-                                   https://api.github.com/repos/sysprog21/rv32emu-prebuilt/releases -O- \
+             LATEST_RELEASE=$(download_with_headers "https://api.github.com/repos/sysprog21/rv32emu-prebuilt/releases" \
+                                                    "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
                                      | grep '"tag_name"' \
                                      | grep "Linux-Image" \
                                      | head -n 1 \
                                      | sed -E 's/.*"tag_name": "([^"]+)".*/\1/')
              make LATEST_RELEASE=$LATEST_RELEASE ENABLE_SYSTEM=1 artifact
-             LATEST_RELEASE=$(wget --header="Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -q \
-                                   https://api.github.com/repos/sysprog21/rv32emu-prebuilt/releases -O- \
+             LATEST_RELEASE=$(download_with_headers "https://api.github.com/repos/sysprog21/rv32emu-prebuilt/releases" \
+                                                    "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
                                      | grep '"tag_name"' \
                                      | grep "sail" \
                                      | head -n 1 \
                                      | sed -E 's/.*"tag_name": "([^"]+)".*/\1/')
              make LATEST_RELEASE=$LATEST_RELEASE ENABLE_ARCH_TEST=1 artifact
              # get from rv32emu-prebuilt
-             wget -O build/shareware_doom_iwad.zip "https://raw.githubusercontent.com/sysprog21/rv32emu-prebuilt/doom-artifact/shareware_doom_iwad.zip"
+             download_to_file "https://raw.githubusercontent.com/sysprog21/rv32emu-prebuilt/doom-artifact/shareware_doom_iwad.zip" \
+                             "build/shareware_doom_iwad.zip"
              unzip -d build/ build/shareware_doom_iwad.zip
        if: ${{ always() }}
      - name: default build using emcc


### PR DESCRIPTION
This adds a universal download compatibility layer that works with curl or wget, along with download utility functions to .ci/common.sh script.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Introduce a curl/wget compatibility layer and shared download helpers in .ci/common.sh to make CI downloads robust across environments and reduce duplicated shell code.

- New Features
  - Auto-detects curl or wget and exposes a consistent API.
  - Added helpers: download_to_stdout, download_to_file, download_with_headers, download_silent, download_with_progress, check_url.

- Refactors
  - .ci/riscv-toolchain-install.sh now pipes download_to_stdout into tar.
  - .github/workflows/main.yml sources .ci/common.sh and replaces wget calls with download_with_headers and download_to_file for release queries and asset downloads.

<!-- End of auto-generated description by cubic. -->

