### PR TITLE
Restore wall-clock time source for user mode

### DIFF
--- a/src/emulate.c
+++ b/src/emulate.c
@@ -102,6 +102,12 @@ static inline void check_tohost_write(riscv_t *rv,
 #if RV32_HAS(Zicsr)
 static inline void update_time(riscv_t *rv)
 {
+#if !RV32_HAS(SYSTEM)
+    struct timeval tv;
+
+    rv_gettimeofday(&tv);
+    rv->timer = (uint64_t) tv.tv_sec * 1e6 + (uint32_t) tv.tv_usec;
+#endif
     rv->csr_time[0] = rv->timer & 0xFFFFFFFF;
     rv->csr_time[1] = rv->timer >> 32;
 }


### PR DESCRIPTION
Commit a6ecb0c ("Bring up Linux kernel") refactored the time update mechanism to use a static cycle counter. However, that counter only increments when the SYSTEM feature is enabled.

In user mode, the counter remains at zero, causing the timer CSRs to freeze. This regression breaks time-dependent applications, such as nyancat, resulting in a static image.

Restore the use of gettimeofday for non-SYSTEM builds to ensure the timer reflects actual time passage.

Fixes: a6ecb0c ("Bring up Linux kernel")
Closes: https://github.com/sysprog21/rv32emu/issues/640



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore wall-clock time in user mode by using gettimeofday when SYSTEM is disabled. Fixes frozen timer CSRs so time-dependent apps (like nyancat) run correctly.

<sup>Written for commit f04d93a53e8abf0ef23f4a00c5cf5cff6efbfc75. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



