### PR TITLE
Fix csr cycle unasync

### DIFF
--- a/src/emulate.c
+++ b/src/emulate.c
@@ -190,8 +190,22 @@ static uint32_t *csr_get_ptr(riscv_t *rv, uint32_t csr)
  * If rd == x0, then the instruction shall not read the CSR and shall not cause
  * any of the side effects that might occur on a CSR read.
  */
-static uint32_t csr_csrrw(riscv_t *rv, uint32_t csr, uint32_t val)
+static uint32_t csr_csrrw(riscv_t *rv,
+                          uint32_t csr,
+                          uint32_t val,
+                          uint64_t cycle)
 {
+    /* Sync cycle counter for cycle-related CSRs only */
+    switch (csr & 0xFFF) {
+    case CSR_CYCLE:
+    case CSR_CYCLEH:
+    case CSR_INSTRET:
+    case CSR_INSTRETH:
+        if (rv->csr_cycle != cycle)
+            rv->csr_cycle = cycle;
+        break;
+    }
+
     uint32_t *c = csr_get_ptr(rv, csr);
     if (!c)
         return 0;
@@ -222,8 +236,21 @@ static uint32_t csr_csrrw(riscv_t *rv, uint32_t csr, uint32_t val)
 }
 
 /* perform csrrs (atomic read and set) */
-static uint32_t csr_csrrs(riscv_t *rv, uint32_t csr, uint32_t val)
+static uint32_t csr_csrrs(riscv_t *rv,
+                          uint32_t csr,
+                          uint32_t val,
+                          uint64_t cycle)
 {
+    /* Sync cycle counter for cycle-related CSRs only */
+    switch (csr & 0xFFF) {
+    case CSR_CYCLE:
+    case CSR_CYCLEH:
+    case CSR_INSTRET:
+    case CSR_INSTRETH:
+        if (rv->csr_cycle != cycle)
+            rv->csr_cycle = cycle;
+        break;
+    }
     uint32_t *c = csr_get_ptr(rv, csr);
     if (!c)
         return 0;
@@ -243,8 +270,22 @@ static uint32_t csr_csrrs(riscv_t *rv, uint32_t csr, uint32_t val)
  * Read old value of CSR, zero-extend to XLEN bits, write to rd.
  * Read value from rs1, use as bit mask to clear bits in CSR.
  */
-static uint32_t csr_csrrc(riscv_t *rv, uint32_t csr, uint32_t val)
+static uint32_t csr_csrrc(riscv_t *rv,
+                          uint32_t csr,
+                          uint32_t val,
+                          uint64_t cycle)
 {
+    /* Sync cycle counter for cycle-related CSRs only */
+    switch (csr & 0xFFF) {
+    case CSR_CYCLE:
+    case CSR_CYCLEH:
+    case CSR_INSTRET:
+    case CSR_INSTRETH:
+        if (rv->csr_cycle != cycle)
+            rv->csr_cycle = cycle;
+        break;
+    }
+
     uint32_t *c = csr_get_ptr(rv, csr);
     if (!c)
         return 0;

--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -1216,7 +1216,7 @@ RVOP(
 RVOP(
     csrrw,
     {
-        uint32_t tmp = csr_csrrw(rv, ir->imm, rv->X[ir->rs1]);
+        uint32_t tmp = csr_csrrw(rv, ir->imm, rv->X[ir->rs1], cycle);
         rv->X[ir->rd] = ir->rd ? tmp : rv->X[ir->rd];
     },
     GEN({
@@ -1236,7 +1236,7 @@ RVOP(
     csrrs,
     {
         uint32_t tmp = csr_csrrs(
-            rv, ir->imm, (ir->rs1 == rv_reg_zero) ? 0U : rv->X[ir->rs1]);
+            rv, ir->imm, (ir->rs1 == rv_reg_zero) ? 0U : rv->X[ir->rs1], cycle);
         rv->X[ir->rd] = ir->rd ? tmp : rv->X[ir->rd];
     },
     GEN({
@@ -1248,7 +1248,7 @@ RVOP(
     csrrc,
     {
         uint32_t tmp = csr_csrrc(
-            rv, ir->imm, (ir->rs1 == rv_reg_zero) ? 0U : rv->X[ir->rs1]);
+            rv, ir->imm, (ir->rs1 == rv_reg_zero) ? 0U : rv->X[ir->rs1], cycle);
         rv->X[ir->rd] = ir->rd ? tmp : rv->X[ir->rd];
     },
     GEN({
@@ -1259,7 +1259,7 @@ RVOP(
 RVOP(
     csrrwi,
     {
-        uint32_t tmp = csr_csrrw(rv, ir->imm, ir->rs1);
+        uint32_t tmp = csr_csrrw(rv, ir->imm, ir->rs1, cycle);
         rv->X[ir->rd] = ir->rd ? tmp : rv->X[ir->rd];
     },
     GEN({
@@ -1270,7 +1270,7 @@ RVOP(
 RVOP(
     csrrsi,
     {
-        uint32_t tmp = csr_csrrs(rv, ir->imm, ir->rs1);
+        uint32_t tmp = csr_csrrs(rv, ir->imm, ir->rs1, cycle);
         rv->X[ir->rd] = ir->rd ? tmp : rv->X[ir->rd];
     },
     GEN({
@@ -1281,7 +1281,7 @@ RVOP(
 RVOP(
     csrrci,
     {
-        uint32_t tmp = csr_csrrc(rv, ir->imm, ir->rs1);
+        uint32_t tmp = csr_csrrc(rv, ir->imm, ir->rs1, cycle);
         rv->X[ir->rd] = ir->rd ? tmp : rv->X[ir->rd];
     },
     GEN({


### PR DESCRIPTION
Previous [commit 78836cf ](https://github.com/sysprog21/rv32emu/commit/78836cf7b6ee082307072630d47977116480e82d)prevents frequently update of rv->csr_cycle by manipulate it with register. However, currently rv->csr_cycle only update after a block end or JIT clearing block map. This results csr cycle instructions cannot fetch up-to-date cycle. If csr cycle instructions are located in a same block, leading to the result cycle count becomes zero.

This commit updates rv->csr_cycle everytime before csr instruction is executed.







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Synchronizes cycle and instret CSR reads by updating rv->csr_cycle right before those CSRs execute, so they return the current value even within the same block. Fixes cases where these CSRs could read zero or stale counts until block end.

- **Bug Fixes**
  - Sync rv->csr_cycle only when accessing CSR_CYCLE/CYCLEH or CSR_INSTRET/INSTRETH in csrrw/csrrs/csrrc and their immediate variants.

<sup>Written for commit f69568af97703918c107394b49e141ae4c6629c9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







