### PR TITLE
Fix hart halt when non-SDL programs exit via syscall 93

### DIFF
--- a/src/riscv.h
+++ b/src/riscv.h
@@ -568,6 +568,11 @@ typedef struct {
     bool on_exit;
 #endif
 
+#if RV32_HAS(SDL) && RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+    /* flag to determine if running SDL program in guestOS */
+    bool running_sdl;
+#endif /* SDL */
+
     /* SBI timer */
     uint64_t timer;
 } vm_attr_t;

--- a/src/syscall.c
+++ b/src/syscall.c
@@ -134,18 +134,6 @@ error_handler:
 
 static void syscall_exit(riscv_t *rv)
 {
-#if RV32_HAS(SDL) && RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
-    /*
-     * The guestOS may repeatedly open and close the SDL window,
-     * and the user could close the application using the application’s
-     * built-in exit function. Need to trap the built-in exit and
-     * ensure the SDL window and SDL mixer are destroyed properly.
-     */
-    extern void sdl_video_audio_cleanup();
-    sdl_video_audio_cleanup();
-    return;
-#endif
-
     /* simply halt cpu and save exit code.
      * the application decides the usage of exit code
      */

--- a/src/syscall_sdl.c
+++ b/src/syscall_sdl.c
@@ -393,6 +393,7 @@ void syscall_setup_queue(riscv_t *rv)
      */
     event_queue.base = event_queue.end = 0;
     submission_queue.base = submission_queue.start = 0;
+    PRIV(rv)->running_sdl = true;
 #endif
 
     /* setup_queue(base, capacity, event_count) */


### PR DESCRIPTION
Non-SDL guestOS userspace programs exit directly via syscall 93 (syscall_exit) could cause hart to halt prematurely.

This patch introduces a new attribute, running_sdl, which is set to true during SDL resource initialization and reset to false before entering the guestOS exit path. This ensures hostOS SDL resources are properly cleaned up without halting the hart prematurely.

Additionally, all guestOS exit paths, whether triggered by exit(), _exit(), exit_group() are now follow the same exit path.

Close #596

## Testing
1. Clone the repo:
```shell
$ git clone https://github.com/ChinYikMing/rv32emu.git -b fix-syscall-exit --depth 1 && cd rv32emu
```

2. Build emulator
```shell
$ make ENABLE_SYSTEM=1 ENABLE_SDL=0 INITRD_SIZE=32 -j8
```

3. Fetch artifacts
```shell
$ make artifact ENABLE_SYSTEM=1
```

4. Boot guestOS (<ROOTFS_HAS_ZSTD> is in the [issue](https://github.com/sysprog21/rv32emu/issues/596#issuecomment-3691542113))
```shell
$ build/rv32emu -k build/linux-image/Image -i <ROOTFS_HAS_ZSTD>
```

5. Run `zstd`
```shell
# touch apple && zstd apple -o apple.zstd
```

## Expectation
w/ the patch: the hart does not halt after `zstd` exits.
```
# touch apple && zstd apple -o apple.zstd
apple                :  (     0 B =>     13 B, apple.zstd)                     
# 
```
w/o the patch: the hart halts after `zstd` exits.
```
# touch apple && zstd apple -o apple.zstd
apple                :  (     0 B =>     13 B, apple.zstd)                     
23:53:06 INFO  src/main.c:362: RISC-V emulator is destroyed
```



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes premature hart halt when non-SDL guest programs exit via syscall 93 by routing exits through the normal OS path and cleaning up SDL only when an SDL app is running.

- **Bug Fixes**
  - Added running_sdl flag; set during SDL init and cleared on trapped exit.
  - Moved SDL cleanup from syscall_exit to U-mode ecall handler and removed special-casing of syscall 93.

<sup>Written for commit 6dda36735788faf6541cf49c10b6cfe4dc9725fb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





