### PR TITLE
Fix unsafe string handling in virtio-blk path

### DIFF
--- a/src/riscv.c
+++ b/src/riscv.c
@@ -720,12 +720,20 @@ riscv_t *rv_create(riscv_user_t rv_attr)
                     exit(EXIT_FAILURE);
                 }
 
-                vblk_device = malloc(strlen(vblk_opts[0]) - 1 /* skip ~ */ +
-                                     strlen(home) + 1);
-                assert(vblk_device);
-
-                strcpy(vblk_device, home);
-                strcat(vblk_device, vblk_opts[0] + 1 /* skip ~ */);
+                const char *suffix = vblk_opts[0] + 1; /* skip ~ */
+                size_t home_len = strlen(home);
+                size_t suffix_len = strlen(suffix);
+                if (home_len > SIZE_MAX - suffix_len - 1) {
+                    rv_log_error("Disk path too long");
+                    exit(EXIT_FAILURE);
+                }
+                size_t path_len = home_len + suffix_len + 1;
+                vblk_device = malloc(path_len);
+                if (!vblk_device) {
+                    rv_log_error("Failed to allocate memory for disk path");
+                    exit(EXIT_FAILURE);
+                }
+                snprintf(vblk_device, path_len, "%s%s", home, suffix);
             } else {
                 vblk_device = vblk_opts[0];
             }


### PR DESCRIPTION
This replaces strcpy/strcat with snprintf for `~` path expansion in virtio block device initialization. The original code used banned functions from CERT C Secure Coding guidelines.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secures ~ path expansion in virtio-blk initialization to prevent buffer overflows and improve error handling.

- **Bug Fixes**
  - Replaced strcpy/strcat with snprintf for building the disk path.
  - Added length/overflow checks and exact-sized allocation with error logging on failure.
  - Preserves existing behavior when no ~ is used.

<sup>Written for commit d122cbdd73c52d3b9eacb207c9bc64afbc791b64. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

