### PR TITLE
Adopt preserve_none attribute for MUST_TAIL optimization

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -191,7 +191,11 @@ static inline uint8_t ilog2(uint32_t x)
  * even without optimizations enabled.
  */
 #if defined(__has_attribute) && __has_attribute(musttail)
+#if __has_attribute(preserve_none)
+#define MUST_TAIL __attribute__((musttail)) __attribute__((preserve_none))
+#else
 #define MUST_TAIL __attribute__((musttail))
+#endif
 #else
 #define MUST_TAIL
 #endif


### PR DESCRIPTION
Despite using __attribute__((musttail)), the compiler may still emit full stack frames and spill callee-saved registers in complex handlers (e.g., do_lw), undermining the benefits of the threaded interpreter.

Integrate Clang's __attribute__((preserve_none)) (available since Clang 19.1.0) into the MUST_TAIL macro. This attribute modifies the calling convention to avoid preserving registers, thereby minimizing stack setup and register pressure during instruction dispatch.

This ensures more consistent tail call optimization and reduces overhead in the interpreter loop.

Closes: https://github.com/sysprog21/rv32emu/issues/601

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend MUST_TAIL to include preserve_none when available, so tail-call dispatch avoids stack frames and callee-saved spills. This makes tail calls more reliable and reduces interpreter loop overhead, especially in complex handlers.

<sup>Written for commit d8382ab75e1873d939e418af346af0fcd59562a7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

