### PR TITLE
Fix critical memory safety issues

### DIFF
--- a/src/elf.c
+++ b/src/elf.c
@@ -274,14 +274,14 @@ bool elf_load(elf_t *e, memory_t *mem)
 
         /* memcpy required range */
         const int to_copy = min(phdr->p_memsz, phdr->p_filesz);
-        if (to_copy)
-            memory_write(mem, phdr->p_vaddr, e->raw_data + phdr->p_offset,
-                         to_copy);
+        if (to_copy && !memory_write(mem, phdr->p_vaddr,
+                                     e->raw_data + phdr->p_offset, to_copy))
+            return false;
 
         /* zero fill required range */
         const int to_zero = max(phdr->p_memsz, phdr->p_filesz) - to_copy;
-        if (to_zero)
-            memory_fill(mem, phdr->p_vaddr + to_copy, to_zero, 0);
+        if (to_zero && !memory_fill(mem, phdr->p_vaddr + to_copy, to_zero, 0))
+            return false;
     }
 
     return true;

--- a/src/io.c
+++ b/src/io.c
@@ -23,6 +23,8 @@ memory_t *memory_new(uint32_t size)
         return NULL;
 
     memory_t *mem = malloc(sizeof(memory_t));
+    if (!mem)
+        return NULL;
     assert(mem);
 #if HAVE_MMAP
     data_memory_base = mmap(NULL, size, PROT_READ | PROT_WRITE,

--- a/src/io.h
+++ b/src/io.h
@@ -36,12 +36,16 @@ uint8_t memory_read_b(uint32_t addr);
 void memory_read(const memory_t *m, uint8_t *dst, uint32_t addr, uint32_t size);
 
 /* write a length of data to memory */
-static inline void memory_write(memory_t *m,
+static inline bool memory_write(memory_t *m,
                                 uint32_t addr,
                                 const uint8_t *src,
                                 uint32_t size)
 {
+    /* Bounds checking to prevent buffer overflow */
+    if (addr >= m->mem_size || size > m->mem_size - addr)
+        return false;
     memcpy(m->mem_base + addr, src, size);
+    return true;
 }
 
 /* write a word to memory */
@@ -54,10 +58,14 @@ void memory_write_s(uint32_t addr, const uint8_t *src);
 void memory_write_b(uint32_t addr, const uint8_t *src);
 
 /* write a length of certain value to memory */
-static inline void memory_fill(memory_t *m,
+static inline bool memory_fill(memory_t *m,
                                uint32_t addr,
                                uint32_t size,
                                uint8_t val)
 {
+    /* Bounds checking to prevent buffer overflow */
+    if (addr >= m->mem_size || size > m->mem_size - addr)
+        return false;
     memset(m->mem_base + addr, val, size);
+    return true;
 }

--- a/src/syscall_sdl.c
+++ b/src/syscall_sdl.c
@@ -216,9 +216,10 @@ static submission_t submission_pop(riscv_t *rv)
 static void event_push(riscv_t *rv, event_t event)
 {
     vm_attr_t *attr = PRIV(rv);
-    memory_write(attr->mem,
-                 event_queue.base + event_queue.end * sizeof(event_t),
-                 (void *) &event, sizeof(event_t));
+    if (!memory_write(attr->mem,
+                      event_queue.base + event_queue.end * sizeof(event_t),
+                      (void *) &event, sizeof(event_t)))
+        return;
     ++event_queue.end;
     event_queue.end &= queues_capacity - 1;
 


### PR DESCRIPTION
This adds explicit NULL checks for all malloc/calloc/mpool_alloc calls that previously relied solely on assert(), which compiles out with `-DNDEBUG`. It prevents NULL pointer dereferences in production builds.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds NULL checks and graceful fallbacks for critical allocations across the emulator, JIT, cache, IO, and syscalls. Prevents crashes when assert() is disabled and degrades behavior safely on OOM.

- **Bug Fixes**
  - Block/IR/branch-table allocations now checked; translation can fail cleanly.
  - Fused operation generation falls back to non-fused ops if malloc fails.
  - JIT init and queue entry allocations validated; cleanup on failure; skip tier-2 enqueue on OOM.
  - Cache put restores the replaced entry if new allocation fails.
  - IO, syscall, and riscv init guard malloc/calloc; return NULL or -1 instead of crashing.

<!-- End of auto-generated description by cubic. -->

