### PR TITLE
CI: Parallelize architecture tests

### DIFF
--- a/.ci/riscv-tests.sh
+++ b/.ci/riscv-tests.sh
@@ -21,9 +21,46 @@ make distclean
 # much smaller memory mapping regions.
 make ENABLE_ARCH_TEST=1 ENABLE_EXT_M=1 ENABLE_EXT_A=1 ENABLE_EXT_F=1 ENABLE_EXT_C=1 \
     ENABLE_Zicsr=1 ENABLE_Zifencei=1 ENABLE_FULL4G=1 $PARALLEL
-make arch-test RISCV_DEVICE=IMAFCZicsrZifencei hw_data_misaligned_support=1 $PARALLEL || exit 1
-make arch-test RISCV_DEVICE=FCZicsr hw_data_misaligned_support=1 $PARALLEL || exit 1
-make arch-test RISCV_DEVICE=IMZbaZbbZbcZbs hw_data_misaligned_support=1 $PARALLEL || exit 1
+
+# Pre-fetch shared resources before parallel execution to avoid race conditions
+make ENABLE_ARCH_TEST=1 artifact
+make riscof-check
+git submodule update --init tests/riscv-arch-test/
+
+# Determine host platform for sail binary (matches mk/common.mk logic)
+case "$(uname -m)" in
+    x86_64) HOST_PLATFORM=x86 ;;
+    aarch64) HOST_PLATFORM=aarch64 ;;
+    arm64) HOST_PLATFORM=arm64 ;;
+    *)
+        print_error "Unsupported platform: $(uname -m)"
+        exit 1
+        ;;
+esac
+cp "build/rv32emu-prebuilt-sail-${HOST_PLATFORM}" tests/arch-test-target/sail_cSim/riscv_sim_RV32
+chmod +x tests/arch-test-target/sail_cSim/riscv_sim_RV32
+
+# Run architecture tests in parallel (each uses device-specific work directory and config)
+arch_test_pids=()
+arch_test_devices=("IMAFCZicsrZifencei" "FCZicsr" "IMZbaZbbZbcZbs")
+
+for device in "${arch_test_devices[@]}"; do
+    make ENABLE_ARCH_TEST=1 arch-test RISCV_DEVICE="$device" hw_data_misaligned_support=1 SKIP_PREREQ=1 $PARALLEL &
+    arch_test_pids+=($!)
+done
+
+# Wait for all parallel arch-tests and check results
+arch_test_failed=0
+for i in "${!arch_test_pids[@]}"; do
+    if ! wait "${arch_test_pids[$i]}"; then
+        print_error "arch-test failed for device: ${arch_test_devices[$i]}"
+        arch_test_failed=1
+    fi
+done
+
+if [ "$arch_test_failed" -ne 0 ]; then
+    exit 1
+fi
 
 # Rebuild with RV32E
 make distclean

--- a/Makefile
+++ b/Makefile
@@ -397,6 +397,9 @@ $(BIN): $(OBJS) $(DEV_OBJS) | $(OUT)
 	$(VECHO) "  LD\t$@\n"
 	$(Q)$(CC) -o $@ $(CFLAGS_emcc) $^ $(LDFLAGS)
 
+# Skip config file rebuild when SKIP_PREREQ=1 to avoid race conditions in parallel make.
+# The config file is only needed for building $(BIN), not for arch-test with SKIP_PREREQ=1.
+ifneq ($(SKIP_PREREQ),1)
 $(CONFIG_FILE): FORCE
 	$(Q)mkdir -p $(OUT)
 	$(Q)echo "$(CFLAGS)" | xargs -n1 | sort | sed -n 's/^RV32_FEATURE/ENABLE/p' > $@.tmp
@@ -406,6 +409,7 @@ $(CONFIG_FILE): FORCE
 	else \
 		$(RM) $@.tmp; \
 	fi
+endif
 
 .PHONY: FORCE config
 FORCE:

--- a/mk/riscv-arch-test.mk
+++ b/mk/riscv-arch-test.mk
@@ -8,23 +8,47 @@ ARCH_TEST_DIR ?= tests/riscv-arch-test
 ARCH_TEST_SUITE ?= $(ARCH_TEST_DIR)/riscv-test-suite
 export RISCV_TARGET := tests/arch-test-target
 export TARGETDIR := $(shell pwd)
-export WORK := $(TARGETDIR)/build/arch-test
 export RISCV_DEVICE ?= IMACFZicsrZifencei
+# Use device-specific work directory to enable parallel arch-test execution
+export WORK := $(TARGETDIR)/build/arch-test-$(RISCV_DEVICE)
+
+# SKIP_PREREQ=1 skips artifact/git/copy steps (used when pre-fetched for parallel execution)
+SKIP_PREREQ ?= 0
 
 ifeq ($(RISCV_DEVICE),FCZicsr)
 ARCH_TEST_SUITE := tests/rv32fc-test-suite
 endif
 
-arch-test: riscof-check $(BIN) artifact
+# Dependencies for arch-test (skipped when SKIP_PREREQ=1 for parallel execution)
+# When SKIP_PREREQ=1, we don't depend on $(BIN) to avoid race conditions in parallel make.
+# The binary must already be built - we verify it exists in the recipe.
+ifeq ($(SKIP_PREREQ),1)
+ARCH_TEST_DEPS := riscof-check
+else
+ARCH_TEST_DEPS := riscof-check $(BIN) artifact
+endif
+
+arch-test: $(ARCH_TEST_DEPS)
 ifeq ($(CROSS_COMPILE),)
 	$(error GNU Toolchain for RISC-V is required to build architecture tests. Please check package installation)
 endif
+ifeq ($(SKIP_PREREQ),1)
+	$(Q)test -x $(BIN) || \
+		{ echo "Error: SKIP_PREREQ=1 requires pre-built binary. Run 'make' first."; exit 1; }
+	$(Q)test -x tests/arch-test-target/sail_cSim/riscv_sim_RV32 || \
+		{ echo "Error: SKIP_PREREQ=1 requires pre-fetched sail binary. Run 'make artifact' first."; exit 1; }
+	$(Q)test -d $(ARCH_TEST_DIR) || \
+		{ echo "Error: SKIP_PREREQ=1 requires submodule. Run 'git submodule update --init tests/riscv-arch-test/' first."; exit 1; }
+else
 	git submodule update --init $(dir $(ARCH_TEST_DIR))
 	$(Q)cp $(OUT)/rv32emu-prebuilt-sail-$(HOST_PLATFORM) tests/arch-test-target/sail_cSim/riscv_sim_RV32
 	$(Q)chmod +x tests/arch-test-target/sail_cSim/riscv_sim_RV32
-	$(Q)python3 -B $(RISCV_TARGET)/setup.py --riscv_device=$(RISCV_DEVICE) --hw_data_misaligned_support=$(hw_data_misaligned_support)
-	$(Q)riscof run --work-dir=$(WORK) \
-			--config=$(RISCV_TARGET)/config.ini \
+endif
+	$(Q)python3 -B $(RISCV_TARGET)/setup.py --riscv_device=$(RISCV_DEVICE) --hw_data_misaligned_support=$(hw_data_misaligned_support) --work_dir=$(WORK)
+	$(Q)grep -q '^\[RISCOF\]' $(WORK)/config.ini || \
+		{ echo "Error: config.ini missing RISCOF section. Contents:"; cat $(WORK)/config.ini; exit 1; }
+	$(Q)riscof run --no-clean --work-dir=$(WORK) \
+			--config=$(WORK)/config.ini \
 			--suite=$(ARCH_TEST_SUITE) \
 			--env=$(ARCH_TEST_DIR)/riscv-test-suite/env
 

--- a/tests/arch-test-target/constants.py
+++ b/tests/arch-test-target/constants.py
@@ -34,3 +34,27 @@ path={1}
 jobs=3
 timeout=900
 """
+
+# Template with explicit ispec path and isolated DUT path for parallel execution
+# {5} = ispec_path, {6} = dut_path (device-specific work directory)
+config_temp_with_ispec = """[RISCOF]
+ReferencePlugin={0}
+ReferencePluginPath={1}
+DUTPlugin={2}
+DUTPluginPath={3}
+
+[{2}]
+pluginpath={3}
+ispec={5}
+pspec={3}/{2}_platform.yaml
+path={6}
+target_run=1
+jobs=3
+timeout=600
+
+[{0}]
+pluginpath={1}
+path={1}
+jobs=3
+timeout=900
+"""

--- a/tests/arch-test-target/setup.py
+++ b/tests/arch-test-target/setup.py
@@ -1,12 +1,21 @@
 import constants
 import argparse
 import ruamel.yaml
+import os
 
 
 # setup the ISA config file
-def setup_testlist(riscv_device, hw_data_misaligned_support):
-    # ISA config file path
-    ispec = constants.root + "/rv32emu/rv32emu_isa.yaml"
+def setup_testlist(riscv_device, hw_data_misaligned_support, work_dir=None):
+    # ISA config file path - use work_dir if provided for parallel execution
+    if work_dir:
+        os.makedirs(work_dir, exist_ok=True)
+        ispec = os.path.join(work_dir, "rv32emu_isa.yaml")
+    else:
+        ispec = constants.root + "/rv32emu/rv32emu_isa.yaml"
+
+    # Read from the template in source tree
+    ispec_template = constants.root + "/rv32emu/rv32emu_isa.yaml"
+
     misa = 0x40000000
     ISA = "RV32"
 
@@ -44,7 +53,7 @@ def setup_testlist(riscv_device, hw_data_misaligned_support):
     if "Zifencei" in riscv_device:
         ISA += "_Zifencei" if "Z" in ISA else "Zifencei"
 
-    with open(ispec, "r") as file:
+    with open(ispec_template, "r") as file:
         try:
             file = ruamel.yaml.YAML(typ="safe", pure=True).load(file)
         except ruamel.yaml.YAMLError as msg:
@@ -59,23 +68,65 @@ def setup_testlist(riscv_device, hw_data_misaligned_support):
 
     with open(ispec, "w+") as outfile:
         ruamel.yaml.YAML(typ="unsafe", pure=True).dump(file, outfile)
+        outfile.flush()
+        os.fsync(outfile.fileno())
+
+    return ispec
 
 
 # setup the riscof config file
-def setup_config():
+def setup_config(work_dir=None, ispec_path=None):
     cwd = constants.cwd
     root = constants.root
     refname = constants.refname
     dutname = constants.dutname
 
-    # create config file
-    configfile = open(root + "/config.ini", "w")
-    configfile.write(
-        constants.config_temp.format(
+    # Use work_dir if provided for parallel execution
+    if work_dir:
+        config_path = os.path.join(work_dir, "config.ini")
+    else:
+        config_path = root + "/config.ini"
+
+    # path always points to where rv32emu binary is located (cwd/build)
+    # This is used by riscof_rv32emu.py to find the executable
+    dut_path = cwd + "/build"
+
+    # create config file with device-specific ISA spec path
+    # Use explicit fsync to ensure file is written before riscof reads it
+    if ispec_path and work_dir:
+        # Use custom config template with explicit ispec path and isolated DUT path
+        config_content = constants.config_temp_with_ispec.format(
+            refname,
+            root + "/" + refname,
+            dutname,
+            root + "/" + dutname,
+            cwd,
+            ispec_path,
+            dut_path,
+        )
+    else:
+        config_content = constants.config_temp.format(
             refname, root + "/" + refname, dutname, root + "/" + dutname, cwd
         )
-    )
-    configfile.close()
+    with open(config_path, "w") as configfile:
+        configfile.write(config_content)
+        configfile.flush()
+        os.fsync(configfile.fileno())
+
+    # Verify the config file was written correctly
+    if not os.path.exists(config_path):
+        raise RuntimeError(f"Config file not created: {config_path}")
+
+    with open(config_path, "r") as verify_file:
+        content = verify_file.read()
+        if "[RISCOF]" not in content:
+            raise RuntimeError(
+                f"Config file missing [RISCOF] section after write.\n"
+                f"Path: {config_path}\n"
+                f"Content ({len(content)} bytes):\n{content[:500]}"
+            )
+
+    return config_path
 
 
 if __name__ == "__main__":
@@ -88,7 +139,14 @@ if __name__ == "__main__":
         help="whether the hardware data misalgnment is implemented or not",
         default="1",
     )
+    parser.add_argument(
+        "--work_dir",
+        help="work directory for device-specific config files (enables parallel execution)",
+        default=None,
+    )
     args = parser.parse_args()
 
-    setup_testlist(args.riscv_device, args.hw_data_misaligned_support)
-    setup_config()
+    ispec_path = setup_testlist(
+        args.riscv_device, args.hw_data_misaligned_support, args.work_dir
+    )
+    setup_config(args.work_dir, ispec_path if args.work_dir else None)


### PR DESCRIPTION
This runs the first three arch-test configurations in parallel instead of sequentially.
- Use device-specific work directories: build/arch-test-$(RISCV_DEVICE)
- Generate isolated config.ini and rv32emu_isa.yaml per device
- Pre-fetch shared resources (artifact, submodule, sail binary) before parallel execution to avoid race conditions
- Add SKIP_PREREQ flag to skip redundant setup in parallel jobs
- Add safety checks when SKIP_PREREQ=1 to fail fast with clear errors





























<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parallelized the first three RISC-V architecture test configs in CI to cut runtime and avoid race conditions using device-specific work dirs and per-device configs.

- **New Features**
  - Run these configs in parallel: IMAFCZicsrZifencei, FCZicsr, IMZbaZbbZbcZbs.
  - Use build/arch-test-$(RISCV_DEVICE) with isolated config.ini and rv32emu_isa.yaml; set explicit ispec/DUT paths, add fsync + read-back checks, and use riscof --no-clean to preserve per-device work dirs.
  - Pre-fetch artifact, riscv-arch-test submodule, and Sail binary (with host platform detection) before parallel jobs.
  - Add SKIP_PREREQ to skip redundant setup and config rebuild; include safety checks to fail fast if prerequisites or config are missing.

<sup>Written for commit 6a88bbd70b2bf2c710c080b59685d3b092bb3ffb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





























