### PR TITLE
Support ~ in virtio-blk paths and improve error handling

### DIFF
--- a/.ci/boot-linux.sh
+++ b/.ci/boot-linux.sh
@@ -77,6 +77,19 @@ if [ "${ENABLE_VBLK}" -eq "1" ]; then
         expect "# " { send "\x01"; send "x" } timeout { exit 3 }
     ')
 
+    # Read-write using disk image with ~ home directory symbol
+    TEST_OPTIONS+=("${OPTS_BASE} -x vblk:~$(pwd | sed "s|$HOME||")/${VBLK_IMG}")
+    VBLK_EXPECT_CMDS='
+        expect "buildroot login:" { send "root\n" } timeout { exit 1 }
+        expect "# " { send "uname -a\n" } timeout { exit 2 }
+        expect "riscv32 GNU/Linux" { send "mkdir mnt && mount /dev/vda mnt\n" } timeout { exit 3 }
+        expect "# " { send "echo rv32emu > mnt/emu.txt\n" } timeout { exit 3 }
+        expect "# " { send "sync\n" } timeout { exit 3 }
+        expect "# " { send "umount mnt\n" } timeout { exit 3 }
+        expect "# " { send "\x01"; send "x" } timeout { exit 3 }
+    '
+    EXPECT_CMDS+=("${VBLK_EXPECT_CMDS}")
+
     # Read-write using disk image
     TEST_OPTIONS+=("${OPTS_BASE} -x vblk:${VBLK_IMG}")
     VBLK_EXPECT_CMDS='


### PR DESCRIPTION
This commit allows the virtio block device to resolve disk image paths starting with ~ to the user's home directory, making it more convenient. Additionally, it adds error handling for cases where the -x vblk: option is used without specifying a path.

## Testing
```
$ build/rv32emu -k build/linux-image/Image -i build/linux-image/rootfs.cpio -x vblk:~/disk_test.img
```

## Expectation
GuestOS is bootable and `~/disk_test.img` is accessible via `/dev/vda`.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enable ~ expansion in virtio-blk disk paths and add clear errors for invalid input. Users can now pass ~/disk.img; we resolve it to HOME and fail fast on empty paths or missing HOME.

- **New Features**
  - Expand ~ to $HOME in -x vblk: disk image paths.

- **Bug Fixes**
  - Reject empty vblk path with a clear error.
  - Error if HOME is unset when using ~.

<!-- End of auto-generated description by cubic. -->

