### PR TITLE
Add simplefs as new Linux image artifact

### DIFF
--- a/.github/workflows/build-linux-artifacts.yml
+++ b/.github/workflows/build-linux-artifacts.yml
@@ -58,6 +58,7 @@ jobs:
           mkdir -p /tmp/rv32emu-linux-image-prebuilt/linux-image
           mv build/linux-image/Image /tmp/rv32emu-linux-image-prebuilt/linux-image
           mv build/linux-image/rootfs.cpio /tmp/rv32emu-linux-image-prebuilt/linux-image
+          mv build/linux-image/simplefs.ko /tmp/rv32emu-linux-image-prebuilt/simplefs.ko
           mv build/sha1sum-linux-image /tmp
       - name: Create tarball
         run: |

--- a/.github/workflows/build-linux-artifacts.yml
+++ b/.github/workflows/build-linux-artifacts.yml
@@ -55,11 +55,6 @@ jobs:
         run: |
           make build-linux-image
           make artifact ENABLE_PREBUILT=0 ENABLE_SYSTEM=1
-          mkdir -p /tmp/rv32emu-linux-image-prebuilt/linux-image
-          mv build/linux-image/Image /tmp/rv32emu-linux-image-prebuilt/linux-image
-          mv build/linux-image/rootfs.cpio /tmp/rv32emu-linux-image-prebuilt/linux-image
-          mv build/linux-image/simplefs.ko /tmp/rv32emu-linux-image-prebuilt/simplefs.ko
-          mv build/sha1sum-linux-image /tmp
       - name: Create tarball
         run: |
           cd /tmp

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,8 @@ jobs:
                                   . \${TMP_FILE}; \
                                   .ci/boot-linux.sh; \
                                   EXIT_CODE=\$?; \
-                                  sudo env TMP_FILE=\${TMP_FILE} BLK_DEV=\${BLK_DEV} .ci/boot-linux-prepare.sh cleanup; \
+                                  sudo env TMP_FILE=\${TMP_FILE} BLK_DEV_EXT4=\${BLK_DEV_EXT4} \
+                                           BLK_DEV_SIMPLEFS=\${BLK_DEV_SIMPLEFS} .ci/boot-linux-prepare.sh cleanup; \
                                   exit \${EXIT_CODE};" >> "$GITHUB_ENV"
     - name: fetch artifact first to reduce HTTP requests
       env:
@@ -375,7 +376,7 @@ jobs:
                                    . \${TMP_FILE}; \
                                    .ci/boot-linux.sh; \
                                    EXIT_CODE=\$?; \
-                                   sudo env TMP_FILE=\${TMP_FILE} BLK_DEV=\${BLK_DEV} .ci/boot-linux-prepare.sh cleanup; \
+                                   sudo env TMP_FILE=\${TMP_FILE} BLK_DEV_EXT4=\${BLK_DEV_EXT4} .ci/boot-linux-prepare.sh cleanup; \
                                    exit \${EXIT_CODE};" >> "$GITHUB_ENV"
      - name: Symlink gcc-15 due to the default /usr/local/bin/gcc links to system's clang
        run: |

--- a/README.md
+++ b/README.md
@@ -111,6 +111,19 @@ $ build/rv32emu -k <kernel_img_path> -i <rootfs_img_path> -x vblk:disk.img -x vb
 ```
 Note that the /dev/vdx device order in guestOS is assigned in reverse: the first `-x vblk` argument corresponds to the device with the highest letter, while subsequent arguments receive lower-lettered device names.
 
+In addition to the built-in ext4 filesystem support, other out-of-tree filesystems such as [simplefs](https://github.com/sysprog21/simplefs) are also supported. To use simplefs, first follow the instructions [here](https://github.com/sysprog21/simplefs?tab=readme-ov-file#build-and-run) to generate the simplefs disk image, and then attach it to the guestOS via the virtio block device. An additional ext4 image containing `simplefs.ko` must also be attached to the guestOS, since `simplefs.ko` is out-of-tree kernel module. The pre-built `simplefs.ko` can be found at `build/linux-image/` (run `make artifact ENABLE_SYSTEM=1` to get the artifacts).
+```shell
+$ build/rv32emu -k <kernel_img_path> -i <rootfs_img_path> -x vblk:<ext4_disk_img_path> -x vblk:<simplefs_disk_img_path>
+```
+Once the guestOS is booted, insert the `simplefs.ko` kernel module. After loading the kernel module, the simplefs disk will be recognized by the Linux kernel and can be mounted and used as a regular filesystem.
+```shell
+# mkdir -p mnt && mount /dev/vdb mnt # mount the ext4 disk that contains simplefs.ko
+
+# insmod mnt/simplefs.ko # insert simplefs.ko
+
+# mkdir -p simplefs && mount -t simplefs /dev/vda simplefs # mount the simplefs disk
+```
+
 #### Customize bootargs
 Build and run with customized bootargs to boot the guestOS. Otherwise, the default bootargs defined in `src/devices/minimal.dts` will be used.
 ```shell

--- a/mk/artifact.mk
+++ b/mk/artifact.mk
@@ -137,6 +137,7 @@ else
 ifeq ($(call has, SYSTEM), 1)
 	$(Q)(cd $(BIN_DIR) && $(SHA1SUM) linux-image/Image >> sha1sum-linux-image)
 	$(Q)(cd $(BIN_DIR) && $(SHA1SUM) linux-image/rootfs.cpio >> sha1sum-linux-image)
+	$(Q)(cd $(BIN_DIR) && $(SHA1SUM) linux-image/simplefs.ko >> sha1sum-linux-image)
 else
 	git submodule update --init $(addprefix ./tests/,$(foreach tb,$(TEST_SUITES),$(tb)))
 	$(Q)for tb in $(TEST_SUITES); do \

--- a/mk/artifact.mk
+++ b/mk/artifact.mk
@@ -135,9 +135,14 @@ else
 endif
 else
 ifeq ($(call has, SYSTEM), 1)
+	$(Q)(mkdir -p /tmp/rv32emu-linux-image-prebuilt/linux-image)
 	$(Q)(cd $(BIN_DIR) && $(SHA1SUM) linux-image/Image >> sha1sum-linux-image)
 	$(Q)(cd $(BIN_DIR) && $(SHA1SUM) linux-image/rootfs.cpio >> sha1sum-linux-image)
 	$(Q)(cd $(BIN_DIR) && $(SHA1SUM) linux-image/simplefs.ko >> sha1sum-linux-image)
+	$(Q)(mv $(BIN_DIR)/sha1sum-linux-image /tmp)
+	$(Q)(mv $(BIN_DIR)/linux-image/Image /tmp/rv32emu-linux-image-prebuilt/linux-image)
+	$(Q)(mv $(BIN_DIR)/linux-image/rootfs.cpio /tmp/rv32emu-linux-image-prebuilt/linux-image)
+	$(Q)(mv $(BIN_DIR)/linux-image/simplefs.ko /tmp/rv32emu-linux-image-prebuilt/linux-image)
 else
 	git submodule update --init $(addprefix ./tests/,$(foreach tb,$(TEST_SUITES),$(tb)))
 	$(Q)for tb in $(TEST_SUITES); do \

--- a/mk/external.mk
+++ b/mk/external.mk
@@ -137,6 +137,13 @@ LINUX_DATA_SHA = $(shell wget -q -O- $(LINUX_CDN_VERSION_URL)/sha256sums.asc | \
                          grep $(LINUX_DATA) | awk '{print $$1}')
 LINUX_DATA_SHA_CMD = $(SHA256SUM)
 
+# simplefs
+SIMPLEFS_VERSION = rel2025.0
+SIMPLEFS_DATA = /tmp/simplefs
+SIMPLEFS_DATA_URL = git clone https://github.com/sysprog21/simplefs $(SIMPLEFS_DATA) -b $(SIMPLEFS_VERSION) --depth=1
+SIMPLEFS_DATA_SHA = 863936f72e0781b240c5ec4574510c57f0394b99
+SIMPLEFS_DATA_SHA_CMD = $(SHA1SUM)
+
 define download-extract-verify
 $($(T)_DATA):
 	$(Q)$$(call prologue,$$@)
@@ -146,5 +153,5 @@ $($(T)_DATA):
 	$(Q)$$(call epilogue,$(notdir $($(T)_DATA_URL)),$(SHA_FILE1),$(SHA_FILE2))
 endef
 
-EXTERNAL_DATA = DOOM QUAKE TIMIDITY BUILDROOT LINUX
+EXTERNAL_DATA = DOOM QUAKE TIMIDITY BUILDROOT LINUX SIMPLEFS
 $(foreach T,$(EXTERNAL_DATA),$(eval $(download-extract-verify)))

--- a/mk/tools.mk
+++ b/mk/tools.mk
@@ -35,7 +35,7 @@ $(HIST_BIN): $(HIST_OBJS)
 TOOLS_BIN += $(HIST_BIN)
 
 # Build Linux image
-LINUX_IMAGE_SRC = $(BUILDROOT_DATA) $(LINUX_DATA)
+LINUX_IMAGE_SRC = $(BUILDROOT_DATA) $(LINUX_DATA) $(SIMPLEFS_DATA)
 build-linux-image: $(LINUX_IMAGE_SRC)
 	$(Q)./tools/build-linux-image.sh
 	$(Q)$(PRINTF) "Build done.\n"

--- a/tools/build-linux-image.sh
+++ b/tools/build-linux-image.sh
@@ -51,5 +51,14 @@ function do_linux
     cp -f $SRC_DIR/linux/arch/riscv/boot/Image $OUTPUT_DIR
 }
 
+function do_simplefs
+{
+    pushd $SRC_DIR/simplefs
+    ASSERT make KDIR=$SRC_DIR/linux $PARALLEL
+    popd
+    cp -f $SRC_DIR/simplefs/simplefs.ko $OUTPUT_DIR
+}
+
 do_buildroot && OK
 do_linux && OK
+do_simplefs && OK


### PR DESCRIPTION
# Description

To enhance the guest OS functionality, this commit integrates the simplefs kernel module to support an additional filesystem. It appends simplefs as a new Linux image artifact and automatically builds the latest simplefs.ko when make build-linux-image is executed.

# Testing
1. Clone the repo:
```shell
$ git clone https://github.com/ChinYikMing/rv32emu.git -b mount-simplefs --depth 1 && cd rv32emu
```

2. Build emulator
```shell
$ make ENABLE_SYSTEM=1 INITRD_SIZE=32 -j8
```

3. Fetch artifacts
```shell
$ make artifact ENABLE_SYSTEM=1
```

4. Create ext4 disk image and store simple.ko
```shell
$ dd if=/dev/zero of=disk.img bs=4M count=32
$ mkfs.ext4 disk.img
$ mkdir mnt
$ sudo mount disk.img mnt
$ sudo cp build/linux-image/simplefs.ko mnt
$ sudo umount mnt
```

5. Clone simplefs to create simplefs disk image
```shell
$ git clone https://github.com/sysprog21/simplefs.git --depth 1
$ make test.img -C simplefs
```

6. Boot guestOS
```shell
$ build/rv32emu -k build/linux-image/Image -i build/linux-image/rootfs.cpio -x vblk:disk.img -x vblk:simplefs/test.img
```

7. insmod simplefs.ko
```shell
# mkdir -p mnt && mount /dev/vdb mnt && insmod mnt/simplefs.ko
```

8. Mount simplefs disk image
```shell
# mkdir -p simplefs && mount -t simplefs /dev/vda simplefs
```

9. Manipulate the disk image typed simplefs
```shell
# cd simplefs
# touch apple
# ls
apple
# mkdir banana
# ls 
apple banana
```

# Expectation
- Filesystem commands like cd, touch, ls, mkdir, etc should be operational.

- Run `mount` and the /dev/vda has filesystem typed simplefs will be shown.

Sample output:
```shell
# mount
rootfs on / type rootfs (rw,size=241136k,nr_inodes=60284)
devtmpfs on /dev type devtmpfs (rw,relatime,size=241136k,nr_inodes=60284,mode=755)
proc on /proc type proc (rw,relatime)
devpts on /dev/pts type devpts (rw,relatime,gid=5,mode=620,ptmxmode=666)
tmpfs on /dev/shm type tmpfs (rw,relatime)
tmpfs on /tmp type tmpfs (rw,relatime)
tmpfs on /run type tmpfs (rw,nosuid,nodev,relatime,mode=755)
sysfs on /sys type sysfs (rw,relatime)
/dev/vdb on /root/mnt type ext4 (rw,relatime)
/dev/vda on /root/simplefs type simplefs (rw,relatime)
```



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add simplefs support by auto-building and packaging simplefs.ko as a Linux image artifact, so the guest OS can mount and use simplefs volumes. README includes brief usage steps.

- **New Features**
  - Build simplefs.ko in tools/build-linux-image.sh and output to build/linux-image/.
  - Include simplefs.ko in artifact checksums (mk/artifact.mk).
  - Add SIMPLEFS as external data and a build prerequisite (mk/external.mk, mk/tools.mk).
  - Document how to attach the module and mount a simplefs disk in the README.

- **Dependencies**
  - Clone sysprog21/simplefs (master) during build and verify via SHA1.

<!-- End of auto-generated description by cubic. -->

