### PR TITLE
Fix -Werror=maybe-uninitialized warning

### DIFF
--- a/src/map.c
+++ b/src/map.c
@@ -572,7 +572,7 @@ bool map_insert(map_t obj, const void *key, const void *val)
         return false;
 
     rb_path_entry_t path[RB_MAX_DEPTH];
-    rb_path_entry_t *pathp;
+    rb_path_entry_t *pathp = NULL;
 
     /* Single traversal to check existence and get insertion point */
     const map_node_t *existing = rb_insert_unique(obj, key, path, &pathp);


### PR DESCRIPTION
GCC with AddressSanitizer reports that pathp in map_insert() may be used uninitialized:
```
src/map.c:593:15: error: pathp may be used uninitialized
  593 |     for (pathp--; (uintptr_t) pathp >= (uintptr_t) path; pathp--)
```

While the program logic ensures pathp is always initialized through rb_insert_unique() before use, static analysis cannot prove this due to the pointer-to-pointer assignment pattern. Initialize to NULL to satisfy the compiler and improve defensive programming.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Initialize pathp to NULL in map_insert() to silence GCC -Werror=maybe-uninitialized under AddressSanitizer and prevent build failures. No functional change; rb_insert_unique() still sets pathp before use, this just makes the compiler happy.

<!-- End of auto-generated description by cubic. -->

