### PR TITLE
Fix preserve_none attribute usage for macOS

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -191,13 +191,20 @@ static inline uint8_t ilog2(uint32_t x)
  * even without optimizations enabled.
  */
 #if defined(__has_attribute) && __has_attribute(musttail)
-#if __has_attribute(preserve_none)
-#define MUST_TAIL __attribute__((musttail)) __attribute__((preserve_none))
-#else
 #define MUST_TAIL __attribute__((musttail))
-#endif
 #else
 #define MUST_TAIL
+#endif
+
+/* The preserve_none calling convention minimizes register preservation overhead
+ * in the interpreter's threaded dispatch. It must be applied to function
+ * declarations, not return statements. macOS clang falsely reports support.
+ */
+#if defined(__has_attribute) && __has_attribute(preserve_none) && \
+    !defined(__APPLE__)
+#define PRESERVE_NONE __attribute__((preserve_none))
+#else
+#define PRESERVE_NONE
 #endif
 
 /* Assume that all POSIX-compatible environments provide mmap system call. */

--- a/src/decode.h
+++ b/src/decode.h
@@ -384,7 +384,10 @@ typedef struct rv_insn {
      * compiler to leverage TCO.
      */
     struct rv_insn *next;
-    bool (*impl)(riscv_t *, const struct rv_insn *, uint64_t, uint32_t);
+    PRESERVE_NONE bool (*impl)(riscv_t *,
+                               const struct rv_insn *,
+                               uint64_t,
+                               uint32_t);
 
     /* Two pointers, 'branch_taken' and 'branch_untaken', are employed to
      * avoid the overhead associated with aggressive memory copying. Instead

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -438,45 +438,45 @@ static uint32_t peripheral_update_ctr = 64;
 #endif
 
 /* Interpreter-based execution path */
-#define RVOP(inst, code, asm)                                               \
-    static bool do_##inst(riscv_t *rv, const rv_insn_t *ir, uint64_t cycle, \
-                          uint32_t PC)                                      \
-    {                                                                       \
-        IIF(RV32_HAS(SYSTEM))(rv->timer++;, ) cycle++;                      \
-        code;                                                               \
-        IIF(RV32_HAS(SYSTEM))                                               \
-        (                                                                   \
-            if (need_handle_signal) {                                       \
-                need_handle_signal = false;                                 \
-                return true;                                                \
-            }, ) nextop : PC += __rv_insn_##inst##_len;                     \
-        IIF(RV32_HAS(SYSTEM))                                               \
-        (IIF(RV32_HAS(JIT))(                                                \
-             , if (unlikely(need_clear_block_map)) {                        \
-                 block_map_clear(rv);                                       \
-                 need_clear_block_map = false;                              \
-                 rv->csr_cycle = cycle;                                     \
-                 rv->PC = PC;                                               \
-                 return false;                                              \
-             }), );                                                         \
-        if (unlikely(RVOP_NO_NEXT(ir)))                                     \
-            goto end_op;                                                    \
-        const rv_insn_t *next = ir->next;                                   \
-        MUST_TAIL return next->impl(rv, next, cycle, PC);                   \
-    end_op:                                                                 \
-        rv->csr_cycle = cycle;                                              \
-        rv->PC = PC;                                                        \
-        return true;                                                        \
+#define RVOP(inst, code, asm)                                             \
+    static PRESERVE_NONE bool do_##inst(riscv_t *rv, const rv_insn_t *ir, \
+                                        uint64_t cycle, uint32_t PC)      \
+    {                                                                     \
+        IIF(RV32_HAS(SYSTEM))(rv->timer++;, ) cycle++;                    \
+        code;                                                             \
+        IIF(RV32_HAS(SYSTEM))                                             \
+        (                                                                 \
+            if (need_handle_signal) {                                     \
+                need_handle_signal = false;                               \
+                return true;                                              \
+            }, ) nextop : PC += __rv_insn_##inst##_len;                   \
+        IIF(RV32_HAS(SYSTEM))                                             \
+        (IIF(RV32_HAS(JIT))(                                              \
+             , if (unlikely(need_clear_block_map)) {                      \
+                 block_map_clear(rv);                                     \
+                 need_clear_block_map = false;                            \
+                 rv->csr_cycle = cycle;                                   \
+                 rv->PC = PC;                                             \
+                 return false;                                            \
+             }), );                                                       \
+        if (unlikely(RVOP_NO_NEXT(ir)))                                   \
+            goto end_op;                                                  \
+        const rv_insn_t *next = ir->next;                                 \
+        MUST_TAIL return next->impl(rv, next, cycle, PC);                 \
+    end_op:                                                               \
+        rv->csr_cycle = cycle;                                            \
+        rv->PC = PC;                                                      \
+        return true;                                                      \
     }
 
 #include "rv32_template.c"
 #undef RVOP
 
 /* multiple LUI */
-static bool do_fuse1(riscv_t *rv,
-                     const rv_insn_t *ir,
-                     uint64_t cycle,
-                     uint32_t PC)
+static PRESERVE_NONE bool do_fuse1(riscv_t *rv,
+                                   const rv_insn_t *ir,
+                                   uint64_t cycle,
+                                   uint32_t PC)
 {
     cycle += ir->imm2;
     opcode_fuse_t *fuse = ir->fuse;
@@ -493,10 +493,10 @@ static bool do_fuse1(riscv_t *rv,
 }
 
 /* LUI + ADD */
-static bool do_fuse2(riscv_t *rv,
-                     const rv_insn_t *ir,
-                     uint64_t cycle,
-                     uint32_t PC)
+static PRESERVE_NONE bool do_fuse2(riscv_t *rv,
+                                   const rv_insn_t *ir,
+                                   uint64_t cycle,
+                                   uint32_t PC)
 {
     cycle += 2;
     rv->X[ir->rd] = ir->imm;
@@ -512,10 +512,10 @@ static bool do_fuse2(riscv_t *rv,
 }
 
 /* multiple SW */
-static bool do_fuse3(riscv_t *rv,
-                     const rv_insn_t *ir,
-                     uint64_t cycle,
-                     uint32_t PC)
+static PRESERVE_NONE bool do_fuse3(riscv_t *rv,
+                                   const rv_insn_t *ir,
+                                   uint64_t cycle,
+                                   uint32_t PC)
 {
     cycle += ir->imm2;
     opcode_fuse_t *fuse = ir->fuse;
@@ -543,10 +543,10 @@ static bool do_fuse3(riscv_t *rv,
 }
 
 /* multiple LW */
-static bool do_fuse4(riscv_t *rv,
-                     const rv_insn_t *ir,
-                     uint64_t cycle,
-                     uint32_t PC)
+static PRESERVE_NONE bool do_fuse4(riscv_t *rv,
+                                   const rv_insn_t *ir,
+                                   uint64_t cycle,
+                                   uint32_t PC)
 {
     cycle += ir->imm2;
     opcode_fuse_t *fuse = ir->fuse;
@@ -570,10 +570,10 @@ static bool do_fuse4(riscv_t *rv,
 }
 
 /* multiple shift immediate */
-static bool do_fuse5(riscv_t *rv,
-                     const rv_insn_t *ir,
-                     uint64_t cycle,
-                     uint32_t PC)
+static PRESERVE_NONE bool do_fuse5(riscv_t *rv,
+                                   const rv_insn_t *ir,
+                                   uint64_t cycle,
+                                   uint32_t PC)
 {
     cycle += ir->imm2;
     opcode_fuse_t *fuse = ir->fuse;
@@ -606,8 +606,7 @@ FORCE_INLINE bool insn_is_branch(uint8_t opcode)
 {
     switch (opcode) {
 #define _(inst, can_branch, insn_len, translatable, reg_mask) \
-    IIF(can_branch)                                           \
-    (case rv_insn_##inst:, )
+    IIF(can_branch)(case rv_insn_##inst:, )
         RV_INSN_LIST
 #undef _
         return true;
@@ -620,8 +619,7 @@ FORCE_INLINE bool insn_is_translatable(uint8_t opcode)
 {
     switch (opcode) {
 #define _(inst, can_branch, insn_len, translatable, reg_mask) \
-    IIF(translatable)                                         \
-    (case rv_insn_##inst:, )
+    IIF(translatable)(case rv_insn_##inst:, )
         RV_INSN_LIST
 #undef _
         return true;


### PR DESCRIPTION
The preserve_none calling convention attribute must be applied to function declarations, not return statements. The previous commit (d8382ab) incorrectly added it to the MUST_TAIL macro which is used on return statements, causing compilation errors.

Additionally, macOS clang falsely reports __has_attribute(preserve_none) as true but doesn't actually support the attribute, causing 20+ errors.

The optimization now works on Linux (Clang 19.1.0+) while building cleanly on macOS.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misuse of the preserve_none attribute to restore builds on macOS while keeping the calling-convention optimization on Linux (Clang 19.1+). The attribute is now applied to function declarations via a new PRESERVE_NONE macro and disabled on Apple toolchains.

- **Bug Fixes**
  - Removed preserve_none from MUST_TAIL and introduced PRESERVE_NONE for function declarations.
  - Disabled PRESERVE_NONE on macOS due to clang falsely advertising support.
  - Annotated the interpreter op function pointer and do_* handlers with PRESERVE_NONE to retain the optimization on supported compilers.

<sup>Written for commit aa023f04706fa4595dc631768db3a3c57a39819f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



