### PR TITLE
Fix DTB conditional build regression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -311,7 +311,14 @@ include mk/artifact.mk
 include mk/system.mk
 include mk/wasm.mk
 
-all: config $(BUILD_DTB) $(BUILD_DTB2C) $(BIN)
+DTB_DEPS :=
+ifeq ($(call has, SYSTEM), 1)
+ifeq ($(call has, ELF_LOADER), 0)
+DTB_DEPS := $(BUILD_DTB) $(BUILD_DTB2C)
+endif
+endif
+
+all: config $(DTB_DEPS) $(BIN)
 
 OBJS := \
     map.o \


### PR DESCRIPTION
Only build DTB when ENABLE_SYSTEM=1 and ENABLE_ELF_LOADER=0, resolving DTC syntax errors that occur when building with ELF loader mode enabled, as CFLAGS_dt macros are only defined in kernel emulation mode.

The DTB is only needed for Linux kernel emulation, not for ELF loader mode which loads bare-metal programs directly.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Build the DTB only in kernel emulation mode, and skip it in ELF loader builds to prevent DTC syntax errors. DTB is only needed for kernel emulation; ELF loader runs bare-metal programs.

- **Bug Fixes**
  - Compute DTB_DEPS only when ENABLE_SYSTEM=1 and ENABLE_ELF_LOADER=0, and use it in the all target.
  - Skip DTB generation for ELF loader builds to avoid missing CFLAGS_dt macros.

<!-- End of auto-generated description by cubic. -->

