### PR TITLE
Improve the Makefile speed by simple assignment

### DIFF
--- a/mk/external.mk
+++ b/mk/external.mk
@@ -128,12 +128,12 @@ LINUX_CDN_BASE_URL = https://cdn.kernel.org/pub/linux/kernel
 LINUX_CDN_VERSION_URL = $(LINUX_CDN_BASE_URL)/v$(LINUX_VERSION).x
 $(shell mkdir -p /tmp/linux)
 LINUX_DATA_DEST = /tmp/linux
-LINUX_DATA = $(shell wget -q -O- $(LINUX_CDN_VERSION_URL) | \
+LINUX_DATA := $(shell wget -q -O- $(LINUX_CDN_VERSION_URL) | \
                      grep -o 'linux-$(LINUX_VERSION).$(LINUX_PATCHLEVEL).[0-9]\+\.tar.gz' | \
                      sort -V | tail -n 1)
 LINUX_DATA_URL = $(LINUX_CDN_VERSION_URL)/$(LINUX_DATA)
 LINUX_DATA_SKIP_DIR_LEVEL = 1
-LINUX_DATA_SHA = $(shell wget -q -O- $(LINUX_CDN_VERSION_URL)/sha256sums.asc | \
+LINUX_DATA_SHA := $(shell wget -q -O- $(LINUX_CDN_VERSION_URL)/sha256sums.asc | \
                          grep $(LINUX_DATA) | awk '{print $$1}')
 LINUX_DATA_SHA_CMD = $(SHA256SUM)
 


### PR DESCRIPTION
## Why
I Live in slow and bad network environments, recursive variable assignments (`=`) in the Makefile can cause shell commands, such as `wget` for `LINUX_DATA`, to execute multiple times, significantly slowing down the build process.

## How
By using simple assignment (`:=`), `wget` is executed only once during Makefile parsing. This reduces redundant network requests and improves overall Makefile execution speed.

## How to Debug
```shell
make check SHELL="/bin/bash -x -e -o pipefail"
```
## Before
<details>
<summary>Terminal Output</summary>

```bash
+ uname -s
+ uname -m
+ which sha1sum
+ which sha256sum
+ cc --version
+ grep emcc
+ head -n 1
+ cc --version
+ grep clang
+ head -n 1
+ cc --version
+ grep 'Free Software Foundation'
+ uname -m
+ which sdl2-config
+ pkg-config --exists SDL2_mixer
+ echo 0
+ mktemp
+ mktemp
+ mkdir -p /tmp/linux
+ wget -q -O- https://cdn.kernel.org/pub/linux/kernel/v6.x
+ grep -o 'linux-6.1.[0-9]\+\.tar.gz'
+ sort -V
+ tail -n 1
+ wget -q -O- https://cdn.kernel.org/pub/linux/kernel/v6.x
+ grep -o 'linux-6.1.[0-9]\+\.tar.gz'
+ sort -V
+ tail -n 1
+ wget -q -O- https://cdn.kernel.org/pub/linux/kernel/v6.x
+ grep -o 'linux-6.1.[0-9]\+\.tar.gz'
+ sort -V
+ tail -n 1
+ wget -q -O- https://cdn.kernel.org/pub/linux/kernel/v6.x
+ grep -o 'linux-6.1.[0-9]\+\.tar.gz'
+ sort -V
+ tail -n 1
+ wget -q -O- https://cdn.kernel.org/pub/linux/kernel/v6.x/sha256sums.asc
+ awk '{print $1}'
+ grep linux-6.1.157.tar.gz
+ wget -q -O- https://cdn.kernel.org/pub/linux/kernel/v6.x
+ grep -o 'linux-6.1.[0-9]\+\.tar.gz'
+ sort -V
+ tail -n 1
+ wget -q -O- https://cdn.kernel.org/pub/linux/kernel/v6.x
+ grep -o 'linux-6.1.[0-9]\+\.tar.gz'
+ sort -V
+ tail -n 1
+ mkdir -p /home/eastwillow/Documents/RISC-V/rv32emu/build/linux-x86-softfp /home/eastwillow/Documents/RISC-V/rv32emu/build/riscv32 /home/eastwillow/Documents/RISC-V/rv32emu/build/linux-image
+ echo '\033[33mPrebuilt benchmark is found. Skipping downloading.\033[0m\n'
\033[33mPrebuilt benchmark is found. Skipping downloading.\033[0m\n
+ wget -q -O- https://cdn.kernel.org/pub/linux/kernel/v6.x
+ grep -o 'linux-6.1.[0-9]\+\.tar.gz'
+ sort -V
+ tail -n 1
```

</details>

## After
<details>
<summary>Terminal Output</summary>

```bash
+ uname -s
+ uname -m
+ which sha1sum
+ which sha256sum
+ cc --version
+ head -n 1
+ grep emcc
+ cc --version
+ grep clang
+ head -n 1
+ cc --version
+ grep 'Free Software Foundation'
+ uname -m
+ which sdl2-config
+ pkg-config --exists SDL2_mixer
+ echo 0
+ mktemp
+ mktemp
+ mkdir -p /tmp/linux
+ wget -q -O- https://cdn.kernel.org/pub/linux/kernel/v6.x
+ sort -V
+ grep -o 'linux-6.1.[0-9]\+\.tar.gz'
+ tail -n 1
+ wget -q -O- https://cdn.kernel.org/pub/linux/kernel/v6.x/sha256sums.asc
+ grep linux-6.1.157.tar.gz
+ awk '{print $1}'
+ mkdir -p /home/eastwillow/Documents/RISC-V/rv32emu/build/linux-x86-softfp /home/eastwillow/Documents/RISC-V/rv32emu/build/riscv32 /home/eastwillow/Documents/RISC-V/rv32emu/build/linux-image
+ echo '\033[33mPrebuilt benchmark is found. Skipping downloading.\033[0m\n'
```

</details>

## References
- [GNU Make Manual: Simple Assignment](https://www.gnu.org/software/make/manual/html_node/Simple-Assignment.html)
-  [Makefile 語法和示範 ](https://hackmd.io/@sysprog/SySTMXPvl)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch LINUX_DATA and LINUX_DATA_SHA to simple assignment (:=) so wget runs once at parse time. This prevents repeated downloads and speeds up builds, especially on slow networks.

<!-- End of auto-generated description by cubic. -->

