### PR TITLE
Add RISCOF compliance test support

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -314,6 +314,25 @@ int main(int argc, char **args)
     }
     rv_log_info("RISC-V emulator is created and ready to run");
 
+#if RV32_HAS(ARCH_TEST)
+    /* Extract tohost/fromhost addresses for arch-test mode */
+    if (opt_arch_test && opt_prog_name) {
+        elf_t *elf = elf_new();
+        if (elf && elf_open(elf, opt_prog_name)) {
+            const struct Elf32_Sym *sym;
+            if ((sym = elf_get_symbol(elf, "tohost"))) {
+                rv_set_tohost_addr(rv, sym->st_value);
+                rv_log_info("Found tohost at 0x%08x", sym->st_value);
+            }
+            if ((sym = elf_get_symbol(elf, "fromhost"))) {
+                rv_set_fromhost_addr(rv, sym->st_value);
+                rv_log_info("Found fromhost at 0x%08x", sym->st_value);
+            }
+        }
+        elf_delete(elf);
+    }
+#endif
+
 #if defined(__EMSCRIPTEN__)
     disable_run_button();
 #endif

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -886,6 +886,18 @@ bool rv_has_halted(riscv_t *rv)
     return rv->halt;
 }
 
+#if RV32_HAS(ARCH_TEST)
+void rv_set_tohost_addr(riscv_t *rv, uint32_t addr)
+{
+    rv->tohost_addr = addr;
+}
+
+void rv_set_fromhost_addr(riscv_t *rv, uint32_t addr)
+{
+    rv->fromhost_addr = addr;
+}
+#endif
+
 void rv_delete(riscv_t *rv)
 {
     assert(rv);

--- a/src/riscv.h
+++ b/src/riscv.h
@@ -440,6 +440,12 @@ void rv_halt(riscv_t *rv);
 /* return the halt state */
 bool rv_has_halted(riscv_t *rv);
 
+#if RV32_HAS(ARCH_TEST)
+/* Set tohost/fromhost addresses for architectural testing */
+void rv_set_tohost_addr(riscv_t *rv, uint32_t addr);
+void rv_set_fromhost_addr(riscv_t *rv, uint32_t addr);
+#endif
+
 enum {
     /* run and trace instructions and print them out during emulation */
     RV_RUN_TRACE = 1,

--- a/src/riscv_private.h
+++ b/src/riscv_private.h
@@ -229,6 +229,12 @@ struct riscv_internal {
      */
     uint32_t last_csr_sepc;
 #endif
+
+#if RV32_HAS(ARCH_TEST)
+    /* RISC-V architectural test support: tohost/fromhost addresses */
+    uint32_t tohost_addr;
+    uint32_t fromhost_addr;
+#endif
 };
 
 /* sign extend a 16 bit value */

--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -705,7 +705,11 @@ RVOP(
     sb,
     {
         const uint32_t addr = rv->X[ir->rs1] + ir->imm;
-        rv->io.mem_write_b(rv, addr, rv->X[ir->rs2]);
+        const uint32_t value = rv->X[ir->rs2];
+        rv->io.mem_write_b(rv, addr, value);
+#if RV32_HAS(ARCH_TEST)
+        check_tohost_write(rv, addr, value);
+#endif
     },
     GEN({
         mem;
@@ -722,7 +726,11 @@ RVOP(
     {
         const uint32_t addr = rv->X[ir->rs1] + ir->imm;
         RV_EXC_MISALIGN_HANDLER(1, STORE, false, 1);
-        rv->io.mem_write_s(rv, addr, rv->X[ir->rs2]);
+        const uint32_t value = rv->X[ir->rs2];
+        rv->io.mem_write_s(rv, addr, value);
+#if RV32_HAS(ARCH_TEST)
+        check_tohost_write(rv, addr, value);
+#endif
     },
     GEN({
         mem;
@@ -739,7 +747,11 @@ RVOP(
     {
         const uint32_t addr = rv->X[ir->rs1] + ir->imm;
         RV_EXC_MISALIGN_HANDLER(3, STORE, false, 1);
-        rv->io.mem_write_w(rv, addr, rv->X[ir->rs2]);
+        const uint32_t value = rv->X[ir->rs2];
+        rv->io.mem_write_w(rv, addr, value);
+#if RV32_HAS(ARCH_TEST)
+        check_tohost_write(rv, addr, value);
+#endif
     },
     GEN({
         mem;
@@ -1501,8 +1513,12 @@ RVOP(
          */
         const uint32_t addr = rv->X[ir->rs1];
         RV_EXC_MISALIGN_HANDLER(3, STORE, false, 1);
-        rv->io.mem_write_w(rv, addr, rv->X[ir->rs2]);
+        const uint32_t value = rv->X[ir->rs2];
+        rv->io.mem_write_w(rv, addr, value);
         rv->X[ir->rd] = 0;
+#if RV32_HAS(ARCH_TEST)
+        check_tohost_write(rv, addr, value);
+#endif
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1519,6 +1535,9 @@ RVOP(
         if (ir->rd)
             rv->X[ir->rd] = value1;
         rv->io.mem_write_w(rv, addr, value2);
+#if RV32_HAS(ARCH_TEST)
+        check_tohost_write(rv, addr, value2);
+#endif
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1536,6 +1555,9 @@ RVOP(
             rv->X[ir->rd] = value1;
         const uint32_t res = value1 + value2;
         rv->io.mem_write_w(rv, addr, res);
+#if RV32_HAS(ARCH_TEST)
+        check_tohost_write(rv, addr, res);
+#endif
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1553,6 +1575,9 @@ RVOP(
             rv->X[ir->rd] = value1;
         const uint32_t res = value1 ^ value2;
         rv->io.mem_write_w(rv, addr, res);
+#if RV32_HAS(ARCH_TEST)
+        check_tohost_write(rv, addr, res);
+#endif
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1570,6 +1595,9 @@ RVOP(
             rv->X[ir->rd] = value1;
         const uint32_t res = value1 & value2;
         rv->io.mem_write_w(rv, addr, res);
+#if RV32_HAS(ARCH_TEST)
+        check_tohost_write(rv, addr, res);
+#endif
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1587,6 +1615,9 @@ RVOP(
             rv->X[ir->rd] = value1;
         const uint32_t res = value1 | value2;
         rv->io.mem_write_w(rv, addr, res);
+#if RV32_HAS(ARCH_TEST)
+        check_tohost_write(rv, addr, res);
+#endif
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1606,6 +1637,9 @@ RVOP(
         const int32_t b = value2;
         const uint32_t res = a < b ? value1 : value2;
         rv->io.mem_write_w(rv, addr, res);
+#if RV32_HAS(ARCH_TEST)
+        check_tohost_write(rv, addr, res);
+#endif
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1625,6 +1659,9 @@ RVOP(
         const int32_t b = value2;
         const uint32_t res = a > b ? value1 : value2;
         rv->io.mem_write_w(rv, addr, res);
+#if RV32_HAS(ARCH_TEST)
+        check_tohost_write(rv, addr, res);
+#endif
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1642,6 +1679,9 @@ RVOP(
             rv->X[ir->rd] = value1;
         const uint32_t ures = value1 < value2 ? value1 : value2;
         rv->io.mem_write_w(rv, addr, ures);
+#if RV32_HAS(ARCH_TEST)
+        check_tohost_write(rv, addr, ures);
+#endif
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1659,6 +1699,9 @@ RVOP(
             rv->X[ir->rd] = value1;
         const uint32_t ures = value1 > value2 ? value1 : value2;
         rv->io.mem_write_w(rv, addr, ures);
+#if RV32_HAS(ARCH_TEST)
+        check_tohost_write(rv, addr, ures);
+#endif
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -1688,7 +1731,11 @@ RVOP(
         /* copy from float registers */
         const uint32_t addr = rv->X[ir->rs1] + ir->imm;
         RV_EXC_MISALIGN_HANDLER(3, STORE, false, 1);
-        rv->io.mem_write_w(rv, addr, rv->F[ir->rs2].v);
+        const uint32_t value = rv->F[ir->rs2].v;
+        rv->io.mem_write_w(rv, addr, value);
+#if RV32_HAS(ARCH_TEST)
+        check_tohost_write(rv, addr, value);
+#endif
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -2070,7 +2117,11 @@ RVOP(
     {
         const uint32_t addr = rv->X[ir->rs1] + (uint32_t) ir->imm;
         RV_EXC_MISALIGN_HANDLER(3, STORE, true, 1);
-        rv->io.mem_write_w(rv, addr, rv->X[ir->rs2]);
+        const uint32_t value = rv->X[ir->rs2];
+        rv->io.mem_write_w(rv, addr, value);
+#if RV32_HAS(ARCH_TEST)
+        check_tohost_write(rv, addr, value);
+#endif
     },
     GEN({
         mem;
@@ -2591,7 +2642,11 @@ RVOP(
     {
         const uint32_t addr = rv->X[rv_reg_sp] + ir->imm;
         RV_EXC_MISALIGN_HANDLER(3, STORE, true, 1);
-        rv->io.mem_write_w(rv, addr, rv->X[ir->rs2]);
+        const uint32_t value = rv->X[ir->rs2];
+        rv->io.mem_write_w(rv, addr, value);
+#if RV32_HAS(ARCH_TEST)
+        check_tohost_write(rv, addr, value);
+#endif
     },
     GEN({
         mem;
@@ -2622,7 +2677,11 @@ RVOP(
     {
         const uint32_t addr = rv->X[rv_reg_sp] + ir->imm;
         RV_EXC_MISALIGN_HANDLER(3, STORE, false, 1);
-        rv->io.mem_write_w(rv, addr, rv->F[ir->rs2].v);
+        const uint32_t value = rv->F[ir->rs2].v;
+        rv->io.mem_write_w(rv, addr, value);
+#if RV32_HAS(ARCH_TEST)
+        check_tohost_write(rv, addr, value);
+#endif
     },
     GEN({
         assert; /* FIXME: Implement */
@@ -2646,7 +2705,11 @@ RVOP(
     {
         const uint32_t addr = rv->X[ir->rs1] + (uint32_t) ir->imm;
         RV_EXC_MISALIGN_HANDLER(3, STORE, false, 1);
-        rv->io.mem_write_w(rv, addr, rv->F[ir->rs2].v);
+        const uint32_t value = rv->F[ir->rs2].v;
+        rv->io.mem_write_w(rv, addr, value);
+#if RV32_HAS(ARCH_TEST)
+        check_tohost_write(rv, addr, value);
+#endif
     },
     GEN({
         assert; /* FIXME: Implement */


### PR DESCRIPTION
This implements complete support for RISC-V architectural compliance tests that use the tohost/fromhost protocol.
- Add check_tohost_write() function to detect writes to tohost address
- Extract tohost/fromhost symbol addresses from ELF during init
- Add tohost detection hooks to all store instructions:
  * Basic stores: SB, SH, SW
  * Atomic operations: SC.W, AMOSWAP.W, AMOADD.W, AMOXOR.W, AMOAND.W, AMOOR.W, AMOMIN.W, AMOMAX.W, AMOMINU.W, AMOMAXU.W
  * Floating point: FSW
  * Compressed: C.SW, C.SWSP, C.FSW, C.FSWSP
  * Fused operations: Multiple SW fusion
- Remove exit code truncation to preserve full test numbers
- Add tohost_addr/fromhost_addr fields to riscv_t structure

All changes are conditionally compiled with RV32_HAS(ARCH_TEST) to ensure zero overhead when the feature is disabled. The implementation follows the RISC-V tohost protocol: tests write exit code to tohost (extracted as value >> 1) and enter infinite loop.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add full RISC-V architectural (RISCOF) compliance test support using the tohost/fromhost protocol. The emulator now detects tohost writes, halts, and returns the correct exit code.

- **New Features**
  - Parse tohost/fromhost symbol addresses from the ELF at startup when arch-test mode is enabled.
  - Detect writes to tohost across all store paths (SB/SH/SW, AMO/SC.W, FSW, compressed stores, fused multi-SW) and halt with exit_code = value >> 1.
  - Preserve full exit codes (no truncation).
  - Add tohost_addr/fromhost_addr fields and setter APIs on riscv_t.
  - Fully gated behind RV32_HAS(ARCH_TEST) for zero overhead when disabled.

<sup>Written for commit 0767f169631fa75b9a0e4511cdcf8d63b60ca3e5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

