### PR TITLE
Refine build system for efficient configurations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -283,8 +283,14 @@ jobs:
     - name: Architecture test
       env:
         CC: ${{ steps.install_cc.outputs.cc }}
-        LATEST_RELEASE: dummy
       run: |
+            . .ci/common.sh
+            export LATEST_RELEASE=$(download_with_headers "https://api.github.com/repos/sysprog21/rv32emu-prebuilt/releases" \
+                                                          "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+                                           | grep '"tag_name"' \
+                                           | grep "sail" \
+                                           | head -n 1 \
+                                           | sed -E 's/.*"tag_name": "([^"]+)".*/\1/')
             .ci/riscv-tests.sh
       if: ${{ always() }}
 
@@ -342,7 +348,8 @@ jobs:
      - uses: actions/checkout@v4
      - name: install-dependencies
        run: |
-             brew install make dtc expect sdl2 sdl2_mixer bc e2fsprogs p7zip llvm@18 dcfldd
+             brew install make dtc expect sdl2 bc e2fsprogs p7zip llvm@18 dcfldd
+             brew install sdl2_mixer || echo "Warning: sdl2_mixer installation failed, continuing without SDL_MIXER support"
              .ci/riscv-toolchain-install.sh
              echo "${{ github.workspace }}/toolchain/bin" >> $GITHUB_PATH
              echo "$(brew --prefix llvm@18)/bin" >> $GITHUB_PATH
@@ -493,8 +500,14 @@ jobs:
      - name: Architecture test
        env:
          CC: ${{ steps.install_cc.outputs.cc }}
-         LATEST_RELEASE: dummy
        run: |
+             . .ci/common.sh
+             export LATEST_RELEASE=$(download_with_headers "https://api.github.com/repos/sysprog21/rv32emu-prebuilt/releases" \
+                                                           "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+                                            | grep '"tag_name"' \
+                                            | grep "sail" \
+                                            | head -n 1 \
+                                            | sed -E 's/.*"tag_name": "([^"]+)".*/\1/')
              python3 -m venv venv
              . venv/bin/activate
              .ci/riscv-tests.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -283,6 +283,7 @@ jobs:
     - name: Architecture test
       env:
         CC: ${{ steps.install_cc.outputs.cc }}
+        LATEST_RELEASE: dummy
       run: |
             .ci/riscv-tests.sh
       if: ${{ always() }}
@@ -492,6 +493,7 @@ jobs:
      - name: Architecture test
        env:
          CC: ${{ steps.install_cc.outputs.cc }}
+         LATEST_RELEASE: dummy
        run: |
              python3 -m venv venv
              . venv/bin/activate
@@ -529,8 +531,12 @@ jobs:
             sudo apt-get install -q=2 clang-18 clang-tools-18
       shell: bash
     - name: run scan-build without JIT
+      env:
+        LATEST_RELEASE: dummy
       run: make distclean && scan-build-18 -v -o ~/scan-build --status-bugs --use-cc=clang-18 --force-analyze-debug-code --show-description -analyzer-config stable-report-filename=true -enable-checker valist,nullability make ENABLE_EXT_F=0 ENABLE_SDL=0 ENABLE_JIT=0
     - name: run scan-build with JIT
+      env:
+        LATEST_RELEASE: dummy
       run: |
           make ENABLE_JIT=1 distclean && scan-build-18 -v -o ~/scan-build --status-bugs --use-cc=clang-18 --force-analyze-debug-code --show-description -analyzer-config stable-report-filename=true -enable-checker valist,nullability make ENABLE_EXT_F=0 ENABLE_SDL=0 ENABLE_JIT=1
 

--- a/Makefile
+++ b/Makefile
@@ -207,15 +207,10 @@ $(warning No sdl2-config in $$PATH. Check SDL2 installation in advance)
 override ENABLE_SDL := 0
 endif
 ifeq (1, $(shell pkg-config --exists SDL2_mixer; echo $$?))
-$(warning No SDL2_mixer lib installed. Check SDL2_mixer installation in advance)
-override ENABLE_SDL := 0
+$(warning No SDL2_mixer lib installed. SDL2_mixer support will be disabled)
 override ENABLE_SDL_MIXER := 0
 endif
 endif
-else
-# Disable SDL_MIXER for emscripten builds to avoid SDL2_mixer port compilation issues
-# The emscripten-ports/SDL2_mixer was archived in Jan 2024 with unfixable warnings
-override ENABLE_SDL_MIXER := 0
 endif
 $(call set-feature, SDL)
 $(call set-feature, SDL_MIXER)

--- a/mk/external.mk
+++ b/mk/external.mk
@@ -4,10 +4,10 @@ COMPRESSED_IS_DIR :=
 EXTRACTOR :=
 VERIFIER :=
 
-# temporarily files to store correct SHA value and computed SHA value
+# Temporary files to store correct SHA value and computed SHA value
 # respectively for verification of directory source
-$(eval SHA_FILE1 := $(shell mktemp))
-$(eval SHA_FILE2 := $(shell mktemp))
+SHA_FILE1 := $(shell mktemp)
+SHA_FILE2 := $(shell mktemp)
 
 # $(1): compressed source
 define prologue
@@ -17,7 +17,7 @@ endef
 
 # $(1), $(2), $(3): files to be deleted
 define epilogue
-    $(eval _ := $(shell $(RM) $(1) $(2) $(3)))
+    $(RM) $(1) $(2) $(3)
 endef
 
 # $(1): compressed source URL

--- a/mk/riscv-arch-test.mk
+++ b/mk/riscv-arch-test.mk
@@ -1,8 +1,8 @@
 riscof-check:
 	$(Q)if [ "$(shell pip show riscof 2>&1 | head -n 1 | cut -d' ' -f1)" = "WARNING:" ]; then \
-	$(PRINTF) "Run 'pip3 install -r requirements.txt to install dependencies.\n"; \
-	exit 1; \
-	fi;
+		$(PRINTF) "Run 'pip3 install -r requirements.txt' to install dependencies.\n"; \
+		exit 1; \
+	fi
 
 ARCH_TEST_DIR ?= tests/riscv-arch-test
 ARCH_TEST_SUITE ?= $(ARCH_TEST_DIR)/riscv-test-suite
@@ -27,3 +27,5 @@ endif
 			--config=$(RISCV_TARGET)/config.ini \
 			--suite=$(ARCH_TEST_SUITE) \
 			--env=$(ARCH_TEST_DIR)/riscv-test-suite/env
+
+.PHONY: riscof-check arch-test

--- a/mk/softfloat.mk
+++ b/mk/softfloat.mk
@@ -334,10 +334,12 @@ $(SOFTFLOAT_DUMMY_PLAT):
 	$(Q)touch $@
 
 $(SOFTFLOAT_FILES): $(SOFTFLOAT_SENTINEL)
-$(OUT)/softfloat/%.o: $(SOFTFLOAT_DIR)/%.c $(SOFTFLOAT_SENTINEL) $(SOFTFLOAT_DUMMY_PLAT)
-	$(Q)mkdir -p $(shell dirname $@)
+$(OUT)/softfloat/%.o: $(SOFTFLOAT_DIR)/%.c $(CONFIG_FILE) $(SOFTFLOAT_SENTINEL) $(SOFTFLOAT_DUMMY_PLAT) | $(OUT)/softfloat $(OUT)/softfloat/RISCV
 	$(VECHO) "  CC\t$@\n"
 	$(Q)$(CC) -o $@ $(CFLAGS) $(CFLAGS_softfloat) -c -MMD -MF $@.d $<
+
+$(OUT)/softfloat $(OUT)/softfloat/RISCV:
+	$(Q)mkdir -p $@
 
 SOFTFLOAT_LIB := $(OUT)/softfloat/softfloat.a
 $(SOFTFLOAT_LIB): $(SOFTFLOAT_OBJS)

--- a/mk/system.mk
+++ b/mk/system.mk
@@ -29,10 +29,13 @@ $(BUILD_DTB2C): $(BIN_TO_C) $(BUILD_DTB)
 	$(VECHO) "  BIN2C\t$@\n"
 	$(Q)$(BIN_TO_C) $(BUILD_DTB) > $@
 
-$(DEV_OUT)/%.o: $(DEV_SRC)/%.c $(deps_emcc)
-	$(Q)mkdir -p $(DEV_OUT)
+$(DEV_OUT)/%.o: $(DEV_SRC)/%.c $(CONFIG_FILE) $(deps_emcc) | $(DEV_OUT)
 	$(VECHO) "  CC\t$@\n"
 	$(Q)$(CC) -o $@ $(CFLAGS) $(CFLAGS_emcc) -c -MMD -MF $@.d $<
+
+$(DEV_OUT):
+	$(Q)mkdir -p $@
+
 DEV_OBJS := $(patsubst $(DEV_SRC)/%.c, $(DEV_OUT)/%.o, $(wildcard $(DEV_SRC)/*.c))
 deps := $(DEV_OBJS:%.o=%.o.d)
 
@@ -45,5 +48,7 @@ system_action := ($(BIN) -k $(OUT)/$(LINUX_IMAGE_DIR)/Image -i $(OUT)/$(LINUX_IM
 system_deps += artifact $(BUILD_DTB) $(BUILD_DTB2C) $(BIN)
 system: $(system_deps)
 	$(system_action)
+
+.PHONY: system
 
 endif

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -85,10 +85,12 @@ $(CACHE_TEST_TARGET): $(CACHE_TEST_OBJS)
 	$(VECHO) "  CC\t$@\n"
 	$(Q)$(CC) $^ -o $@ $(LDFLAGS)
 
-$(CACHE_TEST_OUTDIR)/%.o: $(CACHE_TEST_SRCDIR)/%.c
+$(CACHE_TEST_OUTDIR)/%.o: $(CACHE_TEST_SRCDIR)/%.c $(CONFIG_FILE) | $(CACHE_TEST_OUTDIR) $(CACHE_TEST_OUTDIR)/lfu
 	$(VECHO) "  CC\t$@\n"
-	$(Q)mkdir -p $(dir $@)/lfu
 	$(Q)$(CC) -o $@ $(CFLAGS) -I./src -c -MMD -MF $@.d $<
+
+$(CACHE_TEST_OUTDIR) $(CACHE_TEST_OUTDIR)/lfu:
+	$(Q)mkdir -p $@
 
 $(MAP_TEST_OUT): $(MAP_TEST_TARGET)
 	$(Q)touch $@
@@ -97,10 +99,12 @@ $(MAP_TEST_TARGET): $(MAP_TEST_OBJS)
 	$(VECHO) "  CC\t$@\n"
 	$(Q)$(CC) $^ -o $@ $(LDFLAGS)
 
-$(MAP_TEST_OUTDIR)/%.o: $(MAP_TEST_SRCDIR)/%.c
+$(MAP_TEST_OUTDIR)/%.o: $(MAP_TEST_SRCDIR)/%.c $(CONFIG_FILE) | $(MAP_TEST_OUTDIR)
 	$(VECHO) "  CC\t$@\n"
-	$(Q)mkdir -p $(dir $@)
 	$(Q)$(CC) -o $@ $(CFLAGS) -I./src -c -MMD -MF $@.d $<
+
+$(MAP_TEST_OUTDIR):
+	$(Q)mkdir -p $@
 
 $(PATH_TEST_OUT): $(PATH_TEST_TARGET)
 	$(Q)touch $@
@@ -109,7 +113,11 @@ $(PATH_TEST_TARGET): $(PATH_TEST_OBJS)
 	$(VECHO) "  CC\t$@\n"
 	$(Q)$(CC) $^ -o $@ $(LDFLAGS)
 
-$(PATH_TEST_OUTDIR)/%.o: $(PATH_TEST_SRCDIR)/%.c
+$(PATH_TEST_OUTDIR)/%.o: $(PATH_TEST_SRCDIR)/%.c $(CONFIG_FILE) | $(PATH_TEST_OUTDIR)
 	$(VECHO) "  CC\t$@\n"
-	$(Q)mkdir -p $(dir $@)
 	$(Q)$(CC) -o $@ $(CFLAGS) -I./src -c -MMD -MF $@.d $<
+
+$(PATH_TEST_OUTDIR):
+	$(Q)mkdir -p $@
+
+.PHONY: tests run-test-cache run-test-map run-test-path

--- a/mk/tools.mk
+++ b/mk/tools.mk
@@ -23,7 +23,7 @@ HIST_OBJS := \
 HIST_OBJS := $(addprefix $(OUT)/, $(HIST_OBJS))
 deps += $(HIST_OBJS:%.o=%.o.d)
 
-$(OUT)/%.o: tools/%.c
+$(OUT)/%.o: tools/%.c | $(OUT)
 	$(VECHO) "  CC\t$@\n"
 	$(Q)$(CC) -o $@ $(CFLAGS) -Wno-missing-field-initializers -Isrc -c -MMD -MF $@.d $<
 
@@ -39,3 +39,5 @@ LINUX_IMAGE_SRC = $(BUILDROOT_DATA) $(LINUX_DATA)
 build-linux-image: $(LINUX_IMAGE_SRC)
 	$(Q)./tools/build-linux-image.sh
 	$(Q)$(PRINTF) "Build done.\n"
+
+.PHONY: build-linux-image

--- a/mk/wasm.mk
+++ b/mk/wasm.mk
@@ -18,7 +18,10 @@ CFLAGS += -mtail-call
 
 # Build emscripten-port SDL
 ifeq ($(call has, SDL), 1)
-CFLAGS_emcc += -sUSE_SDL=2 -sSDL2_MIXER_FORMATS=wav,mid -sUSE_SDL_MIXER=2
+# Disable STRICT mode to avoid -Werror in SDL2_mixer port compilation.
+# The emscripten-ports/SDL2_mixer was archived in Jan 2024 and has warnings
+# in music_modplug.c that become fatal errors under STRICT mode.
+CFLAGS_emcc += -sSTRICT=0 -sUSE_SDL=2 -sSDL2_MIXER_FORMATS=wav,mid -sUSE_SDL_MIXER=2
 OBJS_EXT += syscall_sdl.o
 LDFLAGS += -pthread
 endif
@@ -159,4 +162,7 @@ start-web: $(start_web_deps)
 	$(foreach T, $(STATIC_WEB_FILES), $(call cp-web-file, $(T)))
 	$(Q)mv $(DEMO_DIR)/*.html $(DEMO_DIR)/index.html
 	$(Q)python3 -m http.server --bind $(DEMO_IP) $(DEMO_PORT) --directory $(DEMO_DIR)
+
+.PHONY: check-demo-dir-exist start-web
+
 endif

--- a/src/syscall_sdl.c
+++ b/src/syscall_sdl.c
@@ -849,7 +849,9 @@ static void play_sfx(riscv_t *rv)
      * after sfx_handler return, thus we have to join them. sfx_handler does not
      * contain infinite loop,so do not worry to be stalled by it */
 #ifdef __EMSCRIPTEN__
+#if RV32_HAS(SDL_MIXER)
     pthread_join(sfx_thread, NULL);
+#endif
 #endif
 }
 
@@ -908,7 +910,9 @@ static void play_music(riscv_t *rv)
      * after music_handler return, thus we have to join them. music_handler does
      * not contain infinite loop,so do not worry to be stalled by it */
 #ifdef __EMSCRIPTEN__
+#if RV32_HAS(SDL_MIXER)
     pthread_join(music_thread, NULL);
+#endif
 #endif
 }
 
@@ -981,13 +985,16 @@ static void shutdown_audio()
         pthread_join(sfx_thread, NULL);
         Mix_HaltChannel(-1);
         Mix_FreeChunk(sfx_chunk);
-        free(sfx_samples);
-        sfx_samples = NULL;
     }
 
     Mix_CloseAudio();
     Mix_Quit();
 #endif
+
+    if (sfx_samples) {
+        free(sfx_samples);
+        sfx_samples = NULL;
+    }
 
     audio_init = sfx_thread_init = music_thread_init = false;
 }


### PR DESCRIPTION
This addresses build system inefficiencies and compatibility issues:
1. Configuration change detection: Use cmp-based comparison to avoid unnecessary rebuilds when configuration hasn't actually changed. Previously, every make run would touch .config and trigger full rebuilds.
2. Directory creation optimization: Replace runtime mkdir -p $(shell dirname) calls with order-only prerequisites (|).
3. Configuration dependency tracking: Add $(CONFIG_FILE) as explicit prerequisite to all compilation rules. This ensures object files rebuild when feature flags change (e.g., ENABLE_JIT=1 -> 0).
4. Build system hygiene: Remove duplicate .PHONY declarations, fix shell script indentation in riscv-arch-test.mk, and add .PHONY coverage for all target declarations.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Speeds up and stabilizes the Make build by only updating .config when values change and rebuilding objects when feature flags change. Also replaces ad‑hoc mkdir calls with proper directory prerequisites and adds clearer config warnings.

- **Refactors**
  - Update .config only when config actually changes; remove forced config step from default build.
  - Track $(CONFIG_FILE) in all compile rules (core, dev, tests, tools, softfloat) so files rebuild when flags change.
  - Use order-only prerequisites and explicit dir targets instead of inline mkdir.
  - Add GNU make version check for order-only prerequisites.
  - Clean up .PHONY targets and minor make/script formatting; soften noisy logs (use warnings where appropriate).
  - Add config validation messages (e.g., SDL with SYSTEM/FULL4G, T2C disabled note).

- **Migration**
  - Requires GNU make 3.81 or newer.

<!-- End of auto-generated description by cubic. -->

