### PR TITLE
Emulate misaligned access in default trap handler

### DIFF
--- a/src/jit.h
+++ b/src/jit.h
@@ -56,6 +56,15 @@ void jit_state_exit(struct jit_state *state);
 void jit_translate(riscv_t *rv, block_t *block);
 typedef void (*exec_block_func_t)(riscv_t *rv, uintptr_t);
 
+/* JIT misaligned memory access handler.
+ * Performs misaligned load/store operations using byte-level memory accesses.
+ */
+void jit_misaligned_handler(riscv_t *rv,
+                            uint32_t addr,
+                            uint32_t vreg_idx,
+                            uint32_t type,
+                            bool is_store);
+
 #if RV32_HAS(T2C)
 void t2c_compile(riscv_t *, block_t *);
 typedef void (*exec_t2c_func_t)(riscv_t *);


### PR DESCRIPTION
Previously, the default trap handler simply skipped misaligned memory instructions, which does not match real RISC-V hardware behavior. This change properly emulates misaligned load/store operations by breaking them into smaller aligned accesses.
- Add emulate_misaligned_load() for lw, lh, lhu and compressed variants
- Add emulate_misaligned_store() for sw, sh and compressed variants
- Use fast-path with halfword operations for 2-byte aligned addresses
- Fall back to byte operations for odd addresses
- Add jit_misaligned_handler() for future JIT integration

The fast-path reduces I/O callback overhead by 50% for the common case of 2-byte aligned word accesses (2 halfword ops vs 4 byte ops).

Close #528

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emulates misaligned loads/stores in the default trap handler to match RISC-V behavior instead of skipping the instruction. Adds a fast path for 2-byte aligned word accesses to cut I/O callback overhead by ~50%.

- **Bug Fixes**
  - Decode the faulting instruction and emulate lw/lh/lhu and sw/sh (including compressed) using halfword fast path and byte fallback for odd addresses.
  - Advance PC after successful emulation; skip only if fetch/decode fails or the op is unsupported.

- **New Features**
  - Added emulate_misaligned_load() and emulate_misaligned_store() helpers.
  - Added jit_misaligned_handler() for future JIT integration.

<sup>Written for commit 0aaa830fc0bf3e527fe2a63bf89b7485d3fc4a46. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

