### PR TITLE
Fix PLIC priority tie-breaking to favor lowest ID

### DIFF
--- a/src/devices/plic.c
+++ b/src/devices/plic.c
@@ -44,7 +44,7 @@ uint32_t plic_read(plic_t *plic, const uint32_t addr)
         {
             uint32_t intr_candidate = plic->ip & plic->ie;
             if (intr_candidate) {
-                plic_read_val = ilog2(intr_candidate);
+                plic_read_val = rv_ctz(intr_candidate);
                 plic->ip &= ~(1U << (plic_read_val));
             }
             break;


### PR DESCRIPTION
The RISC-V PLIC specification states that "if two or more pending interrupts have the same priority, the one with the lowest ID has the highest priority."

The previous implementation used ilog2(), which identifies the most significant bit (highest ID). Replace it with rv_ctz() to select the least significant bit (lowest ID), ensuring compliance with the specification's arbitration rule.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix PLIC tie-breaking to choose the lowest interrupt ID when multiple pending interrupts share the same priority, matching the RISC-V spec. Replaced ilog2() with rv_ctz() to select the least significant set bit in the pending-enabled mask.

<sup>Written for commit a7ca51b3a52df8d692fb8afb816c6d1d356a80f4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

