### PR TITLE
Leverage dtsfmt as the standard formatter for DTS and DTSI files

### DIFF
--- a/.dtsfmtrc.toml
+++ b/.dtsfmtrc.toml
@@ -1,0 +1,2 @@
+indent_str = "    "
+warn_on_unhandled_tokens = true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -594,6 +594,7 @@ jobs:
       run: |
             sudo apt-get install -q=2 clang-format-18 shfmt python3-pip
             pip3 install black==25.1.0
+            curl -LSfs https://go.mskelton.dev/dtsfmt/install | sh -s -- -y
             .ci/check-newline.sh
             .ci/check-format.sh
       shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,12 +50,24 @@ Software requirement:
 * [clang-format](https://clang.llvm.org/docs/ClangFormat.html) version 18.
 * [shfmt](https://github.com/mvdan/sh).
 * [black](https://github.com/psf/black) version 25.1.0.
+* [dtsfmt](https://github.com/mskelton/dtsfmt).
 
 To maintain a uniform style across languages, run:
 * `clang-format -i *.{c,h}` to apply the project’s C/C++ formatting rules from the up-to-date .clang-format file.
 * `shfmt -w $(find . -type f -name "*.sh")` to clean and standardize all shell scripts.
 * `black .` to enforce a consistent, idiomatic layout for Python code.
-* `make format` to automatically run all three formatters.
+* `dtsfmt ./src/devices/` to enforce a consistent layout for device tree source (and include).
+* `make format` to automatically run all four formatters.
+
+## Coding Style for Device Tree Source and Device Tree Source Include
+
+Device Tree Source (and Include) must be clean, consistent, and portable. The following `dtsfmt` rules(check `.dtsfmtrc.toml` file) are enforced project-wide:
+* Use spaces for indentation.
+* Indent with 4 spaces.
+* Use multi-line comments.
+* Use Unix-style line endings (LF).
+* Remove trailing whitespace at the end of lines.
+* Ensure the file ends with a newline.
 
 ## Coding Style for Shell Script
 

--- a/Makefile
+++ b/Makefile
@@ -492,6 +492,8 @@ CLANG_FORMAT := $(shell which clang-format-18 2>/dev/null)
 
 SHFMT := $(shell which shfmt 2>/dev/null)
 
+DTSFMT := $(shell which dtsfmt 2>/dev/null)
+
 BLACK := $(shell which black 2>/dev/null)
 BLACK_VERSION := $(if $(strip $(BLACK)),$(shell $(BLACK) --version | head -n 1 | awk '{print $$2}'),)
 BLACK_MAJOR := $(shell echo $(BLACK_VERSION) | cut -f1 -d.)
@@ -519,6 +521,15 @@ ifeq ($(SHFMT),)
 else
 	$(Q)$(SHFMT) -w $(shell find . \( $(SUBMODULES_PRUNE_PATHS) -o -path \"./$(OUT)\" \) \
 		                        -prune -o -name "*.sh" -print)
+endif
+ifeq ($(DTSFMT),)
+	$(error dtsfmt not found. Install dtsfmt and try again)
+else
+	$(Q)for dts_src in $$(find . \( $(SUBMODULES_PRUNE_PATHS) -o -path "./$(OUT)" \) \
+					-prune -o \( -name "*.dts" -o -name "*.dtsi" \) -print); \
+	do \
+		$(DTSFMT) $$dts_src; \
+	done
 endif
 ifeq ($(BLACK),)
 	$(error black not found. Install black version 25.1.0 or above and try again)

--- a/src/devices/minimal.dts
+++ b/src/devices/minimal.dts
@@ -8,24 +8,24 @@
     aliases {
         serial0 = "/soc@F0000000/serial@4000000";
     };
-
     chosen {
         bootargs = "earlycon console=ttyS0";
         stdout-path = "serial0";
         linux,initrd-start = <INITRD_START>;
         linux,initrd-end = <INITRD_END>;
     };
-
     cpus {
         #address-cells = <1>;
         #size-cells = <0>;
         timebase-frequency = <65000000>;
+
         cpu0: cpu@0 {
             device_type = "cpu";
             compatible = "riscv";
             reg = <0>;
             riscv,isa = "rv32ima";
             mmu-type = "riscv,sv32";
+
             cpu0_intc: interrupt-controller {
                 #interrupt-cells = <1>;
                 #address-cells = <0>;
@@ -34,13 +34,11 @@
             };
         };
     };
-
     sram: memory@0 {
         device_type = "memory";
         reg = <MEM_START MEM_END>;
         reg-names = "sram0";
     };
-
     soc: soc@F0000000 {
         #address-cells = <1>;
         #size-cells = <1>;
@@ -57,13 +55,14 @@
             interrupts-extended = <&cpu0_intc 9>;
             riscv,ndev = <31>;
         };
-
         serial@4000000 {
             compatible = "ns16550";
             reg = <0x4000000 0x100000>;
             interrupts = <1>;
             no-loopback-test;
-            clock-frequency = <5000000>; /* the baudrate divisor is ignored */
+            clock-frequency = <5000000>;
+
+            /* the baudrate divisor is ignored */
         };
 
         /*


### PR DESCRIPTION
- Add `.dtsfmtrc.toml` with formatting rules and apply dtsfmt in .ci/check-format.sh. The formatting rules are as follows:
  * Use spaces for indentation.
  * Indent with 4 spaces.
  * Use Multi-line comment.
  * Use Unix-style line endings (LF).
  * Remove trailing whitespace at the end of lines.
  * Ensure the file ends with a newline.

- Update CONTRIBUTING.md with formatting rules and usage instructions. Contributors must ensure consistent DST and DTSI style before code submission.

- The .ci/check-format.sh’s exit code includes dtsfmt's exit code, which should be 0 if all DTS and DTSI files are properly formatted.

- The make format integrates the dtsfmt.

- All existing DTS and DTSI are reformatted with the aforementioned formatting rules.

- Remove non-used REPO_ROOT variable in .ci/check-format.sh.





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopt dtsfmt as the standard formatter for DTS/DTSI files and enforce it in CI. This ensures consistent device tree formatting and makes misformatted files fail the build.

- New Features
  - Add .dtsfmtrc.toml and run dtsfmt in .ci/check-format.sh (CI fails on misformatted .dts/.dtsi).
  - Install dtsfmt in the GitHub Actions workflow.
  - Document DTS/DTSI formatting in CONTRIBUTING and include dtsfmt in make format.
  - Reformat existing DTS files to match the rules.

- Refactors
  - Remove unused REPO_ROOT from .ci/check-format.sh.

<sup>Written for commit 1048c2d99cc5ef4365165fca508f7b8efb053dad. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





