### PR TITLE
Update formatting to require clang-format-20

### DIFF
--- a/.ci/check-format.sh
+++ b/.ci/check-format.sh
@@ -11,12 +11,12 @@ while IFS= read -r file; do
 done < <(git ls-files -- '*.c' '*.cxx' '*.cpp' '*.h' '*.hpp')
 
 if [ ${#C_SOURCES[@]} -gt 0 ]; then
-    if command -v clang-format-18 > /dev/null 2>&1; then
+    if command -v clang-format-20 > /dev/null 2>&1; then
         echo "Checking C/C++ files..."
-        clang-format-18 -n --Werror "${C_SOURCES[@]}"
+        clang-format-20 -n --Werror "${C_SOURCES[@]}"
         C_FORMAT_EXIT=$?
     else
-        echo "Skipping C/C++ format check: clang-format-18 not found" >&2
+        echo "Skipping C/C++ format check: clang-format-20 not found" >&2
         C_FORMAT_EXIT=0
     fi
 else

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -592,7 +592,10 @@ jobs:
     - uses: actions/checkout@v4
     - name: coding convention
       run: |
-            sudo apt-get install -q=2 clang-format-18 shfmt python3-pip
+            wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.gpg >/dev/null
+            echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-20 main" | sudo tee /etc/apt/sources.list.d/llvm-20.list
+            sudo apt-get update -q=2
+            sudo apt-get install -q=2 clang-format-20 shfmt python3-pip
             pip3 install black==25.1.0
             curl -LSfs https://go.mskelton.dev/dtsfmt/install | sh -s -- -y
             .ci/check-newline.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ However, participation requires adherence to fundamental ground rules:
   For instance, opt for "initialize" over "initialise" and "color" rather than "colour".
 
 Software requirement:
-* [clang-format](https://clang.llvm.org/docs/ClangFormat.html) version 18.
+* [clang-format](https://clang.llvm.org/docs/ClangFormat.html) version 20 or later.
 * [shfmt](https://github.com/mvdan/sh).
 * [black](https://github.com/psf/black) version 25.1.0.
 * [dtsfmt](https://github.com/mskelton/dtsfmt).

--- a/Makefile
+++ b/Makefile
@@ -488,7 +488,7 @@ quake: artifact $(quake_deps)
 endif
 endif
 
-CLANG_FORMAT := $(shell which clang-format-18 2>/dev/null)
+CLANG_FORMAT := $(shell which clang-format-20 2>/dev/null)
 
 SHFMT := $(shell which shfmt 2>/dev/null)
 
@@ -510,7 +510,7 @@ SUBMODULES_PRUNE_PATHS := $(shell for subm in $(SUBMODULES); do echo -n "-path \
 
 format:
 ifeq ($(CLANG_FORMAT),)
-	$(error clang-format-18 not found. Install clang-format version 18 and try again)
+	$(error clang-format-20 not found. Install clang-format version 20 and try again)
 else
         # Skip formatting submodules and everything in $(OUT), apply the same rule for shfmt and black
 	$(Q)$(CLANG_FORMAT) -i $(shell find . \( $(SUBMODULES_PRUNE_PATHS) -o -path \"./$(OUT)\" \) \

--- a/src/breakpoint.c
+++ b/src/breakpoint.c
@@ -24,7 +24,7 @@ breakpoint_map_t breakpoint_map_new()
 
 bool breakpoint_map_insert(breakpoint_map_t map, riscv_word_t addr)
 {
-    breakpoint_t bp = (breakpoint_t){.addr = addr, .orig_insn = 0};
+    breakpoint_t bp = (breakpoint_t) {.addr = addr, .orig_insn = 0};
     map_iter_t it;
     map_find(map, &it, &addr);
     /* breakpoints are not expected to be set at duplicate addresses */

--- a/src/elf.c
+++ b/src/elf.c
@@ -191,7 +191,7 @@ static void fill_symbols(elf_t *e)
 {
     /* initialize the symbol table */
     map_clear(e->symbols);
-    map_insert(e->symbols, &(int){0}, &(char *){NULL});
+    map_insert(e->symbols, &(int) {0}, &(char *) {NULL});
 
     /* get the string table */
     const char *strtab = get_strtab(e);

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -86,17 +86,16 @@ static inline void check_tohost_write(riscv_t *rv,
  * @compress: compressed instruction or not
  * @IO: whether the misaligned handler is for load/store or insn.
  */
-#define RV_EXC_MISALIGN_HANDLER(mask_or_pc, type, compress, IO)       \
-    IIF(IO)                                                           \
-    (if (!PRIV(rv)->allow_misalign && unlikely(addr & (mask_or_pc))), \
-     if (unlikely(insn_is_misaligned(PC))))                           \
-    {                                                                 \
-        rv->compressed = compress;                                    \
-        rv->csr_cycle = cycle;                                        \
-        rv->PC = PC;                                                  \
-        SET_CAUSE_AND_TVAL_THEN_TRAP(rv, type##_MISALIGNED,           \
-                                     IIF(IO)(addr, mask_or_pc));      \
-        return false;                                                 \
+#define RV_EXC_MISALIGN_HANDLER(mask_or_pc, type, compress, IO)              \
+    IIF(IO)(if (!PRIV(rv)->allow_misalign && unlikely(addr & (mask_or_pc))), \
+            if (unlikely(insn_is_misaligned(PC))))                           \
+    {                                                                        \
+        rv->compressed = compress;                                           \
+        rv->csr_cycle = cycle;                                               \
+        rv->PC = PC;                                                         \
+        SET_CAUSE_AND_TVAL_THEN_TRAP(rv, type##_MISALIGNED,                  \
+                                     IIF(IO)(addr, mask_or_pc));             \
+        return false;                                                        \
     }
 
 /* FIXME: use more precise methods for updating time, e.g., RTC */
@@ -306,7 +305,7 @@ static uint32_t csr_csrrc(riscv_t *rv,
 void rv_debug(riscv_t *rv)
 {
     if (!gdbstub_init(&rv->gdbstub, &gdbstub_ops,
-                      (arch_info_t){
+                      (arch_info_t) {
                           .reg_num = 33,
                           .target_desc = TARGET_RV32,
                       },
@@ -444,21 +443,19 @@ static uint32_t peripheral_update_ctr = 64;
     {                                                                     \
         IIF(RV32_HAS(SYSTEM))(rv->timer++;, ) cycle++;                    \
         code;                                                             \
-        IIF(RV32_HAS(SYSTEM))                                             \
-        (                                                                 \
+        IIF(RV32_HAS(SYSTEM))(                                            \
             if (need_handle_signal) {                                     \
                 need_handle_signal = false;                               \
                 return true;                                              \
             }, ) nextop : PC += __rv_insn_##inst##_len;                   \
-        IIF(RV32_HAS(SYSTEM))                                             \
-        (IIF(RV32_HAS(JIT))(                                              \
-             , if (unlikely(need_clear_block_map)) {                      \
-                 block_map_clear(rv);                                     \
-                 need_clear_block_map = false;                            \
-                 rv->csr_cycle = cycle;                                   \
-                 rv->PC = PC;                                             \
-                 return false;                                            \
-             }), );                                                       \
+        IIF(RV32_HAS(SYSTEM))(IIF(RV32_HAS(JIT))(                         \
+                                  , if (unlikely(need_clear_block_map)) { \
+                                      block_map_clear(rv);                \
+                                      need_clear_block_map = false;       \
+                                      rv->csr_cycle = cycle;              \
+                                      rv->PC = PC;                        \
+                                      return false;                       \
+                                  }), );                                  \
         if (unlikely(RVOP_NO_NEXT(ir)))                                   \
             goto end_op;                                                  \
         const rv_insn_t *next = ir->next;                                 \
@@ -1184,11 +1181,11 @@ void rv_step(void *arg)
             PRIV(rv)->on_exit = true;
 #endif
 
-            /* After emulating the previous block, it is determined whether the
-             * branch is taken or not. The IR array of the current block is then
-             * assigned to either the branch_taken or branch_untaken pointer of
-             * the previous block.
-             */
+        /* After emulating the previous block, it is determined whether the
+         * branch is taken or not. The IR array of the current block is then
+         * assigned to either the branch_taken or branch_untaken pointer of
+         * the previous block.
+         */
 
 #if RV32_HAS(BLOCK_CHAINING)
         if (prev

--- a/src/jit.c
+++ b/src/jit.c
@@ -2214,8 +2214,8 @@ static void resolve_jumps(struct jit_state *state)
             target_loc = jump.offset_loc + sizeof(uint32_t);
             for (int i = 0; i < state->n_blocks; i++) {
                 if (jump.target_pc == state->offset_map[i].pc) {
-                    IIF(RV32_HAS(SYSTEM))
-                    (if (jump.target_satp == state->offset_map[i].satp), )
+                    IIF(RV32_HAS(SYSTEM))(
+                        if (jump.target_satp == state->offset_map[i].satp), )
                     {
                         target_loc = state->offset_map[i].offset;
                         break;
@@ -2256,8 +2256,7 @@ static void translate_chained_block(struct jit_state *state,
         block_t *block1 =
             cache_get(rv->block_cache, ir->branch_untaken->pc, false);
         if (block1->translatable) {
-            IIF(RV32_HAS(SYSTEM))
-            (if (block1->satp == rv->csr_satp), )
+            IIF(RV32_HAS(SYSTEM))(if (block1->satp == rv->csr_satp), )
                 translate_chained_block(state, rv, block1);
         }
     }
@@ -2265,8 +2264,7 @@ static void translate_chained_block(struct jit_state *state,
         block_t *block1 =
             cache_get(rv->block_cache, ir->branch_taken->pc, false);
         if (block1->translatable) {
-            IIF(RV32_HAS(SYSTEM))
-            (if (block1->satp == rv->csr_satp), )
+            IIF(RV32_HAS(SYSTEM))(if (block1->satp == rv->csr_satp), )
                 translate_chained_block(state, rv, block1);
         }
     }
@@ -2287,8 +2285,7 @@ static void translate_chained_block(struct jit_state *state,
                 block_t *block1 =
                     cache_get(rv->block_cache, bt->PC[max_idx], false);
                 if (block1 && block1->translatable) {
-                    IIF(RV32_HAS(SYSTEM))
-                    (if (block1->satp == rv->csr_satp), )
+                    IIF(RV32_HAS(SYSTEM))(if (block1->satp == rv->csr_satp), )
                         translate_chained_block(state, rv, block1);
                 }
             }

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -173,15 +173,15 @@ void rv_remap_stdstream(riscv_t *rv, fd_stream_pair_t *fsp, uint32_t fsp_size)
 }
 
 #define MEMIO(op) on_mem_##op
-#define IO_HANDLER_IMPL(type, op, RW)                                     \
-    static IIF(RW)(                                                       \
-        /* W */ void MEMIO(op)(UNUSED riscv_t * rv, riscv_word_t addr,    \
-                               riscv_##type##_t data),                    \
-        /* R */ riscv_##type##_t MEMIO(op)(UNUSED riscv_t * rv,           \
-                                           riscv_word_t addr))            \
-    {                                                                     \
-        IIF(RW)                                                           \
-        (memory_##op(addr, (uint8_t *) &data), return memory_##op(addr)); \
+#define IO_HANDLER_IMPL(type, op, RW)                                  \
+    static IIF(RW)(                                                    \
+        /* W */ void MEMIO(op)(UNUSED riscv_t * rv, riscv_word_t addr, \
+                               riscv_##type##_t data),                 \
+        /* R */ riscv_##type##_t MEMIO(op)(UNUSED riscv_t * rv,        \
+                                           riscv_word_t addr))         \
+    {                                                                  \
+        IIF(RW)(memory_##op(addr, (uint8_t *) &data),                  \
+                return memory_##op(addr));                             \
     }
 
 #if !RV32_HAS(SYSTEM)
@@ -541,7 +541,7 @@ riscv_t *rv_create(riscv_user_t rv_attr)
      */
     attr->fd_map = map_init(int, FILE *, map_cmp_int);
     rv_remap_stdstream(rv,
-                       (fd_stream_pair_t[]){
+                       (fd_stream_pair_t[]) {
                            {STDIN_FILENO, stdin},
                            {STDOUT_FILENO, stdout},
                            {STDERR_FILENO, stderr},

--- a/src/rv32_jit.c
+++ b/src/rv32_jit.c
@@ -155,8 +155,7 @@ GEN(bgeu, {
 GEN(lb, {
     memory_t *m = PRIV(rv)->mem;
     vm_reg[0] = ra_load(state, ir->rs1);
-    IIF(RV32_HAS(SYSTEM_MMIO))
-    (
+    IIF(RV32_HAS(SYSTEM_MMIO))(
         {
             emit_load_imm_sext(state, temp_reg, ir->imm);
             emit_alu32(state, 0x01, vm_reg[0], temp_reg);
@@ -207,8 +206,7 @@ GEN(lb, {
 GEN(lh, {
     memory_t *m = PRIV(rv)->mem;
     vm_reg[0] = ra_load(state, ir->rs1);
-    IIF(RV32_HAS(SYSTEM_MMIO))
-    (
+    IIF(RV32_HAS(SYSTEM_MMIO))(
         {
             emit_load_imm_sext(state, temp_reg, ir->imm);
             emit_alu32(state, 0x01, vm_reg[0], temp_reg);
@@ -259,8 +257,7 @@ GEN(lh, {
 GEN(lw, {
     memory_t *m = PRIV(rv)->mem;
     vm_reg[0] = ra_load(state, ir->rs1);
-    IIF(RV32_HAS(SYSTEM_MMIO))
-    (
+    IIF(RV32_HAS(SYSTEM_MMIO))(
         {
             emit_load_imm_sext(state, temp_reg, ir->imm);
             emit_alu32(state, 0x01, vm_reg[0], temp_reg);
@@ -311,8 +308,7 @@ GEN(lw, {
 GEN(lbu, {
     memory_t *m = PRIV(rv)->mem;
     vm_reg[0] = ra_load(state, ir->rs1);
-    IIF(RV32_HAS(SYSTEM_MMIO))
-    (
+    IIF(RV32_HAS(SYSTEM_MMIO))(
         {
             emit_load_imm_sext(state, temp_reg, ir->imm);
             emit_alu32(state, 0x01, vm_reg[0], temp_reg);
@@ -363,8 +359,7 @@ GEN(lbu, {
 GEN(lhu, {
     memory_t *m = PRIV(rv)->mem;
     vm_reg[0] = ra_load(state, ir->rs1);
-    IIF(RV32_HAS(SYSTEM_MMIO))
-    (
+    IIF(RV32_HAS(SYSTEM_MMIO))(
         {
             emit_load_imm_sext(state, temp_reg, ir->imm);
             emit_alu32(state, 0x01, vm_reg[0], temp_reg);
@@ -415,8 +410,7 @@ GEN(lhu, {
 GEN(sb, {
     memory_t *m = PRIV(rv)->mem;
     vm_reg[0] = ra_load(state, ir->rs1);
-    IIF(RV32_HAS(SYSTEM_MMIO))
-    (
+    IIF(RV32_HAS(SYSTEM_MMIO))(
         {
             emit_load_imm_sext(state, temp_reg, ir->imm);
             emit_alu32(state, 0x01, vm_reg[0], temp_reg);
@@ -465,8 +459,7 @@ GEN(sb, {
 GEN(sh, {
     memory_t *m = PRIV(rv)->mem;
     vm_reg[0] = ra_load(state, ir->rs1);
-    IIF(RV32_HAS(SYSTEM_MMIO))
-    (
+    IIF(RV32_HAS(SYSTEM_MMIO))(
         {
             emit_load_imm_sext(state, temp_reg, ir->imm);
             emit_alu32(state, 0x01, vm_reg[0], temp_reg);
@@ -515,8 +508,7 @@ GEN(sh, {
 GEN(sw, {
     memory_t *m = PRIV(rv)->mem;
     vm_reg[0] = ra_load(state, ir->rs1);
-    IIF(RV32_HAS(SYSTEM_MMIO))
-    (
+    IIF(RV32_HAS(SYSTEM_MMIO))(
         {
             emit_load_imm_sext(state, temp_reg, ir->imm);
             emit_alu32(state, 0x01, vm_reg[0], temp_reg);

--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -161,7 +161,7 @@ RVOP(
         /* link with return address */
         if (ir->rd)
             rv->X[ir->rd] = pc + 4;
-        /* check instruction misaligned */
+    /* check instruction misaligned */
 #if !RV32_HAS(EXT_C)
         RV_EXC_MISALIGN_HANDLER(pc, INSN, false, 0);
 #endif
@@ -170,8 +170,8 @@ RVOP(
 #if RV32_HAS(JIT)
             IIF(RV32_HAS(SYSTEM)(if (!rv->is_trapped && !reloc_enable_mmu), ))
             {
-                IIF(RV32_HAS(SYSTEM))
-                (block_t *next =, ) cache_get(rv->block_cache, PC, true);
+                IIF(RV32_HAS(SYSTEM))(block_t *next =, )
+                    cache_get(rv->block_cache, PC, true);
                 IIF(RV32_HAS(SYSTEM))(if (next->satp == rv->csr_satp), )
                 {
                     if (!set_add(&pc_set, PC))
@@ -263,8 +263,8 @@ RVOP(
         if (block) {                                                         \
             for (int i = 0; i < HISTORY_SIZE; i++) {                         \
                 if (ir->branch_table->PC[i] == PC) {                         \
-                    IIF(RV32_HAS(SYSTEM))                                    \
-                    (if (ir->branch_table->satp[i] == rv->csr_satp), )       \
+                    IIF(RV32_HAS(SYSTEM))(                                   \
+                        if (ir->branch_table->satp[i] == rv->csr_satp), )    \
                     {                                                        \
                         ir->branch_table->times[i]++;                        \
                         if (cache_hot(rv->block_cache, PC))                  \
@@ -285,8 +285,8 @@ RVOP(
             }                                                                \
             ir->branch_table->times[min_idx] = 1;                            \
             ir->branch_table->PC[min_idx] = PC;                              \
-            IIF(RV32_HAS(SYSTEM))                                            \
-            (ir->branch_table->satp[min_idx] = rv->csr_satp, );              \
+            IIF(RV32_HAS(SYSTEM))(                                           \
+                ir->branch_table->satp[min_idx] = rv->csr_satp, );           \
             if (cache_hot(rv->block_cache, PC))                              \
                 goto end_op;                                                 \
             MUST_TAIL return block->ir_head->impl(rv, block->ir_head, cycle, \
@@ -311,7 +311,7 @@ RVOP(
         /* link */
         if (ir->rd)
             rv->X[ir->rd] = pc + 4;
-        /* check instruction misaligned */
+    /* check instruction misaligned */
 #if !RV32_HAS(EXT_C)
         RV_EXC_MISALIGN_HANDLER(pc, INSN, false, 0);
 #endif
@@ -367,8 +367,7 @@ RVOP(
 #define BRANCH_FUNC(type, cond)                                             \
     IIF(RV32_HAS(EXT_C))(, const uint32_t pc = PC;);                        \
     if (BRANCH_COND(type, rv->X[ir->rs1], rv->X[ir->rs2], cond)) {          \
-        IIF(RV32_HAS(SYSTEM))                                               \
-        (                                                                   \
+        IIF(RV32_HAS(SYSTEM))(                                              \
             {                                                               \
                 if (!rv->is_trapped) {                                      \
                     is_branch_taken = false;                                \
@@ -378,8 +377,7 @@ RVOP(
         struct rv_insn *untaken = ir->branch_untaken;                       \
         if (!untaken)                                                       \
             goto nextop;                                                    \
-        IIF(RV32_HAS(JIT))                                                  \
-        (                                                                   \
+        IIF(RV32_HAS(JIT))(                                                 \
             {                                                               \
                 block_t *next = cache_get(rv->block_cache, PC + 4, true);   \
                 if (next IIF(RV32_HAS(SYSTEM))(                             \
@@ -391,8 +389,7 @@ RVOP(
                 }                                                           \
             }, );                                                           \
         PC += 4;                                                            \
-        IIF(RV32_HAS(SYSTEM))                                               \
-        (                                                                   \
+        IIF(RV32_HAS(SYSTEM))(                                              \
             {                                                               \
                 if (!rv->is_trapped) {                                      \
                     last_pc = PC;                                           \
@@ -401,8 +398,7 @@ RVOP(
             }, );                                                           \
         goto end_op;                                                        \
     }                                                                       \
-    IIF(RV32_HAS(SYSTEM))                                                   \
-    (                                                                       \
+    IIF(RV32_HAS(SYSTEM))(                                                  \
         {                                                                   \
             if (!rv->is_trapped) {                                          \
                 is_branch_taken = true;                                     \
@@ -411,12 +407,10 @@ RVOP(
         is_branch_taken = true;);                                           \
     PC += ir->imm;                                                          \
     /* check instruction misaligned */                                      \
-    IIF(RV32_HAS(EXT_C))                                                    \
-    (, RV_EXC_MISALIGN_HANDLER(pc, INSN, false, 0););                       \
+    IIF(RV32_HAS(EXT_C))(, RV_EXC_MISALIGN_HANDLER(pc, INSN, false, 0););   \
     struct rv_insn *taken = ir->branch_taken;                               \
     if (taken) {                                                            \
-        IIF(RV32_HAS(JIT))                                                  \
-        (                                                                   \
+        IIF(RV32_HAS(JIT))(                                                 \
             {                                                               \
                 block_t *next = cache_get(rv->block_cache, PC, true);       \
                 if (next IIF(RV32_HAS(SYSTEM))(                             \
@@ -427,8 +421,7 @@ RVOP(
                         goto end_op;                                        \
                 }                                                           \
             }, );                                                           \
-        IIF(RV32_HAS(SYSTEM))                                               \
-        (                                                                   \
+        IIF(RV32_HAS(SYSTEM))(                                              \
             {                                                               \
                 if (!rv->is_trapped) {                                      \
                     last_pc = PC;                                           \
@@ -2158,8 +2151,8 @@ RVOP(
         struct rv_insn *taken = ir->branch_taken;
         if (taken) {
 #if RV32_HAS(JIT)
-            IIF(RV32_HAS(SYSTEM))
-            (block_t *next =, ) cache_get(rv->block_cache, PC, true);
+            IIF(RV32_HAS(SYSTEM))(block_t *next =, )
+                cache_get(rv->block_cache, PC, true);
             IIF(RV32_HAS(SYSTEM))(if (next->satp == rv->csr_satp), )
             {
                 if (!set_add(&pc_set, PC))
@@ -2329,8 +2322,8 @@ RVOP(
         struct rv_insn *taken = ir->branch_taken;
         if (taken) {
 #if RV32_HAS(JIT)
-            IIF(RV32_HAS(SYSTEM))
-            (block_t *next =, ) cache_get(rv->block_cache, PC, true);
+            IIF(RV32_HAS(SYSTEM))(block_t *next =, )
+                cache_get(rv->block_cache, PC, true);
             IIF(RV32_HAS(SYSTEM))(if (next->satp == rv->csr_satp), )
             {
                 if (!set_add(&pc_set, PC))
@@ -2371,8 +2364,8 @@ RVOP(
             if (!untaken)
                 goto nextop;
 #if RV32_HAS(JIT)
-            IIF(RV32_HAS(SYSTEM))
-            (block_t *next =, ) cache_get(rv->block_cache, PC + 2, true);
+            IIF(RV32_HAS(SYSTEM))(block_t *next =, )
+                cache_get(rv->block_cache, PC + 2, true);
             IIF(RV32_HAS(SYSTEM))(if (next->satp == rv->csr_satp), )
             {
                 if (!set_add(&pc_set, PC + 2))
@@ -2397,8 +2390,8 @@ RVOP(
         struct rv_insn *taken = ir->branch_taken;
         if (taken) {
 #if RV32_HAS(JIT)
-            IIF(RV32_HAS(SYSTEM))
-            (block_t *next =, ) cache_get(rv->block_cache, PC, true);
+            IIF(RV32_HAS(SYSTEM))(block_t *next =, )
+                cache_get(rv->block_cache, PC, true);
             IIF(RV32_HAS(SYSTEM))(if (next->satp == rv->csr_satp), )
             {
                 if (!set_add(&pc_set, PC))
@@ -2448,8 +2441,8 @@ RVOP(
             if (!untaken)
                 goto nextop;
 #if RV32_HAS(JIT)
-            IIF(RV32_HAS(SYSTEM))
-            (block_t *next =, ) cache_get(rv->block_cache, PC + 2, true);
+            IIF(RV32_HAS(SYSTEM))(block_t *next =, )
+                cache_get(rv->block_cache, PC + 2, true);
             IIF(RV32_HAS(SYSTEM))(if (next->satp == rv->csr_satp), )
             {
                 if (!set_add(&pc_set, PC + 2))
@@ -2474,8 +2467,8 @@ RVOP(
         struct rv_insn *taken = ir->branch_taken;
         if (taken) {
 #if RV32_HAS(JIT)
-            IIF(RV32_HAS(SYSTEM))
-            (block_t *next =, ) cache_get(rv->block_cache, PC, true);
+            IIF(RV32_HAS(SYSTEM))(block_t *next =, )
+                cache_get(rv->block_cache, PC, true);
             IIF(RV32_HAS(SYSTEM))(if (next->satp == rv->csr_satp), )
             {
                 if (!set_add(&pc_set, PC))

--- a/src/syscall_sdl.c
+++ b/src/syscall_sdl.c
@@ -379,7 +379,7 @@ void syscall_draw_frame(riscv_t *rv)
     int actual_width, actual_height;
     SDL_GetWindowSize(window, &actual_width, &actual_height);
     SDL_RenderCopy(renderer, texture, NULL,
-                   &(SDL_Rect){0, 0, actual_width, actual_height});
+                   &(SDL_Rect) {0, 0, actual_width, actual_height});
     SDL_RenderPresent(renderer);
 }
 

--- a/src/t2c_template.c
+++ b/src/t2c_template.c
@@ -238,8 +238,7 @@ T2C_MMU_STORE(sw, mmu_write_w);
 #endif
 
 T2C_OP(lb, {
-    IIF(RV32_HAS(SYSTEM))
-    (
+    IIF(RV32_HAS(SYSTEM))(
         { t2c_mmu_wrapper(lb)(builder, start, ir); },
         {
             LLVMValueRef mem_loc =
@@ -253,8 +252,7 @@ T2C_OP(lb, {
 })
 
 T2C_OP(lh, {
-    IIF(RV32_HAS(SYSTEM))
-    (
+    IIF(RV32_HAS(SYSTEM))(
         { t2c_mmu_wrapper(lh)(builder, start, ir); },
         {
             LLVMValueRef mem_loc =
@@ -269,8 +267,7 @@ T2C_OP(lh, {
 
 
 T2C_OP(lw, {
-    IIF(RV32_HAS(SYSTEM))
-    (
+    IIF(RV32_HAS(SYSTEM))(
         { t2c_mmu_wrapper(lw)(builder, start, ir); },
         {
             LLVMValueRef mem_loc =
@@ -282,8 +279,7 @@ T2C_OP(lw, {
 })
 
 T2C_OP(lbu, {
-    IIF(RV32_HAS(SYSTEM))
-    (
+    IIF(RV32_HAS(SYSTEM))(
         { t2c_mmu_wrapper(lbu)(builder, start, ir); },
         {
             LLVMValueRef mem_loc =
@@ -297,8 +293,7 @@ T2C_OP(lbu, {
 })
 
 T2C_OP(lhu, {
-    IIF(RV32_HAS(SYSTEM))
-    (
+    IIF(RV32_HAS(SYSTEM))(
         { t2c_mmu_wrapper(lhu)(builder, start, ir); },
         {
             LLVMValueRef mem_loc =
@@ -312,8 +307,7 @@ T2C_OP(lhu, {
 })
 
 T2C_OP(sb, {
-    IIF(RV32_HAS(SYSTEM))
-    (
+    IIF(RV32_HAS(SYSTEM))(
         { t2c_mmu_wrapper(sb)(builder, start, ir); },
         {
             LLVMValueRef mem_loc =
@@ -325,8 +319,7 @@ T2C_OP(sb, {
 })
 
 T2C_OP(sh, {
-    IIF(RV32_HAS(SYSTEM))
-    (
+    IIF(RV32_HAS(SYSTEM))(
         { t2c_mmu_wrapper(sh)(builder, start, ir); },
         {
             LLVMValueRef mem_loc =
@@ -338,8 +331,7 @@ T2C_OP(sh, {
 })
 
 T2C_OP(sw, {
-    IIF(RV32_HAS(SYSTEM))
-    (
+    IIF(RV32_HAS(SYSTEM))(
         { t2c_mmu_wrapper(sw)(builder, start, ir); },
         {
             LLVMValueRef mem_loc =

--- a/tests/maj2random.c
+++ b/tests/maj2random.c
@@ -186,15 +186,15 @@ char *format_rate(double rate)
 
 vec2 f1(ullong i, ullong j)
 {
-    return (vec2){0.0f, (float) i / (float) j};
+    return (vec2) {0.0f, (float) i / (float) j};
 }
 vec2 f2(ullong i, ullong j)
 {
-    return (vec2){(float) i / (float) j, 0.0f};
+    return (vec2) {(float) i / (float) j, 0.0f};
 }
 vec2 f3(ullong i, ullong j)
 {
-    return (vec2){(float) i / (float) j, (float) i / (float) j};
+    return (vec2) {(float) i / (float) j, (float) i / (float) j};
 }
 
 void test_maj(const char *name,


### PR DESCRIPTION
This bumps the required clang-format version from 18 to 20, including:
- Update CI workflow to configure LLVM 20 apt repository with proper GPG key handling (dearmored to binary format)
- Update format checking script and Makefile to use clang-format-20
- Update CONTRIBUTING.md to reflect new version requirement

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require clang-format-20 across the repo and CI. Updated CI to install LLVM 20 with a trusted GPG key, switched scripts/Makefile to clang-format-20, and reformatted sources for the new style.

- **Dependencies**
  - CI installs clang-format-20 via apt.llvm.org with a dearmored GPG key.
  - .ci/check-format.sh and Makefile now use clang-format-20.
  - CONTRIBUTING updated to require clang-format 20+.

- **Migration**
  - Install clang-format-20 (or newer) locally.
  - Run make format to apply new spacing/macro formatting.
  - Older clang-format versions will be skipped or fail the format target.

<sup>Written for commit bc5920b393de2655bcb97f1a858fbc5d0b38601e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

