### PR TITLE
Fix broken Timidity download URL

### DIFF
--- a/mk/external.mk
+++ b/mk/external.mk
@@ -107,7 +107,7 @@ QUAKE_DATA_SHA = 36b42dc7b6313fd9cabc0be8b9e9864840929735
 QUAKE_DATA_SHA_CMD = $(SHA1SUM)
 
 # Timidity software synthesizer configuration for SDL2_mixer
-TIMIDITY_DATA_URL = http://www.libsdl.org/projects/mixer/timidity/timidity.tar.gz
+TIMIDITY_DATA_URL = https://www.libsdl.org/projects/old/SDL_mixer/timidity/timidity.tar.gz
 TIMIDITY_DATA_DEST = $(OUT)
 TIMIDITY_DATA = $(TIMIDITY_DATA_DEST)/timidity
 TIMIDITY_DATA_SKIP_DIR_LEVEL = 0


### PR DESCRIPTION
The [original URL](http://www.libsdl.org/projects/mixer/timidity/timidity.tar.gz) now returns 404. Migrate to self-hosted asset in `rv32emu-prebuilt` repository and correct the SHA1 checksum for directory verification.





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Timidity data download URL to https://www.libsdl.org/projects/old/SDL_mixer/timidity/timidity.tar.gz to replace the 404 link. This restores successful download of the SDL2_mixer Timidity configuration during builds.

<sup>Written for commit 4e06513453ee7531761cba58ab4a62d009d825ac. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





