### PR TITLE
Fix JIT compilation with SYSTEM/ELF_LOADER enabled

### DIFF
--- a/src/feature.h
+++ b/src/feature.h
@@ -118,5 +118,16 @@
 #define RV32_FEATURE_ARCH_TEST 0
 #endif
 
+/* MMIO support for system emulation
+ * It is enabled when running in SYSTEM mode without ELF_LOADER, corresponding
+ * to booting a full Linux kernel that requires memory-mapped I/O to interact
+ * with virtual devices (UART, PLIC, virtio-blk).
+ */
+#if RV32_FEATURE_SYSTEM && !RV32_FEATURE_ELF_LOADER
+#define RV32_FEATURE_SYSTEM_MMIO 1
+#else
+#define RV32_FEATURE_SYSTEM_MMIO 0
+#endif
+
 /* Feature test macro */
 #define RV32_HAS(x) RV32_FEATURE_##x

--- a/src/jit.c
+++ b/src/jit.c
@@ -1395,7 +1395,7 @@ static void muldivmod(struct jit_state *state,
 }
 #endif /* RV32_HAS(EXT_M) */
 
-#if RV32_HAS(SYSTEM)
+#if RV32_HAS(SYSTEM_MMIO)
 uint32_t jit_mmio_read_wrapper(riscv_t *rv, uint32_t addr)
 {
     MMIO_READ();

--- a/src/rv32_jit.c
+++ b/src/rv32_jit.c
@@ -155,7 +155,7 @@ GEN(bgeu, {
 GEN(lb, {
     memory_t *m = PRIV(rv)->mem;
     vm_reg[0] = ra_load(state, ir->rs1);
-    IIF(RV32_HAS(SYSTEM))
+    IIF(RV32_HAS(SYSTEM_MMIO))
     (
         {
             emit_load_imm_sext(state, temp_reg, ir->imm);
@@ -207,7 +207,7 @@ GEN(lb, {
 GEN(lh, {
     memory_t *m = PRIV(rv)->mem;
     vm_reg[0] = ra_load(state, ir->rs1);
-    IIF(RV32_HAS(SYSTEM))
+    IIF(RV32_HAS(SYSTEM_MMIO))
     (
         {
             emit_load_imm_sext(state, temp_reg, ir->imm);
@@ -259,7 +259,7 @@ GEN(lh, {
 GEN(lw, {
     memory_t *m = PRIV(rv)->mem;
     vm_reg[0] = ra_load(state, ir->rs1);
-    IIF(RV32_HAS(SYSTEM))
+    IIF(RV32_HAS(SYSTEM_MMIO))
     (
         {
             emit_load_imm_sext(state, temp_reg, ir->imm);
@@ -311,7 +311,7 @@ GEN(lw, {
 GEN(lbu, {
     memory_t *m = PRIV(rv)->mem;
     vm_reg[0] = ra_load(state, ir->rs1);
-    IIF(RV32_HAS(SYSTEM))
+    IIF(RV32_HAS(SYSTEM_MMIO))
     (
         {
             emit_load_imm_sext(state, temp_reg, ir->imm);
@@ -363,7 +363,7 @@ GEN(lbu, {
 GEN(lhu, {
     memory_t *m = PRIV(rv)->mem;
     vm_reg[0] = ra_load(state, ir->rs1);
-    IIF(RV32_HAS(SYSTEM))
+    IIF(RV32_HAS(SYSTEM_MMIO))
     (
         {
             emit_load_imm_sext(state, temp_reg, ir->imm);
@@ -415,7 +415,7 @@ GEN(lhu, {
 GEN(sb, {
     memory_t *m = PRIV(rv)->mem;
     vm_reg[0] = ra_load(state, ir->rs1);
-    IIF(RV32_HAS(SYSTEM))
+    IIF(RV32_HAS(SYSTEM_MMIO))
     (
         {
             emit_load_imm_sext(state, temp_reg, ir->imm);
@@ -465,7 +465,7 @@ GEN(sb, {
 GEN(sh, {
     memory_t *m = PRIV(rv)->mem;
     vm_reg[0] = ra_load(state, ir->rs1);
-    IIF(RV32_HAS(SYSTEM))
+    IIF(RV32_HAS(SYSTEM_MMIO))
     (
         {
             emit_load_imm_sext(state, temp_reg, ir->imm);
@@ -515,7 +515,7 @@ GEN(sh, {
 GEN(sw, {
     memory_t *m = PRIV(rv)->mem;
     vm_reg[0] = ra_load(state, ir->rs1);
-    IIF(RV32_HAS(SYSTEM))
+    IIF(RV32_HAS(SYSTEM_MMIO))
     (
         {
             emit_load_imm_sext(state, temp_reg, ir->imm);

--- a/src/system.h
+++ b/src/system.h
@@ -16,6 +16,10 @@
 #define R 1
 #define W 0
 
+/* MMIO definitions for Linux kernel emulation.
+ * Only defined when ELF_LOADER is disabled, as kernel mode needs MMIO but ELF
+ * test mode does not.
+ */
 #if !RV32_HAS(ELF_LOADER)
 
 #define MMIO_R 1


### PR DESCRIPTION
This introduces `SYSTEM_MMIO` feature flag to properly gate MMIO-related code in JIT. This flag is enabled only when `SYSTEM=1` and `ELF_LOADER=0` (Linux kernel mode), preventing compilation errors when both SYSTEM and ELF_LOADER are enabled.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix JIT build when SYSTEM and ELF_LOADER are both enabled by gating MMIO code to Linux kernel mode only. This prevents compilation errors while keeping MMIO for kernel emulation.

- **Bug Fixes**
  - Introduced RV32_FEATURE_SYSTEM_MMIO (enabled when SYSTEM=1 and ELF_LOADER=0).
  - Switched JIT MMIO checks to RV32_HAS(SYSTEM_MMIO) in jit.c and rv32_jit.c.
  - Scoped MMIO macros in system.h behind !RV32_HAS(ELF_LOADER) to avoid conflicts.

<!-- End of auto-generated description by cubic. -->

