### PR TITLE
Fix JIT non-deterministic execution on Arm64

### DIFF
--- a/src/rv32_jit.c
+++ b/src/rv32_jit.c
@@ -556,7 +556,7 @@ GEN(sw, {
 })
 GEN(addi, {
     vm_reg[0] = ra_load(state, ir->rs1);
-    vm_reg[1] = map_vm_reg(state, ir->rd);
+    vm_reg[1] = map_vm_reg_reserved(state, ir->rd, vm_reg[0]);
     if (vm_reg[0] != vm_reg[1]) {
         emit_mov(state, vm_reg[0], vm_reg[1]);
     }
@@ -565,7 +565,7 @@ GEN(addi, {
 GEN(slti, {
     vm_reg[0] = ra_load(state, ir->rs1);
     emit_cmp_imm32(state, vm_reg[0], ir->imm);
-    vm_reg[1] = map_vm_reg(state, ir->rd);
+    vm_reg[1] = map_vm_reg_reserved(state, ir->rd, vm_reg[0]);
     emit_load_imm(state, vm_reg[1], 1);
     uint32_t jump_loc_0 = state->offset;
     emit_jcc_offset(state, 0x8c);
@@ -575,7 +575,7 @@ GEN(slti, {
 GEN(sltiu, {
     vm_reg[0] = ra_load(state, ir->rs1);
     emit_cmp_imm32(state, vm_reg[0], ir->imm);
-    vm_reg[1] = map_vm_reg(state, ir->rd);
+    vm_reg[1] = map_vm_reg_reserved(state, ir->rd, vm_reg[0]);
     emit_load_imm(state, vm_reg[1], 1);
     uint32_t jump_loc_0 = state->offset;
     emit_jcc_offset(state, 0x82);
@@ -584,7 +584,7 @@ GEN(sltiu, {
 })
 GEN(xori, {
     vm_reg[0] = ra_load(state, ir->rs1);
-    vm_reg[1] = map_vm_reg(state, ir->rd);
+    vm_reg[1] = map_vm_reg_reserved(state, ir->rd, vm_reg[0]);
     if (vm_reg[0] != vm_reg[1]) {
         emit_mov(state, vm_reg[0], vm_reg[1]);
     }
@@ -592,7 +592,7 @@ GEN(xori, {
 })
 GEN(ori, {
     vm_reg[0] = ra_load(state, ir->rs1);
-    vm_reg[1] = map_vm_reg(state, ir->rd);
+    vm_reg[1] = map_vm_reg_reserved(state, ir->rd, vm_reg[0]);
     if (vm_reg[0] != vm_reg[1]) {
         emit_mov(state, vm_reg[0], vm_reg[1]);
     }
@@ -600,7 +600,7 @@ GEN(ori, {
 })
 GEN(andi, {
     vm_reg[0] = ra_load(state, ir->rs1);
-    vm_reg[1] = map_vm_reg(state, ir->rd);
+    vm_reg[1] = map_vm_reg_reserved(state, ir->rd, vm_reg[0]);
     if (vm_reg[0] != vm_reg[1]) {
         emit_mov(state, vm_reg[0], vm_reg[1]);
     }
@@ -608,7 +608,7 @@ GEN(andi, {
 })
 GEN(slli, {
     vm_reg[0] = ra_load(state, ir->rs1);
-    vm_reg[1] = map_vm_reg(state, ir->rd);
+    vm_reg[1] = map_vm_reg_reserved(state, ir->rd, vm_reg[0]);
     if (vm_reg[0] != vm_reg[1]) {
         emit_mov(state, vm_reg[0], vm_reg[1]);
     }
@@ -616,7 +616,7 @@ GEN(slli, {
 })
 GEN(srli, {
     vm_reg[0] = ra_load(state, ir->rs1);
-    vm_reg[1] = map_vm_reg(state, ir->rd);
+    vm_reg[1] = map_vm_reg_reserved(state, ir->rd, vm_reg[0]);
     if (vm_reg[0] != vm_reg[1]) {
         emit_mov(state, vm_reg[0], vm_reg[1]);
     }
@@ -624,7 +624,7 @@ GEN(srli, {
 })
 GEN(srai, {
     vm_reg[0] = ra_load(state, ir->rs1);
-    vm_reg[1] = map_vm_reg(state, ir->rd);
+    vm_reg[1] = map_vm_reg_reserved(state, ir->rd, vm_reg[0]);
     if (vm_reg[0] != vm_reg[1]) {
         emit_mov(state, vm_reg[0], vm_reg[1]);
     }
@@ -632,21 +632,21 @@ GEN(srai, {
 })
 GEN(add, {
     ra_load2(state, ir->rs1, ir->rs2);
-    vm_reg[2] = map_vm_reg(state, ir->rd);
+    vm_reg[2] = map_vm_reg_reserved2(state, ir->rd, vm_reg[0], vm_reg[1]);
     emit_mov(state, vm_reg[1], temp_reg);
     emit_mov(state, vm_reg[0], vm_reg[2]);
     emit_alu32(state, 0x01, temp_reg, vm_reg[2]);
 })
 GEN(sub, {
     ra_load2(state, ir->rs1, ir->rs2);
-    vm_reg[2] = map_vm_reg(state, ir->rd);
+    vm_reg[2] = map_vm_reg_reserved2(state, ir->rd, vm_reg[0], vm_reg[1]);
     emit_mov(state, vm_reg[1], temp_reg);
     emit_mov(state, vm_reg[0], vm_reg[2]);
     emit_alu32(state, 0x29, temp_reg, vm_reg[2]);
 })
 GEN(sll, {
     ra_load2(state, ir->rs1, ir->rs2);
-    vm_reg[2] = map_vm_reg(state, ir->rd);
+    vm_reg[2] = map_vm_reg_reserved2(state, ir->rd, vm_reg[0], vm_reg[1]);
     emit_mov(state, vm_reg[1], temp_reg);
     emit_mov(state, vm_reg[0], vm_reg[2]);
     emit_alu32_imm32(state, 0x81, 4, temp_reg, 0x1f);
@@ -654,7 +654,7 @@ GEN(sll, {
 })
 GEN(slt, {
     ra_load2(state, ir->rs1, ir->rs2);
-    vm_reg[2] = map_vm_reg(state, ir->rd);
+    vm_reg[2] = map_vm_reg_reserved2(state, ir->rd, vm_reg[0], vm_reg[1]);
     emit_cmp32(state, vm_reg[1], vm_reg[0]);
     emit_load_imm(state, vm_reg[2], 1);
     uint32_t jump_loc_0 = state->offset;
@@ -664,7 +664,7 @@ GEN(slt, {
 })
 GEN(sltu, {
     ra_load2(state, ir->rs1, ir->rs2);
-    vm_reg[2] = map_vm_reg(state, ir->rd);
+    vm_reg[2] = map_vm_reg_reserved2(state, ir->rd, vm_reg[0], vm_reg[1]);
     emit_cmp32(state, vm_reg[1], vm_reg[0]);
     emit_load_imm(state, vm_reg[2], 1);
     uint32_t jump_loc_0 = state->offset;
@@ -674,14 +674,14 @@ GEN(sltu, {
 })
 GEN(xor, {
   ra_load2(state, ir->rs1, ir->rs2);
-  vm_reg[2] = map_vm_reg(state, ir->rd);
+  vm_reg[2] = map_vm_reg_reserved2(state, ir->rd, vm_reg[0], vm_reg[1]);
   emit_mov(state, vm_reg[1], temp_reg);
   emit_mov(state, vm_reg[0], vm_reg[2]);
   emit_alu32(state, 0x31, temp_reg, vm_reg[2]);
 })
 GEN(srl, {
     ra_load2(state, ir->rs1, ir->rs2);
-    vm_reg[2] = map_vm_reg(state, ir->rd);
+    vm_reg[2] = map_vm_reg_reserved2(state, ir->rd, vm_reg[0], vm_reg[1]);
     emit_mov(state, vm_reg[1], temp_reg);
     emit_mov(state, vm_reg[0], vm_reg[2]);
     emit_alu32_imm32(state, 0x81, 4, temp_reg, 0x1f);
@@ -689,7 +689,7 @@ GEN(srl, {
 })
 GEN(sra, {
     ra_load2(state, ir->rs1, ir->rs2);
-    vm_reg[2] = map_vm_reg(state, ir->rd);
+    vm_reg[2] = map_vm_reg_reserved2(state, ir->rd, vm_reg[0], vm_reg[1]);
     emit_mov(state, vm_reg[1], temp_reg);
     emit_mov(state, vm_reg[0], vm_reg[2]);
     emit_alu32_imm32(state, 0x81, 4, temp_reg, 0x1f);
@@ -697,14 +697,14 @@ GEN(sra, {
 })
 GEN(or, {
     ra_load2(state, ir->rs1, ir->rs2);
-    vm_reg[2] = map_vm_reg(state, ir->rd);
+    vm_reg[2] = map_vm_reg_reserved2(state, ir->rd, vm_reg[0], vm_reg[1]);
     emit_mov(state, vm_reg[1], temp_reg);
     emit_mov(state, vm_reg[0], vm_reg[2]);
     emit_alu32(state, 0x09, temp_reg, vm_reg[2]);
 })
 GEN(and, {
     ra_load2(state, ir->rs1, ir->rs2);
-    vm_reg[2] = map_vm_reg(state, ir->rd);
+    vm_reg[2] = map_vm_reg_reserved2(state, ir->rd, vm_reg[0], vm_reg[1]);
     emit_mov(state, vm_reg[1], temp_reg);
     emit_mov(state, vm_reg[0], vm_reg[2]);
     emit_alu32(state, 0x21, temp_reg, vm_reg[2]);
@@ -746,14 +746,14 @@ GEN(csrrci, { assert(NULL); })
 #if RV32_HAS(EXT_M)
 GEN(mul, {
     ra_load2(state, ir->rs1, ir->rs2);
-    vm_reg[2] = map_vm_reg(state, ir->rd);
+    vm_reg[2] = map_vm_reg_reserved2(state, ir->rd, vm_reg[0], vm_reg[1]);
     emit_mov(state, vm_reg[1], temp_reg);
     emit_mov(state, vm_reg[0], vm_reg[2]);
     muldivmod(state, 0x28, temp_reg, vm_reg[2], 0);
 })
 GEN(mulh, {
     ra_load2_sext(state, ir->rs1, ir->rs2, true, true);
-    vm_reg[2] = map_vm_reg(state, ir->rd);
+    vm_reg[2] = map_vm_reg_reserved2(state, ir->rd, vm_reg[0], vm_reg[1]);
     emit_mov(state, vm_reg[1], temp_reg);
     emit_mov(state, vm_reg[0], vm_reg[2]);
     muldivmod(state, 0x2f, temp_reg, vm_reg[2], 0);
@@ -761,7 +761,7 @@ GEN(mulh, {
 })
 GEN(mulhsu, {
     ra_load2_sext(state, ir->rs1, ir->rs2, true, false);
-    vm_reg[2] = map_vm_reg(state, ir->rd);
+    vm_reg[2] = map_vm_reg_reserved2(state, ir->rd, vm_reg[0], vm_reg[1]);
     emit_mov(state, vm_reg[1], temp_reg);
     emit_mov(state, vm_reg[0], vm_reg[2]);
     muldivmod(state, 0x2f, temp_reg, vm_reg[2], 0);
@@ -769,7 +769,7 @@ GEN(mulhsu, {
 })
 GEN(mulhu, {
     ra_load2(state, ir->rs1, ir->rs2);
-    vm_reg[2] = map_vm_reg(state, ir->rd);
+    vm_reg[2] = map_vm_reg_reserved2(state, ir->rd, vm_reg[0], vm_reg[1]);
     emit_mov(state, vm_reg[1], temp_reg);
     emit_mov(state, vm_reg[0], vm_reg[2]);
     muldivmod(state, 0x2f, temp_reg, vm_reg[2], 0);
@@ -777,28 +777,28 @@ GEN(mulhu, {
 })
 GEN(div, {
     ra_load2_sext(state, ir->rs1, ir->rs2, true, true);
-    vm_reg[2] = map_vm_reg(state, ir->rd);
+    vm_reg[2] = map_vm_reg_reserved2(state, ir->rd, vm_reg[0], vm_reg[1]);
     emit_mov(state, vm_reg[1], temp_reg);
     emit_mov(state, vm_reg[0], vm_reg[2]);
     muldivmod(state, 0x38, temp_reg, vm_reg[2], 1);
 })
 GEN(divu, {
     ra_load2(state, ir->rs1, ir->rs2);
-    vm_reg[2] = map_vm_reg(state, ir->rd);
+    vm_reg[2] = map_vm_reg_reserved2(state, ir->rd, vm_reg[0], vm_reg[1]);
     emit_mov(state, vm_reg[1], temp_reg);
     emit_mov(state, vm_reg[0], vm_reg[2]);
     muldivmod(state, 0x38, temp_reg, vm_reg[2], 0);
 })
 GEN(rem, {
     ra_load2_sext(state, ir->rs1, ir->rs2, true, true);
-    vm_reg[2] = map_vm_reg(state, ir->rd);
+    vm_reg[2] = map_vm_reg_reserved2(state, ir->rd, vm_reg[0], vm_reg[1]);
     emit_mov(state, vm_reg[1], temp_reg);
     emit_mov(state, vm_reg[0], vm_reg[2]);
     muldivmod(state, 0x98, temp_reg, vm_reg[2], 1);
 })
 GEN(remu, {
     ra_load2(state, ir->rs1, ir->rs2);
-    vm_reg[2] = map_vm_reg(state, ir->rd);
+    vm_reg[2] = map_vm_reg_reserved2(state, ir->rd, vm_reg[0], vm_reg[1]);
     emit_mov(state, vm_reg[1], temp_reg);
     emit_mov(state, vm_reg[0], vm_reg[2]);
     muldivmod(state, 0x98, temp_reg, vm_reg[2], 0);
@@ -848,7 +848,7 @@ GEN(fmvwx, { assert(NULL); })
 #if RV32_HAS(EXT_C)
 GEN(caddi4spn, {
     vm_reg[0] = ra_load(state, rv_reg_sp);
-    vm_reg[1] = map_vm_reg(state, ir->rd);
+    vm_reg[1] = map_vm_reg_reserved(state, ir->rd, vm_reg[0]);
     if (vm_reg[0] != vm_reg[1]) {
         emit_mov(state, vm_reg[0], vm_reg[1]);
     }
@@ -910,28 +910,28 @@ GEN(candi, {
 })
 GEN(csub, {
     ra_load2(state, ir->rs1, ir->rs2);
-    vm_reg[2] = map_vm_reg(state, ir->rd);
+    vm_reg[2] = map_vm_reg_reserved2(state, ir->rd, vm_reg[0], vm_reg[1]);
     emit_mov(state, vm_reg[1], temp_reg);
     emit_mov(state, vm_reg[0], vm_reg[2]);
     emit_alu32(state, 0x29, temp_reg, vm_reg[2]);
 })
 GEN(cxor, {
     ra_load2(state, ir->rs1, ir->rs2);
-    vm_reg[2] = map_vm_reg(state, ir->rd);
+    vm_reg[2] = map_vm_reg_reserved2(state, ir->rd, vm_reg[0], vm_reg[1]);
     emit_mov(state, vm_reg[1], temp_reg);
     emit_mov(state, vm_reg[0], vm_reg[2]);
     emit_alu32(state, 0x31, temp_reg, vm_reg[2]);
 })
 GEN(cor, {
     ra_load2(state, ir->rs1, ir->rs2);
-    vm_reg[2] = map_vm_reg(state, ir->rd);
+    vm_reg[2] = map_vm_reg_reserved2(state, ir->rd, vm_reg[0], vm_reg[1]);
     emit_mov(state, vm_reg[1], temp_reg);
     emit_mov(state, vm_reg[0], vm_reg[2]);
     emit_alu32(state, 0x09, temp_reg, vm_reg[2]);
 })
 GEN(cand, {
     ra_load2(state, ir->rs1, ir->rs2);
-    vm_reg[2] = map_vm_reg(state, ir->rd);
+    vm_reg[2] = map_vm_reg_reserved2(state, ir->rd, vm_reg[0], vm_reg[1]);
     emit_mov(state, vm_reg[1], temp_reg);
     emit_mov(state, vm_reg[0], vm_reg[2]);
     emit_alu32(state, 0x21, temp_reg, vm_reg[2]);
@@ -1005,7 +1005,7 @@ GEN(cjr, {
 })
 GEN(cmv, {
     vm_reg[0] = ra_load(state, ir->rs2);
-    vm_reg[1] = map_vm_reg(state, ir->rd);
+    vm_reg[1] = map_vm_reg_reserved(state, ir->rd, vm_reg[0]);
     if (vm_reg[0] != vm_reg[1]) {
         emit_mov(state, vm_reg[0], vm_reg[1]);
     } else {
@@ -1031,7 +1031,7 @@ GEN(cjalr, {
 })
 GEN(cadd, {
     ra_load2(state, ir->rs1, ir->rs2);
-    vm_reg[2] = map_vm_reg(state, ir->rd);
+    vm_reg[2] = map_vm_reg_reserved2(state, ir->rd, vm_reg[0], vm_reg[1]);
     emit_mov(state, vm_reg[1], temp_reg);
     emit_mov(state, vm_reg[0], vm_reg[2]);
     emit_alu32(state, 0x01, temp_reg, vm_reg[2]);

--- a/src/t2c_template.c
+++ b/src/t2c_template.c
@@ -97,6 +97,11 @@ FORCE_INLINE void t2c_jit_cache_helper(LLVMBuilderRef *builder,
 
     LLVMBuildCondBr(*builder, cmp, true_path, false_path);
 
+    /* Acquire fence to ensure we see the entry written by jit_cache_update.
+     * This pairs with the release fence in jit_cache_update().
+     */
+    LLVMBuildFence(true_builder, LLVMAtomicOrderingAcquire, false, "");
+
     /* get jit_cache_t::entry */
     LLVMValueRef entry_ptr = LLVMBuildStructGEP2(
         true_builder, t2c_jit_cache_struct_type, element_ptr, 1, "");

--- a/tests/arch-test-target/constants.py
+++ b/tests/arch-test-target/constants.py
@@ -25,8 +25,12 @@ ispec={3}/{2}_isa.yaml
 pspec={3}/{2}_platform.yaml
 path={4}/build
 target_run=1
+jobs=3
+timeout=600
 
 [{0}]
 pluginpath={1}
 path={1}
+jobs=3
+timeout=900
 """

--- a/tests/arch-test-target/rv32emu/riscof_rv32emu.py
+++ b/tests/arch-test-target/rv32emu/riscof_rv32emu.py
@@ -44,6 +44,9 @@ class rv32emu(pluginTemplate):
         # parallel on the DUT executable. Can also be used in the build function if required.
         self.num_jobs = str(config["jobs"] if "jobs" in config else 1)
 
+        # Timeout in seconds for the make command execution
+        self.timeout = int(config["timeout"]) if "timeout" in config else 300
+
         # Path to the directory where this python file is located. Collect it from the config.ini
         self.pluginpath = os.path.abspath(config["pluginpath"])
 
@@ -178,7 +181,7 @@ class rv32emu(pluginTemplate):
 
         # once the make-targets are done and the makefile has been created, run all the targets in
         # parallel using the make command set above.
-        make.execute_all(self.work_dir)
+        make.execute_all(self.work_dir, self.timeout)
 
         # if target runs are not required then we simply exit as this point after running all
         # the makefile targets.

--- a/tests/arch-test-target/sail_cSim/riscof_sail_cSim.py
+++ b/tests/arch-test-target/sail_cSim/riscof_sail_cSim.py
@@ -28,6 +28,7 @@ class sail_cSim(pluginTemplate):
             logger.error("Config node for sail_cSim missing.")
             raise SystemExit(1)
         self.num_jobs = str(config["jobs"] if "jobs" in config else 1)
+        self.timeout = int(config["timeout"]) if "timeout" in config else 300
         self.pluginpath = os.path.abspath(config["pluginpath"])
         self.sail_exe = {
             "32": os.path.join(
@@ -181,4 +182,4 @@ class sail_cSim(pluginTemplate):
             execute += coverage_cmd
 
             make.add_target(execute)
-        make.execute_all(self.work_dir)
+        make.execute_all(self.work_dir, self.timeout)


### PR DESCRIPTION
## Summary

Fix JIT non-deterministic execution and CI timeout issues on ARM64 (Apple Silicon).

## Commits

### 1. Fix JIT non-determinism issues on Arm64

Addresses cache coherency, instruction encoding, and register allocation issues that caused non-deterministic execution failures on Apple Silicon.

**Root causes identified and fixed:**

| Issue | Root Cause | Fix |
|-------|------------|-----|
| Cache coherency | Rapid toggling of `pthread_jit_write_protect_np` | Thread-local write mode batching |
| T2C stale instructions | Missing ISB barrier in tier-2 JIT path | Add ISB before T2C execution |
| Sign extension loss | `emit_mov` used 32-bit ADD (zero-extends) | Use 64-bit ORR (preserves all bits) |
| Intermittent hangs | R18 platform register used in JIT | Exclude R18 from register allocation |
| Wrong signed division | UDIV used for signed operations | Use SDIV for signed div/rem |

**Additional fixes:**
- Add `emit_sxtw` helper for explicit sign extension
- Add `map_vm_reg_reserved2` to protect two registers during allocation
- Fix `ra_load2_sext` to sign-extend reused registers
- Add acquire barrier for T2C compiled code visibility
- Final DSB/ISB barriers after branch patching

**Troubleshooting notes for Apple Silicon JIT:**
- `pthread_jit_write_protect_np` is per-thread; shared flags cause races
- Cache invalidation must complete before re-enabling write protection
- `sys_icache_invalidate` includes required DSB/ISB on macOS
- ISB barriers needed before ALL JIT execution paths, not just tier-1
- Platform registers vary by OS: R18 reserved on Apple/Windows

### 2. Fix RISCOF timeout for arch-tests on macOS/Arm64

The SAIL reference model was timing out after 300 seconds when running >1000 tests sequentially.

**Changes:**
- Add configurable timeout parameter to SAIL and rv32emu plugins
- Set `jobs=3` for parallel test execution
- Set `timeout=900s` for SAIL (slower reference model)
- Set `timeout=600s` for rv32emu (faster DUT)

## Test Results

After all fixes:
- Sequential execution: 500/500 pass (100%)
- Parallel execution (8 workers): 200/200 pass (100%)
- All `make check` tests pass consistently