### PR TITLE
CI: Reduce optimization level matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -170,7 +170,8 @@ jobs:
         CC: ${{ steps.install_cc.outputs.cc }}
       run: |
             set -euo pipefail
-            for opt_level in -g -Og -O0 -O1 -O2 -O3 -Ofast; do
+            # Test boundary cases: -O0 (unoptimized), -O2 (standard), -Ofast (aggressive)
+            for opt_level in -O0 -O2 -Ofast; do
               echo "Building with OPT_LEVEL=$opt_level"
               if ! (make distclean && make OPT_LEVEL=$opt_level $PARALLEL); then
                 echo "ERROR: Build failed with OPT_LEVEL=$opt_level"
@@ -184,7 +185,8 @@ jobs:
         CC: ${{ steps.install_cc.outputs.cc }}
       run: |
             set -euo pipefail
-            for opt_level in -g -Og -O0 -O1 -O2 -O3 -Ofast; do
+            # Test boundary cases: -O0 (unoptimized), -O2 (standard), -Ofast (aggressive)
+            for opt_level in -O0 -O2 -Ofast; do
               echo "Building system emulation with OPT_LEVEL=$opt_level"
               if ! (make distclean && make OPT_LEVEL=$opt_level ENABLE_SYSTEM=1 $PARALLEL); then
                 echo "ERROR: System emulation build failed with OPT_LEVEL=$opt_level"


### PR DESCRIPTION
This reduces build time by testing only boundary cases instead of all 7 optimization levels:
- `-O0`: Unoptimized (catches uninitialized variable issues)
- `-O2`: Standard optimization (common production setting)
- `-Ofast`: Aggressive optimization (catches strict aliasing issues)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts CI build time by building only at -O0, -O2, and -Ofast instead of all seven levels. Preserves coverage for uninitialized issues, typical production behavior, and strict aliasing edge cases.

- **Refactors**
  - Update main.yml to loop over -O0, -O2, -Ofast for both normal and system emulation builds.
  - Add inline comments documenting the rationale for each selected optimization level.

<sup>Written for commit b2e8134131e18ffc20f20505e6b808324ff47d88. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

