### PR TITLE
CI: Consolidate artifact fetch with retry logic

### DIFF
--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -208,3 +208,118 @@ check_url()
             ;;
     esac
 }
+
+# Fetch latest release tag from rv32emu-prebuilt repository
+# Usage: fetch_latest_release <artifact_type> [max_retries]
+# Arguments:
+#   artifact_type: One of "ELF", "Linux-Image", or "sail"
+#   max_retries: Maximum retry attempts (default: 3, must be >= 1)
+# Environment:
+#   GH_TOKEN: GitHub token for authenticated API access (optional but recommended)
+# Returns: Prints the release tag to stdout, exits with error if not found
+fetch_latest_release()
+{
+    local artifact_type="$1"
+    local max_retries="${2:-3}"
+    local api_url="https://api.github.com/repos/sysprog21/rv32emu-prebuilt/releases"
+    local release_tag
+    local api_response
+    local download_status
+    local attempt
+
+    # Validate artifact type
+    case "$artifact_type" in
+        ELF | Linux-Image | sail) ;;
+        *)
+            print_error "Invalid artifact type: $artifact_type (expected: ELF, Linux-Image, or sail)" >&2
+            return 1
+            ;;
+    esac
+
+    # Validate max_retries is a positive integer
+    if ! [[ "$max_retries" =~ ^[1-9][0-9]*$ ]]; then
+        print_warning "Invalid max_retries '$max_retries', using default (3)" >&2
+        max_retries=3
+    fi
+
+    # Use C-style loop (Bash builtin) instead of 'seq' for portability
+    for ((attempt = 1; attempt <= max_retries; attempt++)); do
+        # Fetch releases with optional authentication
+        # Capture stdout only; let stderr pass through to console for debugging
+        if [ -n "${GH_TOKEN:-}" ]; then
+            api_response=$(download_with_headers "$api_url" "Authorization: Bearer ${GH_TOKEN}") || download_status=$?
+        else
+            api_response=$(download_to_stdout "$api_url") || download_status=$?
+        fi
+
+        if [ -n "${download_status:-}" ] && [ "$download_status" -ne 0 ]; then
+            print_warning "API request failed (exit code: $download_status)" >&2
+            unset download_status
+        else
+            # Parse release tag from response (handle empty grep gracefully)
+            release_tag=$(
+                set +o pipefail
+                echo "$api_response" \
+                    | grep '"tag_name"' \
+                    | grep "$artifact_type" \
+                    | head -n 1 \
+                    | sed -E 's/.*"tag_name": "([^"]+)".*/\1/'
+            )
+
+            if [ -n "$release_tag" ]; then
+                echo "$release_tag"
+                return 0
+            fi
+        fi
+
+        if [ "$attempt" -lt "$max_retries" ]; then
+            print_warning "Attempt $attempt/$max_retries failed for $artifact_type, retrying in 5s..." >&2
+            sleep 5
+        fi
+    done
+
+    print_error "Failed to fetch $artifact_type release tag after $max_retries attempts" >&2
+    return 1
+}
+
+# Fetch and build artifact with automatic release tag resolution
+# Usage: fetch_artifact <artifact_type> [make_options...]
+# Arguments:
+#   artifact_type: One of "ELF", "Linux-Image", or "sail"
+#   make_options: Additional options to pass to make (e.g., ENABLE_SYSTEM=1)
+# Environment:
+#   GH_TOKEN: GitHub token for authenticated API access (optional but recommended)
+#   FETCH_ARTIFACT_RETRIES: Max retries for make artifact (default: 2, must be >= 1)
+fetch_artifact()
+{
+    local artifact_type="$1"
+    shift
+    local make_opts=("$@")
+    local release_tag
+    local max_retries="${FETCH_ARTIFACT_RETRIES:-2}"
+    local attempt
+
+    # Validate max_retries is a positive integer
+    if ! [[ "$max_retries" =~ ^[1-9][0-9]*$ ]]; then
+        print_warning "Invalid FETCH_ARTIFACT_RETRIES '$max_retries', using default (2)" >&2
+        max_retries=2
+    fi
+
+    release_tag=$(fetch_latest_release "$artifact_type") || return 1
+
+    # Use C-style loop (Bash builtin) instead of 'seq' for portability
+    for ((attempt = 1; attempt <= max_retries; attempt++)); do
+        echo "Fetching $artifact_type artifact (release: $release_tag, attempt $attempt/$max_retries)..." >&2
+        if make LATEST_RELEASE="$release_tag" "${make_opts[@]}" artifact; then
+            return 0
+        fi
+
+        if [ "$attempt" -lt "$max_retries" ]; then
+            print_warning "make artifact failed for $artifact_type, retrying in 10s..." >&2
+            sleep 10
+        fi
+    done
+
+    print_error "Failed to fetch $artifact_type artifact after $max_retries attempts" >&2
+    return 1
+}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,10 +140,13 @@ jobs:
     - name: Fetch artifacts
       env:
         CC: ${{ steps.install_cc.outputs.cc }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-            make artifact
-            make ENABLE_SYSTEM=1 artifact
-            make ENABLE_ARCH_TEST=1 artifact
+            . .ci/common.sh
+            fetch_artifact ELF
+            fetch_artifact Linux-Image ENABLE_SYSTEM=1
+            rm -f build/.config  # Clean config after ENABLE_SYSTEM=1 to prevent contamination
+            fetch_artifact sail ENABLE_ARCH_TEST=1
             # get from rv32emu-prebuilt
             .ci/fetch.sh -o build/shareware_doom_iwad.zip "https://raw.githubusercontent.com/sysprog21/rv32emu-prebuilt/doom-artifact/shareware_doom_iwad.zip"
             unzip -o -d build/ build/shareware_doom_iwad.zip
@@ -263,6 +266,8 @@ jobs:
     - name: undefined behavior test
       if: success() || failure()
       run: |
+            # Clear cached config from previous steps to avoid ENABLE_SYSTEM=1 contamination
+            rm -f build/.config
             make distclean && make ENABLE_UBSAN=1 check $PARALLEL
             make ENABLE_JIT=1 clean && make ENABLE_JIT=1 ENABLE_UBSAN=1 check $PARALLEL
 
@@ -463,27 +468,10 @@ jobs:
          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        run: |
              . .ci/common.sh
-             LATEST_RELEASE=$(download_with_headers "https://api.github.com/repos/sysprog21/rv32emu-prebuilt/releases" \
-                                                    "Authorization: Bearer ${GH_TOKEN}" \
-                                     | grep '"tag_name"' \
-                                     | grep "ELF" \
-                                     | head -n 1 \
-                                     | sed -E 's/.*"tag_name": "([^"]+)".*/\1/')
-             make LATEST_RELEASE=$LATEST_RELEASE artifact
-             LATEST_RELEASE=$(download_with_headers "https://api.github.com/repos/sysprog21/rv32emu-prebuilt/releases" \
-                                                    "Authorization: Bearer ${GH_TOKEN}" \
-                                     | grep '"tag_name"' \
-                                     | grep "Linux-Image" \
-                                     | head -n 1 \
-                                     | sed -E 's/.*"tag_name": "([^"]+)".*/\1/')
-             make LATEST_RELEASE=$LATEST_RELEASE ENABLE_SYSTEM=1 artifact
-             LATEST_RELEASE=$(download_with_headers "https://api.github.com/repos/sysprog21/rv32emu-prebuilt/releases" \
-                                                    "Authorization: Bearer ${GH_TOKEN}" \
-                                     | grep '"tag_name"' \
-                                     | grep "sail" \
-                                     | head -n 1 \
-                                     | sed -E 's/.*"tag_name": "([^"]+)".*/\1/')
-             make LATEST_RELEASE=$LATEST_RELEASE ENABLE_ARCH_TEST=1 artifact
+             fetch_artifact ELF
+             fetch_artifact Linux-Image ENABLE_SYSTEM=1
+             rm -f build/.config  # Clean config after ENABLE_SYSTEM=1 to prevent contamination
+             fetch_artifact sail ENABLE_ARCH_TEST=1
              # get from rv32emu-prebuilt
              .ci/fetch.sh -o build/shareware_doom_iwad.zip "https://raw.githubusercontent.com/sysprog21/rv32emu-prebuilt/doom-artifact/shareware_doom_iwad.zip"
              unzip -o -d build/ build/shareware_doom_iwad.zip
@@ -561,6 +549,8 @@ jobs:
        env:
          CC: ${{ steps.install_cc.outputs.cc }}
        run: |
+             # Clear cached config from previous steps to avoid ENABLE_SYSTEM=1 contamination
+             rm -f build/.config
              make distclean && make ENABLE_UBSAN=1 check $PARALLEL
              make ENABLE_JIT=1 clean && make ENABLE_JIT=1 ENABLE_UBSAN=1 check $PARALLEL
 


### PR DESCRIPTION
This add reusable functions for fetching prebuilt artifacts from rv32emu-prebuilt repository:
- fetch_latest_release(): Fetches release tag with retry support
  * Validates artifact type (ELF, Linux-Image, sail)
  * Uses GH_TOKEN for authenticated API access when available
  * Configurable retry count (default: 3 attempts, 5s delay)
  * Input validation with fallback to defaults
- fetch_artifact(): Fetches and builds artifact with retry
  * Wraps fetch_latest_release + make artifact
  * Configurable via FETCH_ARTIFACT_RETRIES env var



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated CI artifact fetching into reusable functions with retry logic to improve reliability and remove duplicated GitHub API calls. Also fixed config contamination by clearing build/.config between artifact builds.

- **Refactors**
  - Added fetch_latest_release and fetch_artifact in .ci/common.sh (type validation, optional GH_TOKEN, retries, FETCH_ARTIFACT_RETRIES).
  - Replaced inline release lookups in workflows with these helpers for ELF, Linux-Image, and sail.
  - Removed unnecessary LATEST_RELEASE fetching in sanitizer jobs; they run on cached artifacts, and we clear build/.config before tests to avoid ENABLE_SYSTEM=1 leakage.

<sup>Written for commit fc8f5d920fdc591b8525b08fc7ea1c4ff957efa8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



