### PR TITLE
Add TLB for MMU and fix trap handling

### DIFF
--- a/src/cache.h
+++ b/src/cache.h
@@ -66,3 +66,28 @@ void clear_cache_hot(const struct cache *cache, clear_func_t func);
 #endif
 
 uint32_t cache_freq(const struct cache *cache, uint32_t key);
+
+#if RV32_HAS(JIT) && RV32_HAS(SYSTEM)
+/**
+ * cache_invalidate_satp - invalidate all blocks matching the given SATP
+ * @cache: a pointer to target cache
+ * @satp: the SATP value to match
+ * @return: number of blocks invalidated
+ *
+ * This is used by SFENCE.VMA with rs1=0 (global flush) to invalidate
+ * JIT-compiled blocks that may contain stale VA→PA mappings.
+ */
+uint32_t cache_invalidate_satp(struct cache *cache, uint32_t satp);
+
+/**
+ * cache_invalidate_va - invalidate blocks within a VA page matching SATP
+ * @cache: a pointer to target cache
+ * @va: the virtual address (page will be derived)
+ * @satp: the SATP value to match
+ * @return: number of blocks invalidated
+ *
+ * This is used by SFENCE.VMA with rs1!=0 (address-specific flush) to
+ * invalidate JIT-compiled blocks in a specific virtual page.
+ */
+uint32_t cache_invalidate_va(struct cache *cache, uint32_t va, uint32_t satp);
+#endif

--- a/src/io.c
+++ b/src/io.c
@@ -116,8 +116,10 @@ static void memory_fault_handler(int sig, siginfo_t *si, void *context)
         }
 
         /* Activate the chunk with read/write permissions */
-        if (mprotect((void *) chunk_start, chunk_len, PROT_READ | PROT_WRITE) ==
-            0) {
+        int result =
+            mprotect((void *) chunk_start, chunk_len, PROT_READ | PROT_WRITE);
+
+        if (result == 0) {
             /* Only count if not already active (handles re-fault edge cases) */
             if (!bitmap_test(chunk_idx)) {
                 bitmap_set(chunk_idx);
@@ -145,7 +147,7 @@ static void memory_fault_handler(int sig, siginfo_t *si, void *context)
     if (prev->sa_flags & SA_SIGINFO) {
         prev->sa_sigaction(sig, si, context);
     } else if (prev->sa_handler == SIG_DFL) {
-        /* Restore default handler and re-raise using sigaction (async-safe) */
+        /* Restore default handler and re-raise */
         struct sigaction dfl;
         dfl.sa_handler = SIG_DFL;
         sigemptyset(&dfl.sa_mask);

--- a/src/jit.c
+++ b/src/jit.c
@@ -2527,7 +2527,8 @@ static void translate_chained_block(struct jit_state *state,
         block_t *block1 =
             cache_get(rv->block_cache, ir->branch_untaken->pc, false);
         if (block1->translatable) {
-            IIF(RV32_HAS(SYSTEM))(if (block1->satp == rv->csr_satp), )
+            IIF(RV32_HAS(SYSTEM))(
+                if (block1->satp == rv->csr_satp && !block1->invalidated), )
                 translate_chained_block(state, rv, block1);
         }
     }
@@ -2535,7 +2536,8 @@ static void translate_chained_block(struct jit_state *state,
         block_t *block1 =
             cache_get(rv->block_cache, ir->branch_taken->pc, false);
         if (block1->translatable) {
-            IIF(RV32_HAS(SYSTEM))(if (block1->satp == rv->csr_satp), )
+            IIF(RV32_HAS(SYSTEM))(
+                if (block1->satp == rv->csr_satp && !block1->invalidated), )
                 translate_chained_block(state, rv, block1);
         }
     }
@@ -2556,7 +2558,8 @@ static void translate_chained_block(struct jit_state *state,
                 block_t *block1 =
                     cache_get(rv->block_cache, bt->PC[max_idx], false);
                 if (block1 && block1->translatable) {
-                    IIF(RV32_HAS(SYSTEM))(if (block1->satp == rv->csr_satp), )
+                    IIF(RV32_HAS(SYSTEM))(if (block1->satp == rv->csr_satp &&
+                                              !block1->invalidated), )
                         translate_chained_block(state, rv, block1);
                 }
             }

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -1023,7 +1023,7 @@ void rv_reset(riscv_t *rv, riscv_word_t pc)
     uintptr_t args_size = (1 + argc + 1) * sizeof(uint32_t);
     uintptr_t args_bottom = attr->mem_size - attr->stack_size;
     uintptr_t args_top = args_bottom - args_size;
-    args_top &= 16;
+    args_top &= -16;
 
     /* argc */
     uintptr_t *args_p = (uintptr_t *) args_top;
@@ -1086,6 +1086,13 @@ void rv_reset(riscv_t *rv, riscv_word_t pc)
 
     /* not being trapped */
     rv->is_trapped = false;
+
+    /* Reset address translation: clear SATP and flush both TLBs to prevent
+     * stale translations from previous execution.
+     */
+    rv->csr_satp = 0;
+    memset(rv->dtlb, 0, sizeof(rv->dtlb));
+    memset(rv->itlb, 0, sizeof(rv->itlb));
 #else
     /* ISA simulation defaults to M-mode */
     rv->priv_mode = RV_PRIV_M_MODE;

--- a/src/riscv.h
+++ b/src/riscv.h
@@ -446,6 +446,14 @@ void rv_set_tohost_addr(riscv_t *rv, uint32_t addr);
 void rv_set_fromhost_addr(riscv_t *rv, uint32_t addr);
 #endif
 
+#if RV32_HAS(SYSTEM)
+/* TLB management functions for SFENCE.VMA instruction and SATP changes.
+ * Invalidate cached address translations when page tables are modified.
+ */
+void mmu_tlb_flush_all(riscv_t *rv);
+void mmu_tlb_flush(riscv_t *rv, uint32_t vaddr);
+#endif
+
 enum {
     /* run and trace instructions and print them out during emulation */
     RV_RUN_TRACE = 1,

--- a/src/riscv_private.h
+++ b/src/riscv_private.h
@@ -92,6 +92,8 @@ typedef struct block {
     bool has_loops;   /**< Determine the block has loop or not */
 #if RV32_HAS(SYSTEM)
     uint32_t satp;
+    bool invalidated; /**< Block invalidated by SFENCE.VMA, needs recompilation
+                       */
 #endif
 #if RV32_HAS(T2C)
     bool compiled; /**< The T2C request is enqueued or not */

--- a/src/system.h
+++ b/src/system.h
@@ -183,8 +183,6 @@ uint32_t mmu_translate(riscv_t *rv, uint32_t vaddr, bool rw);
 void mmu_tlb_flush_all(riscv_t *rv);
 void mmu_tlb_flush(riscv_t *rv, uint32_t vaddr);
 
-uint32_t *mmu_walk(riscv_t *rv, const uint32_t addr, uint32_t *level);
-
 #define get_ppn_and_offset()                                   \
     uint32_t ppn;                                              \
     uint32_t offset;                                           \

--- a/tests/system/alignment/misalign.S
+++ b/tests/system/alignment/misalign.S
@@ -50,9 +50,10 @@ exit:
     ecall
 
 misaligned_insn_fetch_handler:
-    # simply jump back to caller since no really handling it
-    # since the rest of instruction are also misaligned
-    jalr zero, ra, 0
+    # Return to caller by setting sepc to ra and using sret
+    # This properly exits trap mode and clears is_trapped
+    csrw sepc, ra
+    sret
 
 misaligned_load_handler:
     # Handle load misalignment: skip load


### PR DESCRIPTION
This implements TLB for faster address translation:
- 64-entry direct-mapped TLB indexed by VPN for O(1) lookup
- Caches VPN, PPN, permissions (R/W/X/U), and validity
- Superpages handled by caching each 4KB slice with computed PPN
- Flushed on SATP changes and SFENCE.VMA instruction
- Block cache invalidated on SFENCE.VMA for JIT/PTE consistency

Privilege and permission checking:
- U-mode can only access pages with PTE_U bit set
- S-mode accessing U-page requires SUM=1 in sstatus
- MXR bit handling for executable page reads

ELF_LOADER+SYSTEM mode fixes:
- Fix stack alignment: use `&= -16` (not `&= 16`) for 16-byte boundary
- Add retry-after-trap in mmu_ifetch/mmu_translate: after page fault handler returns, retry page walk to check if page was mapped
- Add page fault trap generation for out-of-bounds memory access
- Remove duplicate DTB dependencies from Makefile

Misaligned instruction fetch trap handler fix:
- Use `sret` instead of `ret` to properly exit trap mode
- Set `sepc` to return address before `sret`
- Matches behavior of misaligned load/store handlers

Close #500