### PR TITLE
Add make format target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ However, participation requires adherence to fundamental ground rules:
   For instance, opt for "initialize" over "initialise" and "color" rather than "colour".
 
 Software requirement:
-* [clang-format](https://clang.llvm.org/docs/ClangFormat.html) version 18 or later.
+* [clang-format](https://clang.llvm.org/docs/ClangFormat.html) version 18.
 * [shfmt](https://github.com/mvdan/sh).
 * [black](https://github.com/psf/black) version 25.1.0.
 
@@ -55,6 +55,7 @@ To maintain a uniform style across languages, run:
 * `clang-format -i *.{c,h}` to apply the project’s C/C++ formatting rules from the up-to-date .clang-format file.
 * `shfmt -w $(find . -type f -name "*.sh")` to clean and standardize all shell scripts.
 * `black .` to enforce a consistent, idiomatic layout for Python code.
+* `make format` to automatically run all three formatters.
 
 ## Coding Style for Shell Script
 

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -53,6 +53,20 @@ warn = $(PRINTF) "$(YELLOW)$(strip $1)$(NC)\n"
 # Used inside $(warning) or $(error)
 warnx = $(shell echo "$(YELLOW)$(strip $1)$(NC)\n")
 
+# Version checking
+version_num = $(shell printf "%d%03d%03d" $(1) $(2) $(3))
+# Compare two versions with bc
+# Returns 1 if first == second else 0
+version_eq = $(shell echo "$$(($(call version_num,$(1),$(2),$(3)) == $(call version_num,$(4),$(5),$(6))))" | bc)
+# Returns 1 if first < second else 0
+version_lt = $(shell echo "$$(($(call version_num,$(1),$(2),$(3)) < $(call version_num,$(4),$(5),$(6))))" | bc)
+# Returns 1 if first <= second else 0
+version_lte = $(shell echo "$$(($(call version_num,$(1),$(2),$(3)) <= $(call version_num,$(4),$(5),$(6))))" | bc)
+# Returns 1 if first > second else 0
+version_gt = $(shell echo "$$(($(call version_num,$(1),$(2),$(3)) > $(call version_num,$(4),$(5),$(6))))" | bc)
+# Returns 1 if first >= second else 0
+version_gte = $(shell echo "$$(($(call version_num,$(1),$(2),$(3)) >= $(call version_num,$(4),$(5),$(6))))" | bc)
+
 # File utilities
 SHA1SUM = sha1sum
 SHA1SUM := $(shell which $(SHA1SUM))

--- a/mk/toolchain.mk
+++ b/mk/toolchain.mk
@@ -14,18 +14,10 @@ ifneq ($(shell $(CC) --version | head -n 1 | grep emcc),)
     SDL_MUSIC_PLAY_AT_EMCC_MINOR := 1
     SDL_MUSIC_PLAY_AT_EMCC_PATCH := 51
     SDL_MUSIC_CANNOT_PLAY_WARNING := Video games music might not be played. You may switch emcc to version $(SDL_MUSIC_PLAY_AT_EMCC_MAJOR).$(SDL_MUSIC_PLAY_AT_EMCC_MINOR).$(SDL_MUSIC_PLAY_AT_EMCC_PATCH)
-    ifeq ($(shell echo $(EMCC_MAJOR)\==$(SDL_MUSIC_PLAY_AT_EMCC_MAJOR) | bc), 1)
-        ifeq ($(shell echo $(EMCC_MINOR)\==$(SDL_MUSIC_PLAY_AT_EMCC_MINOR) | bc), 1)
-            ifeq ($(shell echo $(EMCC_PATCH)\==$(SDL_MUSIC_PLAY_AT_EMCC_PATCH) | bc), 1)
-	        # do nothing
-            else
-                $(warning $(SDL_MUSIC_CANNOT_PLAY_WARNING))
-            endif
-        else
-	    $(warning $(SDL_MUSIC_CANNOT_PLAY_WARNING))
-        endif
-    else
-	$(warning $(SDL_MUSIC_CANNOT_PLAY_WARNING))
+    ifeq ($(call version_eq,\
+	    $(EMCC_MAJOR),$(EMCC_MINOR),$(EMCC_PATCH),\
+	    $(SDL_MUSIC_PLAY_AT_EMCC_MAJOR),$(SDL_MUSIC_PLAY_AT_EMCC_MINOR),$(SDL_MUSIC_PLAY_AT_EMCC_PATCH)), 0)
+        $(warning $(SDL_MUSIC_CANNOT_PLAY_WARNING))
     endif
 
     # see commit 165c1a3 of emscripten
@@ -33,16 +25,10 @@ ifneq ($(shell $(CC) --version | head -n 1 | grep emcc),)
     MIMALLOC_SUPPORT_SINCE_MINOR := 1
     MIMALLOC_SUPPORT_SINCE_PATCH := 50
     MIMALLOC_UNSUPPORTED_WARNING := mimalloc is supported after version $(MIMALLOC_SUPPORT_SINCE_MAJOR).$(MIMALLOC_SUPPORT_SINCE_MINOR).$(MIMALLOC_SUPPORT_SINCE_PATCH)
-    ifeq ($(shell echo $(EMCC_MAJOR)\>=$(MIMALLOC_SUPPORT_SINCE_MAJOR) | bc), 1)
-        ifeq ($(shell echo $(EMCC_MINOR)\>=$(MIMALLOC_SUPPORT_SINCE_MINOR) | bc), 1)
-            ifeq ($(shell echo $(EMCC_PATCH)\>=$(MIMALLOC_SUPPORT_SINCE_PATCH) | bc), 1)
-                CFLAGS_emcc += -sMALLOC=mimalloc
-            else
-                $(warning $(MIMALLOC_UNSUPPORTED_WARNING))
-            endif
-        else
-            $(warning $(MIMALLOC_UNSUPPORTED_WARNING))
-        endif
+    ifeq ($(call version_gte,\
+	    $(EMCC_MAJOR),$(EMCC_MINOR),$(EMCC_PATCH),\
+	    $(MIMALLOC_SUPPORT_SINCE_MAJOR),$(MIMALLOC_SUPPORT_SINCE_MINOR),$(MIMALLOC_SUPPORT_SINCE_PATCH)), 1)
+        CFLAGS_emcc += -sMALLOC=mimalloc
     else
         $(warning $(MIMALLOC_UNSUPPORTED_WARNING))
     endif

--- a/mk/wasm.mk
+++ b/mk/wasm.mk
@@ -83,9 +83,10 @@ ifeq ($(UNAME_S),Darwin)
 SAFARI_MAJOR :=
 SAFARI_MINOR :=
 SAFARI_VERSION_CHECK_CMD :=
-SAFARI_SUPPORT_TCO_AT_MAJOR_MINOR := 18.2
+SAFARI_SUPPORT_TCO_AT_MAJOR := 18
+SAFARI_SUPPORT_TCO_AT_MINOR := 2
 SAFARI_SUPPORT_TCO_INFO := Safari supports TCO, you can use Safari to request the wasm
-SAFARI_NO_SUPPORT_TCO_WARNING := Safari not found or Safari must have at least version $(SAFARI_SUPPORT_TCO_AT_MAJOR_MINOR) to support TCO in wasm
+SAFARI_NO_SUPPORT_TCO_WARNING := Safari not found or Safari must have at least version $(SAFARI_SUPPORT_TCO_AT_MAJOR).$(SAFARI_SUPPORT_TCO_AT_MINOR) to support TCO in wasm
 endif
 
 # FIXME: for Windows
@@ -101,14 +102,14 @@ CHROME_MAJOR := $(shell $(CHROME_MAJOR_VERSION_CHECK_CMD))
 FIREFOX_MAJOR := $(shell $(FIREFOX_MAJOR_VERSION_CHECK_CMD))
 
 # Chrome
-ifeq ($(shell echo $(CHROME_MAJOR)\>=$(CHROME_SUPPORT_TCO_AT_MAJOR) | bc), 1)
+ifeq ($(call version_gte,$(CHROME_MAJOR),,,$(CHROME_SUPPORT_TCO_AT_MAJOR),,), 1)
     $(info $(call noticex, $(CHROME_SUPPORT_TCO_INFO)))
 else
     $(warning $(call warnx, $(CHROME_NO_SUPPORT_TCO_WARNING)))
 endif
 
 # Firefox
-ifeq ($(shell echo $(FIREFOX_MAJOR)\>=$(FIREFOX_SUPPORT_TCO_AT_MAJOR) | bc), 1)
+ifeq ($(call version_gte,$(FIREFOX_MAJOR),,,$(FIREFOX_SUPPORT_TCO_AT_MAJOR),,), 1)
     $(info $(call noticex, $(FIREFOX_SUPPORT_TCO_INFO)))
 else
     $(warning $(call warnx, $(FIREFOX_NO_SUPPORT_TCO_WARNING)))
@@ -120,7 +121,7 @@ ifeq ($(UNAME_S),Darwin)
 SAFARI_VERSION := $(shell $(SAFARI_VERSION_CHECK_CMD))
 SAFARI_MAJOR := $(shell echo $(SAFARI_VERSION) | cut -f1 -d.)
 SAFARI_MINOR := $(shell echo $(SAFARI_VERSION) | cut -f2 -d.)
-ifeq ($(shell echo "$(SAFARI_MAJOR).$(SAFARI_MINOR)>=$(SAFARI_SUPPORT_TCO_AT_MAJOR_MINOR)" | bc), 1)
+ifeq ($(call version_gte,$(SAFARI_MAJOR),$(SAFARI_MINOR),,$(SAFARI_SUPPORT_TCO_AT_MAJOR),$(SAFARI_SUPPORT_TCO_AT_MINOR),), 1)
     $(info $(call noticex, $(SAFARI_SUPPORT_TCO_INFO)))
 else
     $(warning $(call warnx, $(SAFARI_NO_SUPPORT_TCO_WARNING)))


### PR DESCRIPTION
# Description

- Add `make format` target for easier formatting for developers.
- Intruduce version checking utils: `version_{eq, lt, lte, gt, gte}` and refactor with them for tools: `emcc`, browsers(Chrome, Firefox, Safari), `black`
- Update CONTRIBUTING.md to reflect the `make format` target











<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a make format target to auto-format C/C++, shell, and Python, and introduces version-compare helpers to simplify build-time checks. This streamlines developer formatting and reduces brittle version logic.

- **New Features**
  - make format runs clang-format, shfmt, and black; skips submodules and OUT.
  - Validates tool presence and versions (clang-format 18, shfmt, black 25.1.0+), with helpful warnings.
  - CONTRIBUTING.md updated to document the new command.

- **Refactors**
  - Added version_{eq,lt,lte,gt,gte} helpers in mk/common.mk.
  - Replaced nested bc checks in mk/toolchain.mk and mk/wasm.mk:
    - SDL music: warn unless emcc == 3.1.51.
    - Enable mimalloc when emcc >= 3.1.50.
    - TCO checks: Chrome/Firefox by major version, Safari >= 18.2.

<sup>Written for commit b1ba59b0cb3e8950c18320c61f5887c9efb7f53a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->











