### PR TITLE
Fix emcc build inheriting stale SYSTEM config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,6 +151,7 @@ jobs:
     - name: default build using emcc
       if: success()
       run: |
+            make distclean
             make CC=emcc ENABLE_JIT=0 $PARALLEL
 
     - name: default build for system emulation using emcc
@@ -475,6 +476,7 @@ jobs:
      - name: default build using emcc
        if: success()
        run: |
+             make distclean
              make CC=emcc ENABLE_JIT=0 $PARALLEL
 
      - name: default build for system emulation using emcc


### PR DESCRIPTION
The emcc build without ENABLE_SYSTEM was failing because it inherited a stale .config file from the previous 'make ENABLE_SYSTEM=1 artifact' step. This caused the build to attempt creating minimal.dtb even though SYSTEM mode was not explicitly enabled.

The fix adds 'make distclean' before the emcc build without SYSTEM to ensure a clean configuration state. This mirrors the pattern already used for the SYSTEM emulation build.

Root cause: The .config file persists across make invocations, and 'make ENABLE_SYSTEM=1 artifact' sets SYSTEM=1 in the config. Without distclean, subsequent builds read this stale config.