### PR TITLE
Improve CI/CD

### DIFF
--- a/.ci/boot-linux-prepare.sh
+++ b/.ci/boot-linux-prepare.sh
@@ -16,10 +16,10 @@ which mkfs.ext4 > /dev/null 2>&1 || which $(brew --prefix e2fsprogs)/sbin/mkfs.e
         echo "Error: mkfs.ext4 not found"
         exit 1
     }
-which 7z > /dev/null 2>&1 || {
-    echo "Error: 7z not found"
-    exit 1
-}
+# Optional tooling used later in the test suite
+if ! command -v debugfs > /dev/null 2>&1 && ! command -v 7z > /dev/null 2>&1; then
+    print_warning "Neither debugfs nor 7z is available; virtio-blk verification will be skipped."
+fi
 
 ACTION=$1
 

--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -1,3 +1,8 @@
+# Bash strict mode (enabled only when executed directly, not sourced)
+if ! (return 0 2> /dev/null); then
+    set -euo pipefail
+fi
+
 # Expect host is Linux/x86_64, Linux/aarch64, macOS/arm64
 
 MACHINE_TYPE=$(uname -m)
@@ -15,11 +20,66 @@ check_platform()
     esac
 }
 
-if [[ "${OS_TYPE}" == "Linux" ]]; then
+if [ "${OS_TYPE}" = "Linux" ]; then
     PARALLEL=-j$(nproc)
 else
     PARALLEL=-j$(sysctl -n hw.logicalcpu)
 fi
+
+# Color output helpers
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+print_success()
+{
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_error()
+{
+    echo -e "${RED}[ERROR]${NC} $1" >&2
+}
+
+print_warning()
+{
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+# Assertion function for tests
+# Usage: ASSERT <condition> <error_message>
+ASSERT()
+{
+    local condition=$1
+    shift
+    local message="$*"
+
+    if ! eval "${condition}"; then
+        print_error "Assertion failed: ${message}"
+        print_error "Condition: ${condition}"
+        return 1
+    fi
+}
+
+# Cleanup function registry
+CLEANUP_FUNCS=()
+
+register_cleanup()
+{
+    CLEANUP_FUNCS+=("$1")
+}
+
+cleanup()
+{
+    local func
+    for func in "${CLEANUP_FUNCS[@]-}"; do
+        [ -n "${func}" ] || continue
+        eval "${func}" || true
+    done
+}
+
+trap cleanup EXIT
 
 # Universal download utility with curl/wget compatibility
 # Provides consistent interface regardless of which tool is available
@@ -49,7 +109,7 @@ download_to_stdout()
     local url="$1"
     case "$DOWNLOAD_TOOL" in
         curl)
-            curl -fsSL "$url"
+            curl -fS --retry 5 --retry-delay 2 --retry-max-time 60 -sL "$url"
             ;;
         wget)
             wget -qO- "$url"
@@ -66,7 +126,7 @@ download_to_file()
     local output="$2"
     case "$DOWNLOAD_TOOL" in
         curl)
-            curl -fsSL -o "$output" "$url"
+            curl -fS --retry 5 --retry-delay 2 --retry-max-time 60 -sL -o "$output" "$url"
             ;;
         wget)
             wget -q -O "$output" "$url"
@@ -88,7 +148,7 @@ download_with_headers()
             for header in "$@"; do
                 headers+=(-H "$header")
             done
-            curl -fsSL "${headers[@]}" "$url"
+            curl -fS --retry 5 --retry-delay 2 --retry-max-time 60 -sL "${headers[@]}" "$url"
             ;;
         wget)
             for header in "$@"; do
@@ -107,7 +167,7 @@ download_silent()
     local url="$1"
     case "$DOWNLOAD_TOOL" in
         curl)
-            curl -fsSL "$url"
+            curl -fS --retry 5 --retry-delay 2 --retry-max-time 60 -sL "$url"
             ;;
         wget)
             wget -qO- "$url"
@@ -124,7 +184,7 @@ download_with_progress()
     local output="$2"
     case "$DOWNLOAD_TOOL" in
         curl)
-            curl -fL -# -o "$output" "$url"
+            curl -fS --retry 5 --retry-delay 2 --retry-max-time 60 -L -# -o "$output" "$url"
             ;;
         wget)
             wget -O "$output" "$url"
@@ -141,7 +201,7 @@ check_url()
     local url="$1"
     case "$DOWNLOAD_TOOL" in
         curl)
-            curl -fsSL --head "$url" > /dev/null 2>&1
+            curl -fS --retry 5 --retry-delay 2 --retry-max-time 60 -sL --head "$url" > /dev/null 2>&1
             ;;
         wget)
             wget --spider -q "$url" 2> /dev/null

--- a/.ci/gdbstub-test.sh
+++ b/.ci/gdbstub-test.sh
@@ -9,8 +9,8 @@ prefixes=("${CROSS_COMPILE}" "riscv32-unknown-elf-" "riscv-none-elf-")
 for prefix in "${prefixes[@]}"; do
     utility=${prefix}gdb
     set +e # temporarily disable exit on error
-    command -v "${utility}" &> /dev/null
-    if [[ $? == 0 ]]; then
+    command -v "${utility}" > /dev/null 2>&1
+    if [ $? = 0 ]; then
         GDB=${utility}
     fi
     set -e

--- a/.ci/riscv-toolchain-install.sh
+++ b/.ci/riscv-toolchain-install.sh
@@ -9,11 +9,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 check_platform
 mkdir -p toolchain
 
-if [[ "$#" == "0" ]] || [[ "$1" != "riscv-collab" ]]; then
+if [ "$#" = "0" ] || [ "$1" != "riscv-collab" ]; then
     GCC_VER=15.2.0-1
     TOOLCHAIN_REPO=https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack
 
-    if [[ "${OS_TYPE}" == "Linux" ]]; then
+    if [ "${OS_TYPE}" = "Linux" ]; then
         case "${MACHINE_TYPE}" in
             "x86_64")
                 TOOLCHAIN_URL=${TOOLCHAIN_REPO}/releases/download/v${GCC_VER}/xpack-riscv-none-elf-gcc-${GCC_VER}-linux-x64.tar.gz

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -345,6 +345,10 @@ jobs:
              .ci/riscv-toolchain-install.sh
              echo "${{ github.workspace }}/toolchain/bin" >> $GITHUB_PATH
              echo "$(brew --prefix llvm@18)/bin" >> $GITHUB_PATH
+     - name: Set up Python 3.12
+       uses: actions/setup-python@v6
+       with:
+         python-version: '3.12'
      - name: Install compiler
        id: install_cc
        uses: rlalik/setup-cpp-compiler@master


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Overhauled CI/CD to be faster, more reliable, and secure. Adds a reusable setup action, caching across dependencies and builds, strict Bash scripts, and workflow concurrency with timeouts.

- **New Features**
  - Added composite action to install rv32emu deps (Linux/macOS) with caching and PATH setup.
  - Enabled caching for APT, RISC-V toolchain, and build artifacts.
  - Set minimal workflow permissions and added concurrency to cancel redundant runs.
  - Applied step/job timeouts and recursive submodule checkout.

- **Refactors**
  - Introduced Bash strict mode, color logging, ASSERT, and a cleanup registry in CI scripts.
  - Simplified format checking using clang-format -n --Werror, black --check, and shfmt on tracked files.
  - Fixed shell scripts to use POSIX-friendly syntax and safer checks (case, command -v).
  - Minor reliability fixes in boot tests, gdb detection, and toolchain installer.

<!-- End of auto-generated description by cubic. -->

