### PR TITLE
Fix heap buffer overflow with -x option

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -131,6 +131,11 @@ static bool parse_args(int argc, char **args)
             emu_argc++;
             break;
         case 'x':
+            if (opt_virtio_blk_idx >= VBLK_DEV_MAX) {
+                rv_log_error("Too many virtio-blk devices. Maximum is %d.\n",
+                             VBLK_DEV_MAX);
+                return false;
+            }
             if (!strncmp("vblk:", optarg, 5))
                 opt_virtio_blk_img[opt_virtio_blk_idx++] =
                     optarg + 5; /* strlen("vblk:") */


### PR DESCRIPTION
The opt_virtio_blk_img array can be overflowed if more than VBLK_DEV_MAX virtio-blk devices are specified using the -x option, as opt_virtio_blk_idx is incremented without bounds checking.

Add a check to ensure that opt_virtio_blk_idx does not exceed VBLK_DEV_MAX. If the limit is reached, log an error and exit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent heap buffer overflow when too many virtio-blk devices are passed via -x. Adds a bounds check on opt_virtio_blk_idx; if it reaches VBLK_DEV_MAX, log an error and exit.

<sup>Written for commit e11b229054b86c5b5f39ffcf25b358277452ea82. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

