### PR TITLE
Support CSR_INSTRETH for insn counter high bits

### DIFF
--- a/src/emulate.c
+++ b/src/emulate.c
@@ -131,6 +131,8 @@ static uint32_t *csr_get_ptr(riscv_t *rv, uint32_t csr)
         return &rv->csr_time[1];
     case CSR_INSTRET: /* Number of Instructions Retired Counter */
         return (uint32_t *) (&rv->csr_cycle);
+    case CSR_INSTRETH: /* Upper 32 bits of instructions retired */
+        return &((uint32_t *) &rv->csr_cycle)[1];
 #if RV32_HAS(EXT_F)
     case CSR_FFLAGS:
         return (uint32_t *) (&rv->csr_fcsr);


### PR DESCRIPTION
This completes the CSR performance counter implementation by adding the missing CSR_INSTRETH handler. This register provides access to the upper 32 bits of the retired instruction counter, maintaining symmetry with CSR_CYCLEH.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add CSR_INSTRETH support to read the high 32 bits of the retired instruction counter (instret). This mirrors CSR_CYCLEH and completes the CSR performance counter implementation.

<!-- End of auto-generated description by cubic. -->

