### PR TITLE
Implement demand paging for automatic memory management

### DIFF
--- a/.ci/riscv-tests.sh
+++ b/.ci/riscv-tests.sh
@@ -15,12 +15,8 @@ export PATH=$(pwd)/toolchain/bin:$PATH
 
 make distclean
 # Rebuild with all RISC-V extensions
-# FIXME: To pass the RISC-V Architecture Tests, full access to 4 GiB is
-# necessary. We need to investigate why full 4 GiB memory access is required
-# for this purpose, although the emulator can run all selected benchmarks with
-# much smaller memory mapping regions.
 make ENABLE_ARCH_TEST=1 ENABLE_EXT_M=1 ENABLE_EXT_A=1 ENABLE_EXT_F=1 ENABLE_EXT_C=1 \
-    ENABLE_Zicsr=1 ENABLE_Zifencei=1 ENABLE_FULL4G=1 $PARALLEL
+    ENABLE_Zicsr=1 ENABLE_Zifencei=1 $PARALLEL
 
 # Pre-fetch shared resources before parallel execution to avoid race conditions
 make ENABLE_ARCH_TEST=1 artifact
@@ -64,7 +60,7 @@ fi
 
 # Rebuild with RV32E
 make distclean
-make ENABLE_ARCH_TEST=1 ENABLE_RV32E=1 ENABLE_FULL4G=1 $PARALLEL
+make ENABLE_ARCH_TEST=1 ENABLE_RV32E=1 $PARALLEL
 make arch-test RISCV_DEVICE=E $PARALLEL || exit 1
 
 # Rebuild with JIT
@@ -73,5 +69,5 @@ make arch-test RISCV_DEVICE=E $PARALLEL || exit 1
 make distclean
 make ENABLE_ARCH_TEST=1 ENABLE_JIT=1 ENABLE_T2C=0 \
     ENABLE_EXT_M=1 ENABLE_EXT_A=1 ENABLE_EXT_F=1 ENABLE_EXT_C=1 \
-    ENABLE_Zicsr=1 ENABLE_Zifencei=1 ENABLE_FULL4G=1 $PARALLEL
+    ENABLE_Zicsr=1 ENABLE_Zifencei=1 $PARALLEL
 make arch-test RISCV_DEVICE=IMC hw_data_misaligned_support=0 $PARALLEL || exit 1

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,9 @@ CFLAGS += -DMEM_SIZE=0x$(call compute_size, $(USER_MEM_SIZE))ULL
 endif
 else
 # Non-SYSTEM mode: user-mode emulation
-USER_MEM_SIZE ?= 256 # unit in MiB (demand paging keeps physical usage minimal)
+# 4GB virtual address space (physical usage minimal via demand paging)
+# Required for arch-tests and user programs with high load addresses
+USER_MEM_SIZE ?= 4096 # unit in MiB
 CFLAGS += -DMEM_SIZE=0x$(call compute_size, $(USER_MEM_SIZE))ULL
 endif
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ faithfully implementing the RISC-V instruction set architecture (ISA).
 It serves as an exercise in modeling a modern RISC-based processor, demonstrating
 the device's operations without the complexities of a hardware implementation.
 The code is designed to be accessible and expandable, making it an ideal educational
-tool and starting point for customization. It is primarily written in C99, with
-a focus on efficiency and readability.
+tool and starting point for customization. It is primarily written in C99, utilizing
+C11 atomics for memory management, with a focus on efficiency and readability.
 
 Features:
 * Fast interpreter for executing the RV32 ISA
@@ -210,7 +210,6 @@ $ build/rv32emu-system \
 * `ENABLE_Zicsr`: Control and Status Register (CSR)
 * `ENABLE_Zifencei`: Instruction-Fetch Fence
 * `ENABLE_GDBSTUB` : GDB remote debugging support
-* `ENABLE_FULL4G` : Full access to 4 GiB address space
 * `ENABLE_SDL` : Experimental Display and Event System Calls
 * `ENABLE_JIT` : Experimental JIT compiler
 * `ENABLE_SYSTEM`: Experimental system emulation, allowing booting Linux kernel. To enable this feature, additional features must also be enabled. However, by default, when `ENABLE_SYSTEM` is enabled, CSR, fence, integer multiplication/division, and atomic Instructions are automatically enabled
@@ -260,7 +259,7 @@ $ .ci/riscv-tests.sh
 
 Or run it with the configuration you want:
 ```shell
-$ make arch-test ENABLE_ARCH_TEST=1 ENABLE_FULL4G=1 <your-config>
+$ make arch-test ENABLE_ARCH_TEST=1 <your-config>
 ```
 
 For macOS users, installing `sdiff` might be required:

--- a/docs/prebuilt.md
+++ b/docs/prebuilt.md
@@ -72,10 +72,8 @@ There are still some prebuilt standalone RISC-V binaries under `build/` director
 
 ## Run benchmarks
 
-Some benchmarks need the pre-allocated 4GB address space. Use the following command to enable it:
-
 ```shell
-$ make ENABLE_FULL4G=1 <your-config>
+$ make <your-config>
 $ build/rv32emu <benchmark>
 ```
 

--- a/src/common.h
+++ b/src/common.h
@@ -207,8 +207,11 @@ static inline uint8_t ilog2(uint32_t x)
 #define PRESERVE_NONE
 #endif
 
-/* Assume that all POSIX-compatible environments provide mmap system call. */
-#if defined(_WIN32)
+/* Assume that all POSIX-compatible environments provide mmap system call.
+ * Emscripten is excluded because it lacks signal-based demand paging support
+ * and C11 atomics require special compilation flags not enabled by default.
+ */
+#if defined(_WIN32) || defined(__EMSCRIPTEN__)
 #define HAVE_MMAP 0
 #else
 /* Assume POSIX-compatible runtime */

--- a/src/devices/virtio-blk.c
+++ b/src/devices/virtio-blk.c
@@ -88,7 +88,8 @@ static void virtio_blk_set_fail(virtio_blk_state_t *vblk)
 static inline uint32_t vblk_preprocess(virtio_blk_state_t *vblk UNUSED,
                                        uint32_t addr)
 {
-    if ((addr >= MEM_SIZE) || (addr & 0b11)) {
+    /* Cast to uint64_t for comparison since MEM_SIZE may be 4GB */
+    if (((uint64_t) addr >= MEM_SIZE) || (addr & 0b11)) {
         virtio_blk_set_fail(vblk);
         return 0;
     }

--- a/src/devices/virtio-blk.c
+++ b/src/devices/virtio-blk.c
@@ -88,8 +88,14 @@ static void virtio_blk_set_fail(virtio_blk_state_t *vblk)
 static inline uint32_t vblk_preprocess(virtio_blk_state_t *vblk UNUSED,
                                        uint32_t addr)
 {
-    /* Cast to uint64_t for comparison since MEM_SIZE may be 4GB */
-    if (((uint64_t) addr >= MEM_SIZE) || (addr & 0b11)) {
+    /* When MEM_SIZE is 4GB, all 32-bit addresses are in bounds by definition.
+     * Use compile-time check to avoid GCC -Wtype-limits warning.
+     */
+#if MEM_SIZE < 0x100000000ULL
+    if ((addr >= MEM_SIZE) || (addr & 0b11)) {
+#else
+    if (addr & 0b11) {
+#endif
         virtio_blk_set_fail(vblk);
         return 0;
     }

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -24,6 +24,7 @@ extern struct target_ops gdbstub_ops;
 #endif
 
 #include "decode.h"
+#include "io.h"
 #include "mpool.h"
 #include "riscv.h"
 #include "riscv_private.h"
@@ -1287,6 +1288,13 @@ void rv_step(void *arg)
 #endif
         prev = block;
     }
+
+    /* Incremental memory maintenance: reclaim unused pages periodically.
+     * Using a 16-bit counter, this runs every 65536 rv_step() calls.
+     */
+    static uint16_t gc_counter = 0;
+    if (unlikely(++gc_counter == 0))
+        memory_gc();
 
 #ifdef __EMSCRIPTEN__
     if (rv_has_halted(rv)) {

--- a/src/io.c
+++ b/src/io.c
@@ -4,56 +4,356 @@
  */
 
 #include <assert.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #if HAVE_MMAP
+#include <signal.h>
+#include <stdatomic.h>
 #include <sys/mman.h>
 #include <unistd.h>
 #endif
 
 #include "io.h"
+#include "log.h"
 
 static uint8_t *data_memory_base;
+static uint64_t data_memory_size;
 
-memory_t *memory_new(uint32_t size)
+#if HAVE_MMAP
+/* Demand Paging Memory Management
+ *
+ * Memory is allocated in chunks on-demand using signal handling:
+ * 1. Initial mapping uses PROT_NONE (no access, no physical memory)
+ * 2. Access triggers SIGSEGV/SIGBUS, handler activates the chunk
+ * 3. Unused chunks can be reclaimed via madvise(MADV_DONTNEED)
+ *
+ * This provides automatic memory growth with minimal initial footprint.
+ */
+
+/* Chunk size: 64KB provides good balance between granularity and overhead */
+#define CHUNK_SHIFT 16
+#define CHUNK_SIZE (1UL << CHUNK_SHIFT)
+#define CHUNK_MASK (~(CHUNK_SIZE - 1))
+
+/* Maximum chunks for 4GB address space: 4GB / 64KB = 65536 */
+#define MAX_CHUNKS (0x100000000ULL >> CHUNK_SHIFT)
+#define BITMAP_SIZE (MAX_CHUNKS / 8)
+
+/* Bitmap tracking which chunks are activated */
+static uint8_t chunk_bitmap[BITMAP_SIZE];
+
+/* GC state: circular scan index */
+static uint32_t gc_scan_idx;
+
+/* Statistics: current and peak number of activated chunks (atomic for signal
+ * safety) */
+static atomic_uint_fast32_t active_chunks;
+static atomic_uint_fast32_t peak_chunks;
+
+/* Previous signal handlers to chain */
+static struct sigaction prev_sigsegv_handler;
+static struct sigaction prev_sigbus_handler;
+
+static inline bool bitmap_test(uint32_t idx)
+{
+    return (chunk_bitmap[idx >> 3] & (1 << (idx & 7))) != 0;
+}
+
+static inline void bitmap_set(uint32_t idx)
+{
+    chunk_bitmap[idx >> 3] |= (1 << (idx & 7));
+}
+
+static inline void bitmap_clear(uint32_t idx)
+{
+    chunk_bitmap[idx >> 3] &= ~(1 << (idx & 7));
+}
+
+/* Check if a memory region is all zeros (for reclaim decision).
+ * Uses byte-wise scan to avoid alignment issues with word-sized access.
+ * Compiler may optimize this to SIMD operations where available.
+ */
+static bool is_region_zero(const uint8_t *ptr, size_t size)
+{
+    for (size_t i = 0; i < size; i++) {
+        if (ptr[i] != 0)
+            return false;
+    }
+    return true;
+}
+
+/* Signal handler for demand paging
+ *
+ * Signal safety notes:
+ * - mprotect() is async-signal-safe per POSIX.1-2008 and later
+ * - Atomic operations with memory_order_relaxed are signal-safe
+ * - Bitmap operations are on static memory with no locks
+ * - No heap allocation or stdio calls in the handler
+ */
+static void memory_fault_handler(int sig, siginfo_t *si, void *context)
+{
+    uintptr_t fault_addr = (uintptr_t) si->si_addr;
+    uintptr_t base = (uintptr_t) data_memory_base;
+    uintptr_t end = base + data_memory_size;
+
+    /* Check if fault is within our guest memory range */
+    if (fault_addr >= base && fault_addr < end) {
+        /* Calculate chunk boundaries relative to base address */
+        uintptr_t offset = fault_addr - base;
+        uintptr_t aligned_offset = offset & CHUNK_MASK;
+        uintptr_t chunk_start = base + aligned_offset;
+        uint32_t chunk_idx = aligned_offset >> CHUNK_SHIFT;
+
+        /* Calculate chunk size (may be partial for last chunk) */
+        size_t chunk_len = CHUNK_SIZE;
+        if (chunk_start + CHUNK_SIZE > end) {
+            /* Last partial chunk */
+            chunk_len = end - chunk_start;
+        }
+
+        /* Activate the chunk with read/write permissions */
+        if (mprotect((void *) chunk_start, chunk_len, PROT_READ | PROT_WRITE) ==
+            0) {
+            /* Only count if not already active (handles re-fault edge cases) */
+            if (!bitmap_test(chunk_idx)) {
+                bitmap_set(chunk_idx);
+                uint_fast32_t current =
+                    atomic_fetch_add_explicit(&active_chunks, 1,
+                                              memory_order_relaxed) +
+                    1;
+                uint_fast32_t peak =
+                    atomic_load_explicit(&peak_chunks, memory_order_relaxed);
+                while (current > peak) {
+                    if (atomic_compare_exchange_weak_explicit(
+                            &peak_chunks, &peak, current, memory_order_relaxed,
+                            memory_order_relaxed))
+                        break;
+                }
+            }
+            return; /* Resume execution */
+        }
+    }
+
+    /* Not our fault or mprotect failed - chain to previous handler */
+    struct sigaction *prev =
+        (sig == SIGSEGV) ? &prev_sigsegv_handler : &prev_sigbus_handler;
+
+    if (prev->sa_flags & SA_SIGINFO) {
+        prev->sa_sigaction(sig, si, context);
+    } else if (prev->sa_handler == SIG_DFL) {
+        /* Restore default handler and re-raise using sigaction (async-safe) */
+        struct sigaction dfl;
+        dfl.sa_handler = SIG_DFL;
+        sigemptyset(&dfl.sa_mask);
+        dfl.sa_flags = 0;
+        sigaction(sig, &dfl, NULL);
+        raise(sig);
+    } else if (prev->sa_handler != SIG_IGN) {
+        prev->sa_handler(sig);
+    }
+}
+
+static bool install_signal_handlers(void)
+{
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_sigaction = memory_fault_handler;
+    sa.sa_flags = SA_SIGINFO; /* No SA_NODEFER: prevent reentrancy */
+    sigemptyset(&sa.sa_mask);
+
+    if (sigaction(SIGSEGV, &sa, &prev_sigsegv_handler) == -1) {
+        rv_log_error("Failed to install SIGSEGV handler for demand paging");
+        return false;
+    }
+
+    if (sigaction(SIGBUS, &sa, &prev_sigbus_handler) == -1) {
+        rv_log_error("Failed to install SIGBUS handler for demand paging");
+        sigaction(SIGSEGV, &prev_sigsegv_handler, NULL);
+        return false;
+    }
+
+    return true;
+}
+
+static void restore_signal_handlers(void)
+{
+    sigaction(SIGSEGV, &prev_sigsegv_handler, NULL);
+    sigaction(SIGBUS, &prev_sigbus_handler, NULL);
+}
+#endif /* HAVE_MMAP */
+
+memory_t *memory_new(uint64_t size)
 {
     if (!size)
+        return NULL;
+
+    /* Maximum supported size is 4GB (32-bit address space).
+     * The demand paging bitmap is sized for exactly 4GB.
+     */
+    if (size > 0x100000000ULL)
         return NULL;
 
     memory_t *mem = malloc(sizeof(memory_t));
     if (!mem)
         return NULL;
-    assert(mem);
+
 #if HAVE_MMAP
-    data_memory_base = mmap(NULL, size, PROT_READ | PROT_WRITE,
-                            MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
-    if (data_memory_base == MAP_FAILED) {
+    /* Install signal handlers for demand paging */
+    if (!install_signal_handlers()) {
         free(mem);
         return NULL;
     }
+
+    /* Map memory with PROT_NONE initially - no physical memory allocated.
+     * Chunks are activated on-demand when accessed (via signal handler).
+     * MAP_NORESERVE ensures no swap space is reserved upfront.
+     */
+#ifndef MAP_NORESERVE
+#define MAP_NORESERVE 0
+#endif
+    data_memory_base = mmap(NULL, size, PROT_NONE,
+                            MAP_ANONYMOUS | MAP_PRIVATE | MAP_NORESERVE, -1, 0);
+    if (data_memory_base == MAP_FAILED) {
+        restore_signal_handlers();
+        free(mem);
+        return NULL;
+    }
+
+    data_memory_size = size;
+    memset(chunk_bitmap, 0, sizeof(chunk_bitmap));
+    gc_scan_idx = 0;
+    atomic_store_explicit(&active_chunks, 0, memory_order_relaxed);
+    atomic_store_explicit(&peak_chunks, 0, memory_order_relaxed);
 #else
+    /* Fallback for systems without mmap (e.g., Windows, Emscripten).
+     * Cannot use demand paging - physical memory is allocated upfront.
+     * Limit to 512MB to avoid excessive memory consumption.
+     * Build with HAVE_MMAP=1 for larger address spaces.
+     */
+#define MALLOC_MAX_SIZE (512UL * 1024 * 1024) /* 512 MB */
+    if (size > MALLOC_MAX_SIZE) {
+        free(mem);
+        return NULL;
+    }
     data_memory_base = malloc(size);
     if (!data_memory_base) {
         free(mem);
         return NULL;
     }
+    /* Zero-initialize for consistent behavior */
+    memset(data_memory_base, 0, size);
+    data_memory_size = size;
+#undef MALLOC_MAX_SIZE
 #endif
+
     mem->mem_base = data_memory_base;
-    mem->mem_size = size;
+    mem->mem_size = data_memory_size; /* Use actual allocated size */
     return mem;
 }
 
 void memory_delete(memory_t *mem)
 {
 #if HAVE_MMAP
+    /* Restore handlers first to prevent use-after-free in signal handler */
+    restore_signal_handlers();
     munmap(mem->mem_base, mem->mem_size);
 #else
     free(mem->mem_base);
 #endif
     free(mem);
 }
+
+/* Return peak physical memory usage in bytes.
+ * With MMAP: Returns actual physical memory allocated via demand paging.
+ * Without MMAP: Returns total allocated size (no demand paging available).
+ */
+uint64_t memory_get_usage(void)
+{
+#if HAVE_MMAP
+    /* Clamp to actual memory size to prevent overflow */
+    uint32_t max_chunks = (data_memory_size + CHUNK_SIZE - 1) >> CHUNK_SHIFT;
+    uint_fast32_t peak =
+        atomic_load_explicit(&peak_chunks, memory_order_relaxed);
+    uint32_t chunks = (peak < max_chunks) ? peak : max_chunks;
+    return (uint64_t) chunks * CHUNK_SIZE;
+#else
+    return data_memory_size;
+#endif
+}
+
+/* Incremental garbage collection - scans one chunk per call.
+ * Reclaims zeroed chunks by releasing physical pages (madvise)
+ * and re-arming the fault handler (mprotect PROT_NONE).
+ */
+void memory_gc(void)
+{
+#if HAVE_MMAP
+    uint32_t idx = gc_scan_idx;
+
+    /* Only process chunks within our actual memory size */
+    uint32_t max_idx = (data_memory_size + CHUNK_SIZE - 1) >> CHUNK_SHIFT;
+    if (max_idx > MAX_CHUNKS)
+        max_idx = MAX_CHUNKS;
+
+    if (idx >= max_idx) {
+        gc_scan_idx = 0;
+        return;
+    }
+
+    /* Block signals during bitmap operations to prevent races with handler */
+    sigset_t block_set, old_set;
+    sigemptyset(&block_set);
+    sigaddset(&block_set, SIGSEGV);
+    sigaddset(&block_set, SIGBUS);
+    sigprocmask(SIG_BLOCK, &block_set, &old_set);
+
+    /* Check if this chunk is activated */
+    if (bitmap_test(idx)) {
+        uint8_t *chunk_ptr =
+            data_memory_base + ((uintptr_t) idx << CHUNK_SHIFT);
+
+        /* Calculate chunk size (may be partial for last chunk) */
+        size_t chunk_len = CHUNK_SIZE;
+        uintptr_t chunk_end = (uintptr_t) chunk_ptr + CHUNK_SIZE;
+        uintptr_t mem_end = (uintptr_t) data_memory_base + data_memory_size;
+        if (chunk_end > mem_end)
+            chunk_len = mem_end - (uintptr_t) chunk_ptr;
+
+        /* Reclaim if chunk is all zeros */
+        if (is_region_zero(chunk_ptr, chunk_len)) {
+            /* Protect first to prevent races where chunk gets dirtied
+             * between madvise and mprotect. Only proceed if successful.
+             */
+            if (mprotect(chunk_ptr, chunk_len, PROT_NONE) == 0) {
+                /* Release physical pages back to OS (advisory) */
+                madvise(chunk_ptr, chunk_len, MADV_DONTNEED);
+                bitmap_clear(idx);
+                uint_fast32_t current =
+                    atomic_load_explicit(&active_chunks, memory_order_relaxed);
+                if (current > 0)
+                    atomic_fetch_sub_explicit(&active_chunks, 1,
+                                              memory_order_relaxed);
+            }
+        }
+    }
+
+    /* Restore signal mask */
+    sigprocmask(SIG_SETMASK, &old_set, NULL);
+
+    /* Advance to next chunk (circular) */
+    gc_scan_idx = (idx + 1) % max_idx;
+#endif
+}
+
+/*
+ * Fast memory access functions - no bounds checking for performance.
+ * Callers must validate addresses. With MMAP, out-of-bounds access
+ * triggers SIGSEGV that chains to the default handler.
+ */
 
 void memory_read(const memory_t *mem,
                  uint8_t *dst,
@@ -65,23 +365,29 @@ void memory_read(const memory_t *mem,
 
 uint32_t memory_ifetch(uint32_t addr)
 {
-    return *(const uint32_t *) (data_memory_base + addr);
+    uint32_t val;
+    memcpy(&val, data_memory_base + addr, sizeof(val));
+    return val;
 }
 
-#define MEM_READ_IMPL(size, type)                   \
-    type memory_read_##size(uint32_t addr)          \
-    {                                               \
-        return *(type *) (data_memory_base + addr); \
+/* Safe unaligned memory access using memcpy (compiler optimizes to load/store)
+ */
+#define MEM_READ_IMPL(size, type)                            \
+    type memory_read_##size(uint32_t addr)                   \
+    {                                                        \
+        type val;                                            \
+        memcpy(&val, data_memory_base + addr, sizeof(type)); \
+        return val;                                          \
     }
 
 MEM_READ_IMPL(w, uint32_t)
 MEM_READ_IMPL(s, uint16_t)
 MEM_READ_IMPL(b, uint8_t)
 
-#define MEM_WRITE_IMPL(size, type)                                 \
-    void memory_write_##size(uint32_t addr, const uint8_t *src)    \
-    {                                                              \
-        *(type *) (data_memory_base + addr) = *(const type *) src; \
+#define MEM_WRITE_IMPL(size, type)                              \
+    void memory_write_##size(uint32_t addr, const uint8_t *src) \
+    {                                                           \
+        memcpy(data_memory_base + addr, src, sizeof(type));     \
     }
 
 MEM_WRITE_IMPL(w, uint32_t)

--- a/src/io.h
+++ b/src/io.h
@@ -15,10 +15,19 @@ typedef struct {
 } memory_t;
 
 /* create a memory instance */
-memory_t *memory_new(uint32_t size);
+memory_t *memory_new(uint64_t size);
 
 /* delete a memory instance */
 void memory_delete(memory_t *m);
+
+/* reclaim unused memory pages (incremental GC) */
+void memory_gc(void);
+
+/* get peak physical memory usage in bytes
+ * With MMAP: actual physical memory via demand paging
+ * Without MMAP: total allocated size (capped at 512MB)
+ */
+uint64_t memory_get_usage(void);
 
 /* read an instruction from memory */
 uint32_t memory_ifetch(uint32_t addr);

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -241,12 +241,10 @@ static void map_file(char **ram_loc, const char *name)
     struct stat st;
     fstat(fd, &st);
 
-/* EMSCRIPTEN: We don't currently support location hints for the address of the
- * mapping */
-/* https://github.com/emscripten-core/emscripten/blob/52bc455316b2f44d3a94104776a335a5861ad73b/system/lib/libc/emscripten_mmap.c#L105
- */
-#if HAVE_MMAP && !defined(__EMSCRIPTEN__)
-    /* remap to a memory region */
+#if HAVE_MMAP
+    /* Remap file to memory region. Emscripten/Windows use fallback read path
+     * since they don't support mmap with location hints.
+     */
     *ram_loc = mmap(*ram_loc, st.st_size, PROT_READ | PROT_WRITE,
                     MAP_FIXED | MAP_PRIVATE, fd, 0);
     if (*ram_loc == MAP_FAILED)

--- a/src/riscv.h
+++ b/src/riscv.h
@@ -502,11 +502,11 @@ typedef struct {
     /* vm memory object */
     memory_t *mem;
 
-    /* max memory size is 2^32 - 1 bytes.
-     * It is for portable on both 32-bit and 64-bit platforms. In this way,
-     * emulator can access any segment of the memory on either platform.
+    /* max memory size is 2^32 bytes (4GB).
+     * Use uint64_t to support full 4GB address space with demand paging.
+     * Physical memory is allocated on-demand, keeping actual usage minimal.
      */
-    uint32_t mem_size;
+    uint64_t mem_size;
 
     /* vm main stack size */
     uint32_t stack_size;


### PR DESCRIPTION
This replaces `ENABLE_FULL4G` with signal-based demand paging that provides:
- Automatic memory growth: pages allocated only when accessed
- Minimal footprint: typical programs use 128KB-1MB vs 256MiB virtual
- Incremental GC: unused zero-filled chunks reclaimed via madvise

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implement signal-based demand paging for guest memory to allocate pages only when accessed and reclaim unused pages automatically. Removes ENABLE_FULL4G and cuts physical memory use to what programs actually touch.

- **New Features**
  - Demand paging via SIGSEGV/SIGBUS and mprotect; initial map is PROT_NONE.
  - Incremental GC: zero-filled chunks reclaimed with madvise during execution.
  - Peak memory usage reporting on shutdown.
  - Safer unaligned memory loads/stores using memcpy.
  - Configurable virtual memory via USER_MEM_SIZE; user-mode defaults to 4 GiB.

- **Migration**
  - ENABLE_FULL4G is removed. Use USER_MEM_SIZE to set virtual memory.
  - Update build/test commands to omit ENABLE_FULL4G.
  - User-mode and SYSTEM with ELF loader now default to 4 GiB virtual memory to support high-address ELFs and arch-tests.
  - On platforms without mmap, large allocations are capped (512 MB).

<sup>Written for commit b91188e56bf2d3ef3bf1945876d16c976f53438b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

