### PR TITLE
Introduce Kconfig-based build system

### DIFF
--- a/.ci/riscv-tests.sh
+++ b/.ci/riscv-tests.sh
@@ -14,9 +14,10 @@ set -x
 export PATH=$(pwd)/toolchain/bin:$PATH
 
 make distclean
-# Rebuild with all RISC-V extensions
+# Rebuild with all RISC-V extensions (including B-extension: Zba/Zbb/Zbc/Zbs)
 make ENABLE_ARCH_TEST=1 ENABLE_EXT_M=1 ENABLE_EXT_A=1 ENABLE_EXT_F=1 ENABLE_EXT_C=1 \
-    ENABLE_Zicsr=1 ENABLE_Zifencei=1 $PARALLEL
+    ENABLE_Zicsr=1 ENABLE_Zifencei=1 \
+    ENABLE_Zba=1 ENABLE_Zbb=1 ENABLE_Zbc=1 ENABLE_Zbs=1 $PARALLEL
 
 # Pre-fetch shared resources before parallel execution to avoid race conditions
 make ENABLE_ARCH_TEST=1 artifact
@@ -61,7 +62,7 @@ fi
 # Rebuild with RV32E
 make distclean
 make ENABLE_ARCH_TEST=1 ENABLE_RV32E=1 $PARALLEL
-make arch-test RISCV_DEVICE=E $PARALLEL || exit 1
+make ENABLE_ARCH_TEST=1 arch-test RISCV_DEVICE=E SKIP_PREREQ=1 $PARALLEL || exit 1
 
 # Rebuild with JIT
 # Do not run the architecture test with "Zicsr" extension. It ignores
@@ -70,4 +71,4 @@ make distclean
 make ENABLE_ARCH_TEST=1 ENABLE_JIT=1 ENABLE_T2C=0 \
     ENABLE_EXT_M=1 ENABLE_EXT_A=1 ENABLE_EXT_F=1 ENABLE_EXT_C=1 \
     ENABLE_Zicsr=1 ENABLE_Zifencei=1 $PARALLEL
-make arch-test RISCV_DEVICE=IMC hw_data_misaligned_support=0 $PARALLEL || exit 1
+make ENABLE_ARCH_TEST=1 arch-test RISCV_DEVICE=IMC hw_data_misaligned_support=0 SKIP_PREREQ=1 $PARALLEL || exit 1

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Build for benchmark
         if: steps.changed-files.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch'
-        run: make ENABLE_SDL=0 all artifact
+        run: make defconfig && make ENABLE_SDL=0 all artifact
       - name: Run benchmark
         if: steps.changed-files.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch'
         run: |

--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -60,6 +60,7 @@ jobs:
           echo "$PWD/toolchain/bin" >> $GITHUB_PATH
       - name: Build binaries
         run: |
+          make defconfig
           make artifact ENABLE_PREBUILT=0
           mkdir -p /tmp/rv32emu-prebuilt
           mv build/sha1sum-linux-x86-softfp /tmp

--- a/.github/workflows/build-linux-artifacts.yml
+++ b/.github/workflows/build-linux-artifacts.yml
@@ -58,7 +58,8 @@ jobs:
       - name: Build Linux image
         run: |
           make build-linux-image
-          make artifact ENABLE_PREBUILT=0 ENABLE_SYSTEM=1
+          make system_defconfig
+          make artifact ENABLE_PREBUILT=0
       - name: Create tarball
         run: |
           cd /tmp

--- a/.github/workflows/deploy-wasm.yml
+++ b/.github/workflows/deploy-wasm.yml
@@ -70,7 +70,8 @@ jobs:
             github.event_name == 'workflow_dispatch' ||
             (github.event_name == 'repository_dispatch' && github.event.action == 'deploy_system_wasm') }}
         run: |
-            make CC=emcc ENABLE_SYSTEM=1 ENABLE_SDL=1 ENABLE_JIT=0 INITRD_SIZE=32 -j
+            make wasm_defconfig
+            make CC=emcc ENABLE_SYSTEM=1 INITRD_SIZE=32 -j
             mkdir /tmp/rv32emu-system-demo
             mv assets/wasm/html/system.html /tmp/rv32emu-system-demo/index.html
             mv assets/wasm/js/coi-serviceworker.min.js /tmp/rv32emu-system-demo
@@ -175,7 +176,8 @@ jobs:
             github.event_name == 'workflow_dispatch' ||
             (github.event_name == 'repository_dispatch' && github.event.action == 'deploy_user_wasm') }}
         run: |
-            make CC=emcc ENABLE_SDL=1 ENABLE_JIT=0
+            make wasm_defconfig
+            make CC=emcc -j
             mkdir /tmp/rv32emu-demo
             mv assets/wasm/html/user.html /tmp/rv32emu-demo/index.html
             mv assets/wasm/js/coi-serviceworker.min.js /tmp/rv32emu-demo

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,9 @@ jobs:
           files: |
               .ci/**
               build/**
+              configs/**
               mk/**
+              scripts/**
               src/**
               tests/**
               tools/**
@@ -158,14 +160,16 @@ jobs:
       if: success()
       run: |
             make distclean
-            make CC=emcc ENABLE_JIT=0 $PARALLEL
+            make wasm_defconfig
+            make CC=emcc $PARALLEL
 
     - name: default build for system emulation using emcc
       if: success()
       run: |
             make distclean
-            make CC=emcc ENABLE_SYSTEM=1 ENABLE_JIT=0 $PARALLEL
-            make distclean ENABLE_SYSTEM=1
+            make wasm_defconfig
+            make CC=emcc ENABLE_SYSTEM=1 $PARALLEL
+            make distclean
 
     - name: Build with various optimization levels
       if: success()
@@ -176,7 +180,7 @@ jobs:
             # Test boundary cases: -O0 (unoptimized), -O2 (standard), -Ofast (aggressive)
             for opt_level in -O0 -O2 -Ofast; do
               echo "Building with OPT_LEVEL=$opt_level"
-              if ! (make distclean && make OPT_LEVEL=$opt_level $PARALLEL); then
+              if ! (make distclean && make defconfig && make OPT_LEVEL=$opt_level $PARALLEL); then
                 echo "ERROR: Build failed with OPT_LEVEL=$opt_level"
                 exit 1
               fi
@@ -191,7 +195,7 @@ jobs:
             # Test boundary cases: -O0 (unoptimized), -O2 (standard), -Ofast (aggressive)
             for opt_level in -O0 -O2 -Ofast; do
               echo "Building system emulation with OPT_LEVEL=$opt_level"
-              if ! (make distclean && make OPT_LEVEL=$opt_level ENABLE_SYSTEM=1 $PARALLEL); then
+              if ! (make distclean && make system_defconfig && make OPT_LEVEL=$opt_level $PARALLEL); then
                 echo "ERROR: System emulation build failed with OPT_LEVEL=$opt_level"
                 exit 1
               fi
@@ -203,6 +207,7 @@ jobs:
         CC: ${{ steps.install_cc.outputs.cc }}
       run: |
             make distclean
+            make defconfig
             make check $PARALLEL
             make tests $PARALLEL
             make misalign $PARALLEL
@@ -222,12 +227,12 @@ jobs:
                        ENABLE_Zicsr ENABLE_Zifencei \
                        ENABLE_MOP_FUSION ENABLE_BLOCK_CHAINING; do
               echo "Testing ${ext}=0 (interpreter)"
-              if ! (make distclean && make ${ext}=0 check $PARALLEL); then
+              if ! (make distclean && make defconfig && make ${ext}=0 check $PARALLEL); then
                 echo "ERROR: Interpreter test failed with ${ext}=0"
                 exit 1
               fi
               echo "Testing ${ext}=0 (JIT)"
-              if ! (make ENABLE_JIT=1 clean && make ${ext}=0 ENABLE_JIT=1 check $PARALLEL); then
+              if ! (make distclean && make jit_defconfig && make ${ext}=0 check $PARALLEL); then
                 echo "ERROR: JIT test failed with ${ext}=0"
                 exit 1
               fi
@@ -239,7 +244,7 @@ jobs:
         CC: ${{ steps.install_cc.outputs.cc }}
       run: |
             # SDL is graphics subsystem, interpreter-only test sufficient
-            make distclean && make ENABLE_SDL=0 check $PARALLEL
+            make distclean && make defconfig && make ENABLE_SDL=0 check $PARALLEL
 
     - name: misalignment test in block emulation
       if: success()
@@ -247,7 +252,7 @@ jobs:
         CC: ${{ steps.install_cc.outputs.cc }}
       run: |
             make -C tests/system/alignment/
-            make distclean && make ENABLE_ELF_LOADER=1 ENABLE_EXT_C=0 ENABLE_SYSTEM=1 misalign-in-blk-emu $PARALLEL
+            make distclean && make system_defconfig && make ENABLE_ELF_LOADER=1 ENABLE_EXT_C=0 misalign-in-blk-emu $PARALLEL
 
     - name: MMU test
       if: success()
@@ -255,14 +260,14 @@ jobs:
         CC: ${{ steps.install_cc.outputs.cc }}
       run: |
             make -C tests/system/mmu/
-            make distclean && make ENABLE_ELF_LOADER=1 ENABLE_SYSTEM=1 mmu-test $PARALLEL
+            make distclean && make system_defconfig && make ENABLE_ELF_LOADER=1 mmu-test $PARALLEL
 
     - name: gdbstub test
       if: success()
       env:
         CC: ${{ steps.install_cc.outputs.cc }}
       run: |
-            make distclean && make ENABLE_GDBSTUB=1 gdbstub-test $PARALLEL
+            make distclean && make defconfig && make ENABLE_GDBSTUB=1 gdbstub-test $PARALLEL
 
     - name: JIT base test
       if: success()
@@ -270,33 +275,31 @@ jobs:
         CC: ${{ steps.install_cc.outputs.cc }}
       run: |
             # Base JIT test (extension disable tests handled in consolidated step above)
-            make ENABLE_JIT=1 clean && make ENABLE_JIT=1 check $PARALLEL
+            make distclean && make jit_defconfig && make check $PARALLEL
 
     - name: undefined behavior test
       if: success() || failure()
       run: |
-            # Clear cached config from previous steps to avoid ENABLE_SYSTEM=1 contamination
-            rm -f build/.config
-            make distclean && make ENABLE_UBSAN=1 check $PARALLEL
-            make ENABLE_JIT=1 clean && make ENABLE_JIT=1 ENABLE_UBSAN=1 check $PARALLEL
+            make distclean && make defconfig && make ENABLE_UBSAN=1 check $PARALLEL
+            make distclean && make jit_defconfig && make ENABLE_UBSAN=1 check $PARALLEL
 
     - name: boot Linux kernel test
       if: success()
       env:
         CC: ${{ steps.install_cc.outputs.cc }}
       run: |
-            make distclean && make INITRD_SIZE=32 ENABLE_SYSTEM=1 $PARALLEL && make ENABLE_SYSTEM=1 artifact $PARALLEL
+            make distclean && make system_defconfig && make INITRD_SIZE=32 $PARALLEL && make artifact $PARALLEL
             bash -c "${BOOT_LINUX_TEST}"
-            make ENABLE_SYSTEM=1 clean
+            make clean
 
     - name: boot Linux kernel test (JIT)
       if: success()
       env:
         CC: ${{ steps.install_cc.outputs.cc }}
       run: |
-            make distclean && make INITRD_SIZE=32 ENABLE_SYSTEM=1 ENABLE_JIT=1 ENABLE_MOP_FUSION=0 $PARALLEL && make ENABLE_SYSTEM=1 artifact $PARALLEL
+            make distclean && make system_defconfig && make INITRD_SIZE=32 ENABLE_JIT=1 ENABLE_MOP_FUSION=0 $PARALLEL && make artifact $PARALLEL
             bash -c "${BOOT_LINUX_TEST}"
-            make ENABLE_SYSTEM=1 ENABLE_JIT=1 ENABLE_MOP_FUSION=0 clean
+            make clean
 
     - name: Architecture test
       if: success()
@@ -385,7 +388,8 @@ jobs:
       env:
         CC: clang-${{ env.LLVM_VERSION }}
       run: |
-            make $PARALLEL
+            make distclean
+            make defconfig
             make check $PARALLEL
 
     - name: JIT tests
@@ -393,7 +397,7 @@ jobs:
         CC: clang-${{ env.LLVM_VERSION }}
       run: |
             set -euo pipefail
-            make ENABLE_JIT=1 clean && make ENABLE_JIT=1 check $PARALLEL
+            make distclean && make jit_defconfig && make check $PARALLEL
             for ext in ENABLE_EXT_A ENABLE_EXT_F ENABLE_EXT_C; do
               echo "JIT test with ${ext}=0"
               make ENABLE_JIT=1 clean && make ${ext}=0 ENABLE_JIT=1 check $PARALLEL
@@ -496,6 +500,7 @@ jobs:
          CC: ${{ steps.install_cc.outputs.cc }}
        run: |
              make distclean
+             make defconfig
              make check $PARALLEL
              make tests $PARALLEL
              make misalign $PARALLEL
@@ -515,12 +520,12 @@ jobs:
                         ENABLE_Zicsr ENABLE_Zifencei \
                         ENABLE_MOP_FUSION ENABLE_BLOCK_CHAINING; do
                echo "Testing ${ext}=0 (interpreter)"
-               if ! (make distclean && make ${ext}=0 check $PARALLEL); then
+               if ! (make distclean && make defconfig && make ${ext}=0 check $PARALLEL); then
                  echo "ERROR: Interpreter test failed with ${ext}=0"
                  exit 1
                fi
                echo "Testing ${ext}=0 (JIT)"
-               if ! (make ENABLE_JIT=1 clean && make ${ext}=0 ENABLE_JIT=1 check $PARALLEL); then
+               if ! (make distclean && make jit_defconfig && make ${ext}=0 check $PARALLEL); then
                  echo "ERROR: JIT test failed with ${ext}=0"
                  exit 1
                fi
@@ -532,14 +537,14 @@ jobs:
          CC: ${{ steps.install_cc.outputs.cc }}
        run: |
              # SDL is graphics subsystem, interpreter-only test sufficient
-             make distclean && make ENABLE_SDL=0 check $PARALLEL
+             make distclean && make defconfig && make ENABLE_SDL=0 check $PARALLEL
 
      - name: gdbstub test, need RV32 toolchain
        if: success()
        env:
          CC: ${{ steps.install_cc.outputs.cc }}
        run: |
-             make distclean && make ENABLE_GDBSTUB=1 gdbstub-test $PARALLEL
+             make distclean && make defconfig && make ENABLE_GDBSTUB=1 gdbstub-test $PARALLEL
 
      - name: JIT base test
        if: success()
@@ -547,36 +552,34 @@ jobs:
          CC: ${{ steps.install_cc.outputs.cc }}
        run: |
              # Base JIT test (extension disable tests handled in consolidated step above)
-             make ENABLE_JIT=1 clean && make ENABLE_JIT=1 check $PARALLEL
+             make distclean && make jit_defconfig && make check $PARALLEL
 
      - name: undefined behavior test
        if: (success() || failure()) && steps.install_cc.outputs.cc == 'clang'  # gcc on macOS/arm64 does not support sanitizers
        env:
          CC: ${{ steps.install_cc.outputs.cc }}
        run: |
-             # Clear cached config from previous steps to avoid ENABLE_SYSTEM=1 contamination
-             rm -f build/.config
-             make distclean && make ENABLE_UBSAN=1 check $PARALLEL
-             make ENABLE_JIT=1 clean && make ENABLE_JIT=1 ENABLE_UBSAN=1 check $PARALLEL
+             make distclean && make defconfig && make ENABLE_UBSAN=1 check $PARALLEL
+             make distclean && make jit_defconfig && make ENABLE_UBSAN=1 check $PARALLEL
 
      - name: boot Linux kernel test
        if: success()
        env:
          CC: ${{ steps.install_cc.outputs.cc }}
        run: |
-             make distclean && make INITRD_SIZE=32 ENABLE_SYSTEM=1 $PARALLEL && \
-             make ENABLE_SYSTEM=1 artifact $PARALLEL
+             make distclean && make system_defconfig && make INITRD_SIZE=32 $PARALLEL && \
+             make artifact $PARALLEL
              bash -c "${BOOT_LINUX_TEST}"
-             make ENABLE_SYSTEM=1 clean
+             make clean
 
      - name: boot Linux kernel test (JIT)
        if: success()
        env:
          CC: ${{ steps.install_cc.outputs.cc }}
        run: |
-             make distclean && make INITRD_SIZE=32 ENABLE_SYSTEM=1 ENABLE_JIT=1 ENABLE_MOP_FUSION=0 $PARALLEL && make ENABLE_SYSTEM=1 artifact $PARALLEL
+             make distclean && make system_defconfig && make INITRD_SIZE=32 ENABLE_JIT=1 ENABLE_MOP_FUSION=0 $PARALLEL && make artifact $PARALLEL
              bash -c "${BOOT_LINUX_TEST}"
-             make ENABLE_SYSTEM=1 ENABLE_JIT=1 ENABLE_MOP_FUSION=0 clean
+             make clean
 
      - name: Architecture test
        if: success()
@@ -655,13 +658,13 @@ jobs:
         LATEST_RELEASE: dummy
       run: |
           LLVM_VERSION=$(cat .ci/llvm-version)
-          make distclean && scan-build-${LLVM_VERSION} -v -o ~/scan-build --status-bugs --use-cc=clang-${LLVM_VERSION} --force-analyze-debug-code --show-description -analyzer-config stable-report-filename=true -enable-checker valist,nullability make ENABLE_EXT_F=0 ENABLE_SDL=0 ENABLE_JIT=0
+          make distclean && make defconfig && scan-build-${LLVM_VERSION} -v -o ~/scan-build --status-bugs --use-cc=clang-${LLVM_VERSION} --force-analyze-debug-code --show-description -analyzer-config stable-report-filename=true -enable-checker valist,nullability make ENABLE_EXT_F=0 ENABLE_SDL=0 ENABLE_JIT=0
     - name: run scan-build with JIT
       env:
         LATEST_RELEASE: dummy
       run: |
           LLVM_VERSION=$(cat .ci/llvm-version)
-          make ENABLE_JIT=1 distclean && scan-build-${LLVM_VERSION} -v -o ~/scan-build --status-bugs --use-cc=clang-${LLVM_VERSION} --force-analyze-debug-code --show-description -analyzer-config stable-report-filename=true -enable-checker valist,nullability make ENABLE_EXT_F=0 ENABLE_SDL=0 ENABLE_JIT=1
+          make distclean && make jit_defconfig && scan-build-${LLVM_VERSION} -v -o ~/scan-build --status-bugs --use-cc=clang-${LLVM_VERSION} --force-analyze-debug-code --show-description -analyzer-config stable-report-filename=true -enable-checker valist,nullability make ENABLE_EXT_F=0 ENABLE_SDL=0 ENABLE_JIT=1
 
   # https://docs.docker.com/build/ci/github-actions/multi-platform/
   docker-hub-build-and-publish:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # external files
 build/DOOM1.WAD*
+tools/kconfig/
 shareware_doom_iwad.zip*
 quakesw-1.0.6.zip*
 build/id1/
@@ -8,7 +9,8 @@ build/doomrc
 toolchain/
 
 # built objects
-build/.config
+.config
+.config.old
 build/rv32emu
 build/arch-test
 build/mini-gdbstub
@@ -31,3 +33,4 @@ tests/arch-test-target/sail_cSim/riscv_sim_RV32
 tests/scimark2/
 __pycache__/
 src/minimal_dtb.h
+src/rv32emu_config.h

--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ and [SDL2_Mixer library](https://wiki.libsdl.org/SDL2_mixer) installed.
 * macOS: `brew install sdl2 sdl2_mixer`
 * Ubuntu Linux / Debian: `sudo apt install libsdl2-dev libsdl2-mixer-dev`
 
+### Quick Start
+```shell
+$ make defconfig      # Apply default configuration
+$ make                # Build rv32emu
+$ make check          # Run tests
+```
+
+For interactive configuration with a menu-driven interface:
+```shell
+$ make config         # Configure build options interactively
+$ make
+```
+
 ### Experimental JIT compilation
 The tier-2 JIT compiler in `rv32emu` leverages LLVM for powerful optimization.
 Therefore, the target system must have [`LLVM`](https://llvm.org/) installed, with version 18 recommended.
@@ -49,13 +62,20 @@ If `LLVM` is not installed, only the tier-1 JIT compiler will be used for perfor
 * macOS: `brew install llvm@18`
 * Ubuntu Linux / Debian: `sudo apt-get install llvm-18`
 
-Build the emulator with experimental JIT compiler:
+Build the emulator with JIT compiler using the predefined configuration:
+```shell
+$ make jit_defconfig
+$ make
+```
+
+Alternatively, use the legacy command-line option (for backward compatibility):
 ```shell
 $ make ENABLE_JIT=1
 ```
 
 If you don't want the JIT compilation feature, simply build with the following:
 ```shell
+$ make defconfig
 $ make
 ```
 
@@ -197,7 +217,32 @@ $ build/rv32emu-system \
 ```
 
 ### Customization
-`rv32emu` is configurable, and you can override the below variable(s) to fit your expectations:
+`rv32emu` uses a [Kconfig](https://github.com/sysprog21/Kconfiglib)-based build system for configuration.
+There are three ways to customize the build:
+
+#### 1. Predefined Configurations
+Use predefined configurations for common use cases:
+```shell
+$ make defconfig          # Default: SDL enabled, all extensions
+$ make mini_defconfig     # Minimal: no SDL, basic extensions only
+$ make jit_defconfig      # JIT: enables tiered JIT compilation
+$ make system_defconfig   # System: enables Linux system emulation
+```
+
+#### 2. Interactive Configuration
+Use the menu-driven interface to customize options:
+```shell
+$ make config
+```
+
+#### 3. Command-line Override (Legacy)
+Override individual options on the command line (for backward compatibility):
+```shell
+$ make ENABLE_EXT_F=0     # Build without floating-point support
+$ make ENABLE_SDL=0       # Build without SDL support
+```
+
+Available configuration options:
 * `ENABLE_RV32E`: RV32E Base Integer Instruction Set
 * `ENABLE_EXT_M`: Standard Extension for Integer Multiplication and Division
 * `ENABLE_EXT_A`: Standard Extension for Atomic Instructions
@@ -209,23 +254,12 @@ $ build/rv32emu-system \
 * `ENABLE_Zbs`: Standard Extension for Single-Bit Instructions
 * `ENABLE_Zicsr`: Control and Status Register (CSR)
 * `ENABLE_Zifencei`: Instruction-Fetch Fence
-* `ENABLE_GDBSTUB` : GDB remote debugging support
-* `ENABLE_SDL` : Experimental Display and Event System Calls
-* `ENABLE_JIT` : Experimental JIT compiler
-* `ENABLE_SYSTEM`: Experimental system emulation, allowing booting Linux kernel. To enable this feature, additional features must also be enabled. However, by default, when `ENABLE_SYSTEM` is enabled, CSR, fence, integer multiplication/division, and atomic Instructions are automatically enabled
-* `ENABLE_MOP_FUSION` : Macro-operation fusion
-* `ENABLE_BLOCK_CHAINING` : Block chaining of translated blocks
-* `ENABLE_LOG_COLOR` : Logging with colors (default)
-
-e.g., run `make ENABLE_EXT_F=0` for the build without floating-point support.
-
-Alternatively, configure the above items in advance by executing `make config` and
-specifying them in a configuration file. Subsequently, run `make` according to the provided
-configurations. For example, employ the following commands:
-```shell
-$ make config ENABLE_SDL=0
-$ make
-```
+* `ENABLE_GDBSTUB`: GDB remote debugging support
+* `ENABLE_SDL`: Experimental Display and Event System Calls
+* `ENABLE_JIT`: Experimental JIT compiler
+* `ENABLE_SYSTEM`: Experimental system emulation, allowing booting Linux kernel
+* `ENABLE_MOP_FUSION`: Macro-operation fusion
+* `ENABLE_BLOCK_CHAINING`: Block chaining of translated blocks
 
 ### RISCOF
 [RISCOF](https://github.com/riscv-software-src/riscof) (RISC-V Compatibility Framework) is

--- a/configs/Kconfig
+++ b/configs/Kconfig
@@ -1,0 +1,350 @@
+# rv32emu Configuration
+#
+# RISC-V RV32 Emulator with tiered JIT compilation
+
+mainmenu "rv32emu Configuration"
+
+# Environment Detection (read-only, set by tools/detect-env.py)
+
+menu "Toolchain Detection"
+
+config COMPILER_TYPE
+    string
+    default "$(shell,tools/detect-env.py --compiler 2>/dev/null || echo Unknown)"
+
+config CC_IS_EMCC
+    def_bool $(shell,tools/detect-env.py --is-emcc 2>/dev/null)
+
+config CC_IS_CLANG
+    def_bool $(shell,tools/detect-env.py --is-clang 2>/dev/null)
+
+config CC_IS_GCC
+    def_bool $(shell,tools/detect-env.py --is-gcc 2>/dev/null)
+
+comment "Build mode: WebAssembly (Emscripten)"
+    depends on CC_IS_EMCC
+
+comment "Build mode: Native"
+    depends on !CC_IS_EMCC
+
+endmenu
+
+# Dependency Detection
+
+config HAVE_SDL2
+    bool
+    default n if CC_IS_EMCC
+    default $(shell,tools/detect-env.py --have-sdl2 2>/dev/null)
+
+config HAVE_SDL2_MIXER
+    bool
+    default n if CC_IS_EMCC
+    default $(shell,tools/detect-env.py --have-sdl2-mixer 2>/dev/null)
+
+config HAVE_LLVM18
+    bool
+    default $(shell,tools/detect-env.py --have-llvm18 2>/dev/null)
+
+config HAVE_RISCV_TOOLCHAIN
+    bool
+    default $(shell,tools/detect-env.py --have-riscv-toolchain 2>/dev/null)
+
+# RISC-V ISA Extensions
+
+menu "RISC-V ISA Configuration"
+
+choice
+    prompt "Base Integer Instruction Set"
+    default RV32I
+
+config RV32I
+    bool "RV32I (Standard 32 registers)"
+    help
+      Standard RISC-V 32-bit base integer instruction set
+      with 32 general-purpose registers.
+
+config RV32E
+    bool "RV32E (Embedded 16 registers)"
+    help
+      Reduced RISC-V base integer instruction set for embedded
+      systems with only 16 general-purpose registers.
+
+endchoice
+
+comment "Standard Extensions"
+
+config EXT_M
+    bool "M - Integer Multiplication and Division"
+    default y
+    help
+      Enable integer multiplication and division instructions.
+      Required for most practical programs.
+
+config EXT_A
+    bool "A - Atomic Instructions"
+    default y
+    help
+      Enable atomic memory operation instructions.
+      Required for multi-threading and synchronization.
+
+config EXT_F
+    bool "F - Single-Precision Floating-Point"
+    default y
+    help
+      Enable single-precision (32-bit) floating-point instructions.
+      Uses Berkeley SoftFloat for IEEE 754 compliance.
+
+config EXT_C
+    bool "C - Compressed Instructions"
+    default y
+    help
+      Enable 16-bit compressed instruction encoding.
+      Reduces code size by approximately 25-30%.
+
+comment "Zicsr and Zifencei Extensions"
+
+config Zicsr
+    bool "Zicsr - Control and Status Register"
+    default y
+    help
+      Enable CSR (Control and Status Register) instructions.
+      Required for privileged mode and system emulation.
+
+config Zifencei
+    bool "Zifencei - Instruction-Fetch Fence"
+    default y
+    help
+      Enable instruction-fetch fence for self-modifying code.
+      Required for JIT compilation support.
+
+comment "Bit Manipulation Extensions (Zb*)"
+
+config Zba
+    bool "Zba - Address Generation"
+    default y
+    help
+      Enable address generation bit manipulation instructions.
+      Provides efficient shifted-add operations.
+
+config Zbb
+    bool "Zbb - Basic Bit Manipulation"
+    default y
+    help
+      Enable basic bit manipulation instructions.
+      Includes count, rotate, byte-reverse operations.
+
+config Zbc
+    bool "Zbc - Carry-less Multiplication"
+    default y
+    help
+      Enable carry-less multiplication instructions.
+      Useful for cryptographic applications (GCM, CRC).
+
+config Zbs
+    bool "Zbs - Single-bit Instructions"
+    default y
+    help
+      Enable single-bit manipulation instructions.
+      Provides efficient bit test, set, clear operations.
+
+endmenu
+
+# Execution Modes
+
+menu "Execution Modes"
+
+comment "Emulation Mode"
+
+choice
+    prompt "Execution Engine"
+    default INTERPRETER_ONLY
+    help
+      Select the execution engine for RISC-V instruction emulation.
+
+config INTERPRETER_ONLY
+    bool "Interpreter Only"
+    help
+      Pure interpreter mode using threaded code dispatch.
+      Most portable, works on all platforms.
+
+      Uses computed goto for efficient instruction dispatch.
+
+config JIT
+    bool "JIT Compilation (Hybrid)"
+    depends on !CC_IS_EMCC
+    help
+      Hybrid interpreter + Just-In-Time compilation.
+      Tier-1 JIT uses template-based code generation for hot paths.
+
+      JIT is only available on x86_64 and ARM64 platforms.
+      Falls back to interpreter for cold code.
+
+endchoice
+
+config T2C
+    bool "Tier-2 LLVM Compiler"
+    default y
+    depends on JIT && HAVE_LLVM18
+    help
+      Enable tier-2 JIT compiler powered by LLVM 18.
+      Provides advanced optimizations for hot code paths.
+
+      Requires LLVM 18 development libraries.
+
+comment "System Emulation"
+
+config SYSTEM
+    bool "System Emulation Mode"
+    default n
+    help
+      Enable system emulation mode for running the Linux kernel.
+      Includes MMU, timer, UART, and virtio device emulation.
+
+      When enabled, rv32emu can boot a complete Linux system.
+      Requires additional kernel image and rootfs.
+
+config ELF_LOADER
+    bool "ELF Loader for System Mode"
+    default n
+    depends on SYSTEM
+    help
+      Use ELF loader in system mode instead of raw kernel image.
+      Required for running ELF executables in system mode tests.
+
+endmenu
+
+# Performance Optimizations
+
+menu "Performance Options"
+
+config MOP_FUSION
+    bool "Macro-op Fusion"
+    default y
+    help
+      Enable macro-operation fusion for common instruction sequences.
+      Fuses consecutive instructions into optimized handlers.
+
+      Improves performance by reducing dispatch overhead.
+
+config BLOCK_CHAINING
+    bool "Block Chaining"
+    default y
+    help
+      Enable basic block chaining for translated code.
+      Links consecutive blocks to avoid dispatch overhead.
+
+      Improves JIT performance significantly.
+
+config LTO
+    bool "Link-Time Optimization"
+    default y
+    depends on CC_IS_GCC || CC_IS_CLANG
+    help
+      Enable link-time optimization for smaller, faster binaries.
+      Increases build time but improves runtime performance.
+
+endmenu
+
+# Debugging and Development
+
+menu "Debugging"
+
+config GDBSTUB
+    bool "GDB Remote Debugging"
+    default n
+    depends on !CC_IS_EMCC
+    help
+      Enable GDB remote debugging stub.
+      Allows debugging RISC-V programs with gdb.
+
+      Connect with: riscv32-unknown-elf-gdb -ex "target remote :1234"
+
+config LOG_COLOR
+    bool "Colored Log Output"
+    default y
+    help
+      Enable ANSI color codes in log output.
+      Improves readability of debug messages.
+
+config UBSAN
+    bool "Undefined Behavior Sanitizer"
+    default n
+    depends on CC_IS_GCC || CC_IS_CLANG
+    help
+      Enable UndefinedBehaviorSanitizer for detecting UB at runtime.
+      Useful for development and debugging, not for production.
+
+endmenu
+
+# SDL Graphics and Audio
+
+menu "Graphics and Audio"
+
+config SDL
+    bool "SDL2 Graphics Support"
+    default y
+    depends on HAVE_SDL2 || CC_IS_EMCC
+    help
+      Enable SDL2-based graphics and input support.
+      Required for graphical applications like Doom and Quake.
+
+      For WebAssembly builds, uses Emscripten SDL2 port.
+
+config SDL_MIXER
+    bool "SDL2_mixer Audio Support"
+    default y
+    depends on SDL && (HAVE_SDL2_MIXER || CC_IS_EMCC)
+    help
+      Enable SDL2_mixer for audio playback.
+      Supports WAV and MIDI formats.
+
+endmenu
+
+# Testing
+
+menu "Testing"
+
+config ARCH_TEST
+    bool "RISC-V Architecture Tests"
+    default n
+    help
+      Build for RISC-V architecture compliance testing.
+      Used by 'make arch-test' target.
+
+endmenu
+
+# Build Options
+
+menu "Build Options"
+
+config OPTIMIZE_LEVEL
+    int "Optimization Level (0-3)"
+    default 2
+    range 0 3
+    help
+      Compiler optimization level:
+        0 - No optimization (fastest compile)
+        1 - Basic optimization
+        2 - Standard optimization (default)
+        3 - Aggressive optimization
+
+config OPTIMIZE_SIZE
+    bool "Optimize for Size (-Os)"
+    default n
+    help
+      Trade speed for smaller binary size.
+      Recommended for embedded or WebAssembly deployments.
+
+config DEBUG_SYMBOLS
+    bool "Include Debug Symbols (-g)"
+    default n
+    help
+      Generate debug information for gdb/lldb.
+      Increases binary size significantly.
+
+endmenu
+
+# Configuration marker
+config CONFIGURED
+    bool
+    default y

--- a/configs/ci_defconfig
+++ b/configs/ci_defconfig
@@ -1,0 +1,3 @@
+# CI configuration with architecture tests
+# CONFIG_LTO is not set
+CONFIG_ARCH_TEST=y

--- a/configs/defconfig
+++ b/configs/defconfig
@@ -1,0 +1,47 @@
+# rv32emu default configuration
+# Standard desktop build with all extensions enabled
+
+# RISC-V ISA Configuration
+CONFIG_RV32I=y
+# CONFIG_RV32E is not set
+CONFIG_EXT_M=y
+CONFIG_EXT_A=y
+CONFIG_EXT_F=y
+CONFIG_EXT_C=y
+CONFIG_Zicsr=y
+CONFIG_Zifencei=y
+CONFIG_Zba=y
+CONFIG_Zbb=y
+CONFIG_Zbc=y
+CONFIG_Zbs=y
+
+# Execution Modes
+CONFIG_INTERPRETER_ONLY=y
+# CONFIG_JIT is not set
+# CONFIG_T2C is not set
+# CONFIG_SYSTEM is not set
+# CONFIG_ELF_LOADER is not set
+
+# Performance Options
+CONFIG_MOP_FUSION=y
+CONFIG_BLOCK_CHAINING=y
+CONFIG_LTO=y
+
+# Debugging
+# CONFIG_GDBSTUB is not set
+CONFIG_LOG_COLOR=y
+# CONFIG_UBSAN is not set
+
+# Graphics and Audio
+CONFIG_SDL=y
+CONFIG_SDL_MIXER=y
+
+# Testing
+# CONFIG_ARCH_TEST is not set
+
+# Build Options
+CONFIG_OPTIMIZE_LEVEL=2
+# CONFIG_OPTIMIZE_SIZE is not set
+# CONFIG_DEBUG_SYMBOLS is not set
+
+CONFIG_CONFIGURED=y

--- a/configs/jit_defconfig
+++ b/configs/jit_defconfig
@@ -1,0 +1,3 @@
+# JIT compilation with tiered optimization
+CONFIG_JIT=y
+CONFIG_T2C=y

--- a/configs/mini_defconfig
+++ b/configs/mini_defconfig
@@ -1,0 +1,9 @@
+# Minimal build without SDL for embedded use
+# CONFIG_EXT_F is not set
+# CONFIG_Zba is not set
+# CONFIG_Zbb is not set
+# CONFIG_Zbc is not set
+# CONFIG_Zbs is not set
+# CONFIG_SDL is not set
+# CONFIG_SDL_MIXER is not set
+CONFIG_OPTIMIZE_SIZE=y

--- a/configs/system_defconfig
+++ b/configs/system_defconfig
@@ -1,0 +1,2 @@
+# System emulation for Linux kernel
+CONFIG_SYSTEM=y

--- a/configs/wasm_defconfig
+++ b/configs/wasm_defconfig
@@ -1,0 +1,3 @@
+# WebAssembly build with Emscripten
+# CONFIG_LTO is not set
+CONFIG_OPTIMIZE_LEVEL=3

--- a/docs/prebuilt.md
+++ b/docs/prebuilt.md
@@ -73,7 +73,8 @@ There are still some prebuilt standalone RISC-V binaries under `build/` director
 ## Run benchmarks
 
 ```shell
-$ make <your-config>
+$ make defconfig          # Or: make jit_defconfig for JIT-enabled build
+$ make
 $ build/rv32emu <benchmark>
 ```
 

--- a/mk/artifact.mk
+++ b/mk/artifact.mk
@@ -55,6 +55,10 @@ endef
 
 LATEST_RELEASE ?=
 
+# Only fetch releases when artifact-related targets are requested
+# This prevents network calls during unrelated targets like 'make defconfig'
+ARTIFACT_TARGETS := artifact fetch-checksum scimark2 ieeelib
+ifneq ($(filter $(ARTIFACT_TARGETS),$(MAKECMDGOALS)),)
 ifeq ($(call has, PREBUILT), 1)
     # On macOS/arm64 Github runner, let's leverage the ${{ secrets.GITHUB_TOKEN }} to prevent 403 rate limit error.
     # Thus, the LATEST_RELEASE tag is defined at Github job steps, no need to fetch them here.
@@ -67,6 +71,10 @@ ifeq ($(call has, PREBUILT), 1)
              $(call fetch-releases-tag,ELF,rv32emu-prebuilt.tar.gz,Prebuilt benchmark)
          endif
     endif
+endif
+endif
+
+ifeq ($(call has, PREBUILT), 1)
     PREBUILT_BLOB_URL = https://github.com/sysprog21/rv32emu-prebuilt/releases/download/$(LATEST_RELEASE)
 else
   # Since rv32emu only supports the dynamic binary translation of integer instruction in tiered compilation currently,

--- a/mk/compat.mk
+++ b/mk/compat.mk
@@ -1,0 +1,126 @@
+# Backward compatibility layer for ENABLE_* flags
+# Converts legacy ENABLE_* variables to CONFIG_* for Kconfig integration
+#
+# This allows existing CI/CD scripts and build commands to continue working
+# with the new Kconfig-based build system.
+#
+# Usage: ENABLE_JIT=1 make  ->  Automatically sets CONFIG_JIT=y
+#
+# Conflict Resolution:
+#   When the same flag appears multiple times (e.g., 'make ENABLE_JIT=0 ENABLE_JIT=1'),
+#   GNU Make uses the LAST value specified. This layer respects that behavior.
+#
+# Accepted Values (whitespace is trimmed):
+#   Enable:  1, y, yes, true, Y, YES, TRUE, Yes, True
+#   Disable: 0, n, no, false, N, NO, FALSE, No, False
+#
+# Deprecation: This compatibility layer will be removed in a future release.
+# Please migrate to using 'make defconfig' or 'make <name>_defconfig'
+
+# Normalize a value to either 'y', 'n', or empty (unknown)
+# Usage: $(call normalize-bool,VALUE)
+# Returns: y (enabled), n (disabled), or empty (invalid/unknown)
+# Note: Strips whitespace and handles common case variations
+normalize-bool = $(strip \
+    $(if $(filter 1 y yes true Y YES TRUE Yes True,$(strip $(1))),y,\
+    $(if $(filter 0 n no false N NO FALSE No False,$(strip $(1))),n,)))
+
+# Helper to convert ENABLE_* to CONFIG_* with value normalization
+# Usage: $(call enable-to-config,FEATURE)
+# Note: Uses 'override' to ensure command-line ENABLE_* takes precedence over .config
+define enable-to-config
+ifdef ENABLE_$(1)
+    ENABLE_$(1)_NORMALIZED := $$(call normalize-bool,$$(ENABLE_$(1)))
+    ifeq ($$(ENABLE_$(1)_NORMALIZED),y)
+        override CONFIG_$(1) := y
+    else ifeq ($$(ENABLE_$(1)_NORMALIZED),n)
+        override CONFIG_$(1) := n
+    else
+        $$(warning Invalid value for ENABLE_$(1)='$$(ENABLE_$(1))'. Use 0/1, y/n, yes/no, or true/false.)
+    endif
+endif
+endef
+
+# Core extensions
+$(eval $(call enable-to-config,EXT_M))
+$(eval $(call enable-to-config,EXT_A))
+$(eval $(call enable-to-config,EXT_F))
+$(eval $(call enable-to-config,EXT_C))
+
+# RV32E mode (Embedded, 16 registers)
+$(eval $(call enable-to-config,RV32E))
+
+# Bit manipulation extensions
+$(eval $(call enable-to-config,Zba))
+$(eval $(call enable-to-config,Zbb))
+$(eval $(call enable-to-config,Zbc))
+$(eval $(call enable-to-config,Zbs))
+
+# CSR and fence extensions
+$(eval $(call enable-to-config,Zicsr))
+$(eval $(call enable-to-config,Zifencei))
+
+# Execution modes
+# Note: JIT is handled separately below (requires CONFIG_INTERPRETER_ONLY coordination)
+$(eval $(call enable-to-config,SYSTEM))
+$(eval $(call enable-to-config,ELF_LOADER))
+$(eval $(call enable-to-config,T2C))
+
+# Performance options
+$(eval $(call enable-to-config,MOP_FUSION))
+$(eval $(call enable-to-config,BLOCK_CHAINING))
+$(eval $(call enable-to-config,LTO))
+
+# Debugging
+$(eval $(call enable-to-config,GDBSTUB))
+$(eval $(call enable-to-config,UBSAN))
+
+# Graphics and audio
+$(eval $(call enable-to-config,SDL))
+$(eval $(call enable-to-config,SDL_MIXER))
+
+# Testing
+$(eval $(call enable-to-config,ARCH_TEST))
+
+# Build options
+$(eval $(call enable-to-config,PREBUILT))
+
+# Special handling for JIT mode - set INTERPRETER_ONLY based on JIT
+# JIT requires coordinated CONFIG_INTERPRETER_ONLY setting, so handled separately
+ifdef ENABLE_JIT
+    ENABLE_JIT_NORMALIZED := $(call normalize-bool,$(ENABLE_JIT))
+    ifeq ($(ENABLE_JIT_NORMALIZED),y)
+        override CONFIG_INTERPRETER_ONLY := n
+        override CONFIG_JIT := y
+    else ifeq ($(ENABLE_JIT_NORMALIZED),n)
+        override CONFIG_INTERPRETER_ONLY := y
+        override CONFIG_JIT := n
+    else
+        $(warning Invalid value for ENABLE_JIT='$(ENABLE_JIT)'. Use 0/1, y/n, yes/no, or true/false.)
+    endif
+endif
+
+# Handle optimization level
+ifdef OPT_LEVEL
+    # Convert -O0, -O2, -Ofast to numeric levels
+    ifeq ($(OPT_LEVEL),-O0)
+        override CONFIG_OPTIMIZE_LEVEL := 0
+    else ifeq ($(OPT_LEVEL),-O1)
+        override CONFIG_OPTIMIZE_LEVEL := 1
+    else ifeq ($(OPT_LEVEL),-O2)
+        override CONFIG_OPTIMIZE_LEVEL := 2
+    else ifeq ($(OPT_LEVEL),-O3)
+        override CONFIG_OPTIMIZE_LEVEL := 3
+    else ifeq ($(OPT_LEVEL),-Ofast)
+        override CONFIG_OPTIMIZE_LEVEL := 3
+    else ifeq ($(OPT_LEVEL),-Os)
+        override CONFIG_OPTIMIZE_SIZE := y
+    else
+        $(warning Invalid OPT_LEVEL='$(OPT_LEVEL)'. Use -O0, -O1, -O2, -O3, -Ofast, or -Os.)
+    endif
+endif
+
+# Handle INITRD_SIZE for system emulation
+ifdef INITRD_SIZE
+    override CONFIG_INITRD_SIZE := $(INITRD_SIZE)
+endif

--- a/mk/deps.mk
+++ b/mk/deps.mk
@@ -1,0 +1,92 @@
+# Unified dependency detection
+#
+# Provides helper functions for detecting libraries and packages.
+
+ifndef _MK_DEPS_INCLUDED
+_MK_DEPS_INCLUDED := 1
+
+# Verbosity control
+ifeq ($(V),1)
+    DEVNULL :=
+else
+    DEVNULL := 2>/dev/null
+endif
+
+# pkg-config for cross-compilation
+PKG_CONFIG ?= pkg-config
+
+# Dependency Detection Functions
+
+# dep(type, packages)
+# type: cflags | libs
+# packages: space-separated package names
+#
+# Usage:
+#   CFLAGS += $(call dep,cflags,sdl2)
+#   LDFLAGS += $(call dep,libs,sdl2)
+#
+define dep
+$(shell \
+    for pkg in $(2); do \
+        if command -v $${pkg}-config >/dev/null 2>&1; then \
+            $${pkg}-config --$(1) $(DEVNULL); \
+        elif command -v $(PKG_CONFIG) >/dev/null 2>&1; then \
+            $(PKG_CONFIG) --$(1) $$pkg $(DEVNULL); \
+        fi; \
+    done \
+)
+endef
+
+# pkg-exists(package)
+# Returns "y" if found, empty otherwise
+#
+define pkg-exists
+$(shell \
+    if command -v $(1)-config >/dev/null 2>&1; then \
+        echo y; \
+    elif $(PKG_CONFIG) --exists $(1) $(DEVNULL); then \
+        echo y; \
+    fi \
+)
+endef
+
+# Common Dependency Checks
+
+# SDL2
+HAVE_SDL2 := $(call pkg-exists,sdl2)
+ifeq ($(HAVE_SDL2),y)
+    SDL2_CFLAGS := $(call dep,cflags,sdl2)
+    SDL2_LIBS := $(call dep,libs,sdl2)
+endif
+
+# SDL2_mixer
+HAVE_SDL2_MIXER := $(shell $(PKG_CONFIG) --exists SDL2_mixer $(DEVNULL) && echo y)
+ifeq ($(HAVE_SDL2_MIXER),y)
+    SDL2_MIXER_LIBS := $(call dep,libs,SDL2_mixer)
+endif
+
+# Export for Kconfig
+export HAVE_SDL2
+export HAVE_SDL2_MIXER
+
+# SHA Utilities
+
+SHA1SUM := $(shell which sha1sum 2>/dev/null)
+ifndef SHA1SUM
+    SHA1SUM := $(shell which shasum 2>/dev/null)
+    ifndef SHA1SUM
+        SHA1SUM := echo
+    endif
+endif
+
+SHA256SUM := $(shell which sha256sum 2>/dev/null)
+ifndef SHA256SUM
+    SHA256SUM_TMP := $(shell which shasum 2>/dev/null)
+    ifdef SHA256SUM_TMP
+        SHA256SUM := $(SHA256SUM_TMP) -a 256
+    else
+        SHA256SUM := echo
+    endif
+endif
+
+endif # _MK_DEPS_INCLUDED

--- a/mk/system.mk
+++ b/mk/system.mk
@@ -1,23 +1,37 @@
 # Peripherals for system emulation
-ifeq ($(call has, SYSTEM), 1)
+#
+# Provides device emulation for running the Linux kernel.
+
+ifndef _MK_SYSTEM_INCLUDED
+_MK_SYSTEM_INCLUDED := 1
+
+# Memory Size Utilities (used by all modes)
+MiB = 1024*1024
+compute_size = $(shell echo "obase=16; ibase=10; $(1)*$(MiB)" | bc)
+
+# System Mode Configuration
+
+ifeq ($(CONFIG_SYSTEM),y)
 
 CFLAGS += -Isrc/dtc/libfdt
-LIBFDT_HACK := $(shell git submodule update --init src/dtc)
+LIBFDT_HACK := $(shell git submodule update --init src/dtc 2>/dev/null)
 
 DEV_SRC := src/devices
+DEV_OUT := $(OUT)/devices
 
 DTC ?= dtc
 BUILD_DTB := $(OUT)/minimal.dtb
-$(BUILD_DTB): $(DEV_SRC)/minimal.dts
+
+# Device Tree compilation
+$(BUILD_DTB): $(DEV_SRC)/minimal.dts | $(OUT)
 	$(VECHO) " DTC\t$@\n"
 	$(Q)$(CC) -nostdinc -E -P -x assembler-with-cpp -undef $(CFLAGS_dt) $^ | $(DTC) - > $@
 
-# Assume the system has either GCC or Clang
-NATIVE_CC := $(shell which gcc || which clang)
+# Native compiler for build tools (emcc generates wasm, need native for tools)
+NATIVE_CC := $(shell which gcc 2>/dev/null || which clang 2>/dev/null)
 
 BIN_TO_C := $(OUT)/bin2c
-$(BIN_TO_C): tools/bin2c.c
-# emcc generates wasm but not executable, so fallback to use GCC or Clang
+$(BIN_TO_C): tools/bin2c.c | $(OUT)
 ifeq ("$(CC_IS_EMCC)", "1")
 	$(Q)$(NATIVE_CC) -Wall -o $@ $^
 else
@@ -29,26 +43,82 @@ $(BUILD_DTB2C): $(BIN_TO_C) $(BUILD_DTB)
 	$(VECHO) "  BIN2C\t$@\n"
 	$(Q)$(BIN_TO_C) $(BUILD_DTB) > $@
 
-$(DEV_OUT)/%.o: $(DEV_SRC)/%.c $(CONFIG_FILE) $(deps_emcc) | $(DEV_OUT)
-	$(VECHO) "  CC\t$@\n"
-	$(Q)$(CC) -o $@ $(CFLAGS) $(CFLAGS_emcc) -c -MMD -MF $@.d $<
-
+# Device object compilation
 $(DEV_OUT):
 	$(Q)mkdir -p $@
 
+$(DEV_OUT)/%.o: $(DEV_SRC)/%.c | $(DEV_OUT)
+	$(VECHO) "  CC\t$@\n"
+	$(Q)$(CC) -o $@ $(CFLAGS) $(CFLAGS_emcc) -c -MMD -MF $@.d $<
+
 DEV_OBJS := $(patsubst $(DEV_SRC)/%.c, $(DEV_OUT)/%.o, $(wildcard $(DEV_SRC)/*.c))
-deps := $(DEV_OBJS:%.o=%.o.d)
+deps += $(DEV_OBJS:%.o=%.o.d)
 
 OBJS_EXT += system.o
 OBJS_EXT += dtc/libfdt/fdt.o dtc/libfdt/fdt_ro.o dtc/libfdt/fdt_rw.o dtc/libfdt/fdt_wip.o
 
-# system target execution by using default dependencies
+# Memory Layout Configuration
+
+# Memory configuration for kernel mode (ELF_LOADER=n)
+ifneq ($(CONFIG_ELF_LOADER),y)
+
+MEM_START ?= 0
+MEM_SIZE ?= 512
+DTB_SIZE ?= 1
+
+# Auto-detect INITRD_SIZE from actual rootfs.cpio if available
+INITRD_FILE := $(OUT)/linux-image/rootfs.cpio
+ifneq ($(wildcard $(INITRD_FILE)),)
+    INITRD_ACTUAL_BYTES := $(shell stat -f%z $(INITRD_FILE) 2>/dev/null || stat -c%s $(INITRD_FILE) 2>/dev/null)
+    ifneq ($(INITRD_ACTUAL_BYTES),)
+        INITRD_SIZE ?= $(shell echo "$$(( ($(INITRD_ACTUAL_BYTES) / 1048576) + 2 ))")
+    else
+        INITRD_SIZE ?= 32
+    endif
+else
+    INITRD_SIZE ?= 32
+endif
+
+REAL_MEM_SIZE = $(call compute_size, $(MEM_SIZE))
+REAL_DTB_SIZE = $(call compute_size, $(DTB_SIZE))
+REAL_INITRD_SIZE = $(call compute_size, $(INITRD_SIZE))
+
+CFLAGS_dt += -DMEM_START=0x$(MEM_START) \
+             -DMEM_END=0x$(shell echo "obase=16; ibase=16; $(MEM_START)+$(REAL_MEM_SIZE)" | bc) \
+             -DINITRD_START=0x$(shell echo "obase=16; ibase=16; \
+                              $(REAL_MEM_SIZE) - $(call compute_size, ($(INITRD_SIZE)+$(DTB_SIZE)))" | bc) \
+             -DINITRD_END=0x$(shell echo "obase=16; ibase=16; \
+                            $(REAL_MEM_SIZE) - $(call compute_size, $(DTB_SIZE)) - 1" | bc)
+
+CFLAGS += -DMEM_SIZE=0x$(REAL_MEM_SIZE) -DDTB_SIZE=0x$(REAL_DTB_SIZE) -DINITRD_SIZE=0x$(REAL_INITRD_SIZE)
+
+else
+# ELF loader mode: 4GB virtual address space
+USER_MEM_SIZE ?= 4096
+CFLAGS += -DMEM_SIZE=0x$(call compute_size, $(USER_MEM_SIZE))ULL
+endif
+
+# System Target
+
 LINUX_IMAGE_DIR := linux-image
 system_action := ($(BIN) -k $(OUT)/$(LINUX_IMAGE_DIR)/Image -i $(OUT)/$(LINUX_IMAGE_DIR)/rootfs.cpio)
 system_deps += artifact $(BUILD_DTB) $(BUILD_DTB2C) $(BIN)
+
 system: $(system_deps)
 	$(system_action)
 
 .PHONY: system
 
+else
+# Non-SYSTEM mode: 4GB virtual address space for user programs
+USER_MEM_SIZE ?= 4096
+CFLAGS += -DMEM_SIZE=0x$(call compute_size, $(USER_MEM_SIZE))ULL
 endif
+
+# Emscripten memory cap
+ifeq ("$(CC_IS_EMCC)", "1")
+CFLAGS := $(filter-out -DMEM_SIZE=%,$(CFLAGS))
+CFLAGS += -DMEM_SIZE=0x20000000ULL
+endif
+
+endif # _MK_SYSTEM_INCLUDED

--- a/mk/toolchain.mk
+++ b/mk/toolchain.mk
@@ -1,85 +1,211 @@
-CC_IS_EMCC :=
+# Compiler and toolchain detection with Kconfig integration
+#
+# This file detects the compiler type and sets up appropriate flags.
+# Works with Kconfig-based configuration via CONFIG_* variables.
+
+ifndef _MK_TOOLCHAIN_INCLUDED
+_MK_TOOLCHAIN_INCLUDED := 1
+
+# Cross-compilation support
+# Note: CROSS_COMPILE is auto-detected below if not provided by user
+SYSROOT ?=
+
+# Platform Detection
+
+UNAME_S := $(shell uname -s)
+UNAME_M := $(shell uname -m)
+
+ifeq ($(UNAME_S),Darwin)
+    PRINTF = printf
+else
+    PRINTF = env printf
+endif
+
+ifeq ($(UNAME_M),x86_64)
+    HOST_PLATFORM := x86
+else ifeq ($(UNAME_M),aarch64)
+    HOST_PLATFORM := aarch64
+else ifeq ($(UNAME_M),arm64)
+    HOST_PLATFORM := arm64
+else
+    HOST_PLATFORM := unknown
+endif
+
+# Compiler Detection
+
+# Set defaults
+CC      ?= cc
+AR      ?= ar
+RANLIB  ?= ranlib
+STRIP   ?= strip
+
+# Apply cross-compile prefix
+ifneq ($(CROSS_COMPILE),)
+    ifeq ($(origin CC),default)
+        CC      := $(CROSS_COMPILE)$(CC)
+        AR      := $(CROSS_COMPILE)$(AR)
+        RANLIB  := $(CROSS_COMPILE)$(RANLIB)
+        STRIP   := $(CROSS_COMPILE)$(STRIP)
+    endif
+endif
+
+# Host toolchain for build-time tools
+HOSTCC  ?= cc
+HOSTAR  ?= ar
+
+# Detect compiler type from version string
+# Note: Pipe directly to grep instead of storing in variable to avoid shell escaping issues
+CC_IS_EMCC  :=
 CC_IS_CLANG :=
-CC_IS_GCC :=
+CC_IS_GCC   :=
+
 ifneq ($(shell $(CC) --version | head -n 1 | grep emcc),)
     CC_IS_EMCC := 1
+else ifneq ($(shell $(CC) --version | head -n 1 | grep clang),)
+    CC_IS_CLANG := 1
+else ifneq ($(shell $(CC) --version 2>&1 | grep "Free Software Foundation"),)
+    CC_IS_GCC := 1
+endif
 
+# Verify supported compiler
+ifeq ("$(CC_IS_CLANG)$(CC_IS_GCC)$(CC_IS_EMCC)", "")
+$(error Unsupported compiler. Only GCC, Clang, and Emscripten are supported.)
+endif
+
+# Emscripten version detection
+ifeq ("$(CC_IS_EMCC)", "1")
     EMCC_VERSION := $(shell $(CC) --version | head -n 1 | cut -f10 -d ' ')
     EMCC_MAJOR := $(shell echo $(EMCC_VERSION) | cut -f1 -d.)
     EMCC_MINOR := $(shell echo $(EMCC_VERSION) | cut -f2 -d.)
     EMCC_PATCH := $(shell echo $(EMCC_VERSION) | cut -f3 -d.)
 
-    # When the emcc version is not 3.1.51, the latest SDL2_mixer library is fetched by emcc and music might not be played in the web browser
-    SDL_MUSIC_PLAY_AT_EMCC_MAJOR := 3
-    SDL_MUSIC_PLAY_AT_EMCC_MINOR := 1
-    SDL_MUSIC_PLAY_AT_EMCC_PATCH := 51
-    SDL_MUSIC_CANNOT_PLAY_WARNING := Video games music might not be played. You may switch emcc to version $(SDL_MUSIC_PLAY_AT_EMCC_MAJOR).$(SDL_MUSIC_PLAY_AT_EMCC_MINOR).$(SDL_MUSIC_PLAY_AT_EMCC_PATCH)
-    ifeq ($(call version_eq,\
-	    $(EMCC_MAJOR),$(EMCC_MINOR),$(EMCC_PATCH),\
-	    $(SDL_MUSIC_PLAY_AT_EMCC_MAJOR),$(SDL_MUSIC_PLAY_AT_EMCC_MINOR),$(SDL_MUSIC_PLAY_AT_EMCC_PATCH)), 0)
-        $(warning $(SDL_MUSIC_CANNOT_PLAY_WARNING))
-    endif
-
-    # see commit 165c1a3 of emscripten
-    MIMALLOC_SUPPORT_SINCE_MAJOR := 3
-    MIMALLOC_SUPPORT_SINCE_MINOR := 1
-    MIMALLOC_SUPPORT_SINCE_PATCH := 50
-    MIMALLOC_UNSUPPORTED_WARNING := mimalloc is supported after version $(MIMALLOC_SUPPORT_SINCE_MAJOR).$(MIMALLOC_SUPPORT_SINCE_MINOR).$(MIMALLOC_SUPPORT_SINCE_PATCH)
-    ifeq ($(call version_gte,\
-	    $(EMCC_MAJOR),$(EMCC_MINOR),$(EMCC_PATCH),\
-	    $(MIMALLOC_SUPPORT_SINCE_MAJOR),$(MIMALLOC_SUPPORT_SINCE_MINOR),$(MIMALLOC_SUPPORT_SINCE_PATCH)), 1)
-        CFLAGS_emcc += -sMALLOC=mimalloc
-    else
-        $(warning $(MIMALLOC_UNSUPPORTED_WARNING))
-    endif
-else ifneq ($(shell $(CC) --version | head -n 1 | grep clang),)
-     CC_IS_CLANG := 1
-else ifneq ($(shell $(CC) --version | grep "Free Software Foundation"),)
-     CC_IS_GCC := 1
+    # Override toolchain for Emscripten
+    AR     := emar
+    RANLIB := emranlib
+    STRIP  := emstrip
 endif
 
-ifeq ("$(CC_IS_CLANG)$(CC_IS_GCC)$(CC_IS_EMCC)", "")
-$(error "Only supported GCC/Clang/Emcc")
+# RISC-V Cross-Compiler Detection
+
+TOOLCHAIN_LIST := riscv-none-elf- \
+                  riscv32-unknown-elf- \
+                  riscv64-unknown-elf- \
+                  riscv-none-embed-
+
+define check-cross-tools
+$(shell which $(1)gcc >/dev/null 2>&1 && \
+        which $(1)cpp >/dev/null 2>&1 && \
+        echo | $(1)cpp -dM - 2>/dev/null | grep __riscv >/dev/null && \
+        echo "$(1) ")
+endef
+
+# Auto-detect RISC-V toolchain if not provided by user
+ifeq ($(CROSS_COMPILE),)
+    CROSS_COMPILE := $(word 1,$(foreach prefix,$(TOOLCHAIN_LIST),$(call check-cross-tools,$(prefix))))
 endif
+export CROSS_COMPILE
+
+# CET Protection Flags
 
 CFLAGS_NO_CET :=
 processor := $(shell uname -m)
 ifeq ($(processor),$(filter $(processor),i386 x86_64))
-    # GCC and Clang can generate support code for Intel's Control-flow
-    # Enforcement Technology (CET) through this compiler flag:
-    # -fcf-protection=[full]
+    # Disable Intel's Control-flow Enforcement Technology for JIT
     CFLAGS_NO_CET := -fcf-protection=none
 endif
 
-# As of Xcode 15, linker warnings are emitted if duplicate '-l' options are
-# present. Until such linkopts can be deduped by the build system, we disable
-# these warnings.
+# macOS Linker Compatibility
+
 ifeq ($(UNAME_S),Darwin)
-    ifeq ("$(CC_IS_CLANG)$(CC_IS_GCC)", "1")
-        ifneq ($(shell ld -version_details | cut -f2 -d: | grep 15.0.0),)
+    ifneq ("$(CC_IS_CLANG)$(CC_IS_GCC)", "")
+        # Xcode 15+ warns about duplicate -l options
+        LD_VERSION := $(shell ld -version_details 2>/dev/null | head -n 1)
+        ifneq ($(shell echo "$(LD_VERSION)" | grep -E "15\.[0-9]"),)
             LDFLAGS += -Wl,-no_warn_duplicate_libraries
         endif
     endif
 endif
 
-# Utilities
-AR ?= ar
+# Kconfig-derived build flags
 
-# Supported GNU Toolchain for RISC-V
-TOOLCHAIN_LIST := riscv-none-elf-      \
-		  riscv32-unknown-elf- \
-		  riscv64-unknown-elf- \
-		  riscv-none-embed-
+KCONFIG_CFLAGS :=
+KCONFIG_LDFLAGS :=
 
-define check-cross-tools
-$(shell which $(1)gcc >/dev/null &&
-        which $(1)cpp >/dev/null &&
-        echo | $(1)cpp -dM - | grep __riscv >/dev/null &&
-        echo "$(1) ")
+# Optimization level
+ifeq ($(CONFIG_OPTIMIZE_SIZE),y)
+    KCONFIG_CFLAGS += -Os
+else
+    OPT_LEVEL := $(if $(CONFIG_OPTIMIZE_LEVEL),-O$(CONFIG_OPTIMIZE_LEVEL),-O2)
+    KCONFIG_CFLAGS += $(OPT_LEVEL)
+endif
+
+# Debug symbols
+ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
+    KCONFIG_CFLAGS += -g
+endif
+
+# Link-time optimization
+ifeq ($(CONFIG_LTO),y)
+    ifeq ("$(CC_IS_EMCC)", "1")
+        ifeq ($(CONFIG_SDL),y)
+            $(warning LTO is not supported for SDL builds with Emscripten)
+        else
+            KCONFIG_CFLAGS += -flto
+            KCONFIG_LDFLAGS += -flto
+        endif
+    else ifeq ("$(CC_IS_GCC)", "1")
+        KCONFIG_CFLAGS += -flto=auto
+        KCONFIG_LDFLAGS += -flto=auto
+    else ifeq ("$(CC_IS_CLANG)", "1")
+        KCONFIG_CFLAGS += -flto=thin -fsplit-lto-unit
+        KCONFIG_LDFLAGS += -flto=thin
+    endif
+endif
+
+# Undefined behavior sanitizer
+ifeq ($(CONFIG_UBSAN),y)
+    KCONFIG_CFLAGS += -fsanitize=undefined -fno-sanitize=alignment -fno-sanitize-recover=all
+    KCONFIG_LDFLAGS += -fsanitize=undefined -fno-sanitize=alignment -fno-sanitize-recover=all
+endif
+
+# Sysroot support
+ifneq ($(SYSROOT),)
+    KCONFIG_CFLAGS += --sysroot=$(SYSROOT)
+    KCONFIG_LDFLAGS += --sysroot=$(SYSROOT)
+endif
+
+# LLVM 18 Detection for T2C
+
+# Find LLVM 18 config (centralized detection)
+# Priority: llvm-config-18 > Homebrew llvm@18 > llvm-config with version check
+# Note: Each fallback is independent - brew presence doesn't block llvm-config check
+define find-llvm-config
+$(strip \
+    $(or \
+        $(shell which llvm-config-18 2>/dev/null),\
+        $(shell brew --prefix llvm@18 2>/dev/null | xargs -I{} sh -c 'test -x {}/bin/llvm-config && echo {}/bin/llvm-config' 2>/dev/null),\
+        $(shell which llvm-config 2>/dev/null | xargs -I{} sh -c '{} --version 2>/dev/null | grep -q "^18\." && echo {}' 2>/dev/null)))
 endef
 
-# TODO: support clang/llvm based cross compilers
-# TODO: support native RISC-V compilers
-CROSS_COMPILE ?= $(word 1,$(foreach prefix,$(TOOLCHAIN_LIST),$(call check-cross-tools, $(prefix))))
+# Simpler Homebrew detection for library path
+HOMEBREW_LLVM_PREFIX := $(shell which brew >/dev/null 2>&1 && brew --prefix llvm@18 2>/dev/null)
 
-export CROSS_COMPILE
+# Export for use in Makefile
+LLVM_CONFIG := $(call find-llvm-config)
+LLVM_FROM_HOMEBREW := $(if $(and $(HOMEBREW_LLVM_PREFIX),$(findstring $(HOMEBREW_LLVM_PREFIX),$(LLVM_CONFIG))),yes,)
+
+# Add Homebrew library path if using Homebrew LLVM
+ifeq ($(LLVM_FROM_HOMEBREW),yes)
+    LDFLAGS += -L$(HOMEBREW_LLVM_PREFIX)/lib
+endif
+
+# Version Comparison Utilities
+
+version_num = $(shell printf "%d%03d%03d" $(1) $(2) $(3) 2>/dev/null || echo 0)
+version_eq = $(shell echo "$$(($(call version_num,$(1),$(2),$(3)) == $(call version_num,$(4),$(5),$(6))))")
+version_lt = $(shell echo "$$(($(call version_num,$(1),$(2),$(3)) < $(call version_num,$(4),$(5),$(6))))")
+version_lte = $(shell echo "$$(($(call version_num,$(1),$(2),$(3)) <= $(call version_num,$(4),$(5),$(6))))")
+version_gt = $(shell echo "$$(($(call version_num,$(1),$(2),$(3)) > $(call version_num,$(4),$(5),$(6))))")
+version_gte = $(shell echo "$$(($(call version_num,$(1),$(2),$(3)) >= $(call version_num,$(4),$(5),$(6))))")
+
+endif # _MK_TOOLCHAIN_INCLUDED

--- a/mk/wasm.mk
+++ b/mk/wasm.mk
@@ -1,3 +1,10 @@
+# WebAssembly build configuration
+#
+# Provides Emscripten-specific build flags and targets.
+
+ifndef _MK_WASM_INCLUDED
+_MK_WASM_INCLUDED := 1
+
 CFLAGS_emcc ?=
 deps_emcc :=
 ASSETS := assets/wasm
@@ -5,155 +12,134 @@ WEB_HTML_RESOURCES := $(ASSETS)/html
 WEB_JS_RESOURCES := $(ASSETS)/js
 EXPORTED_FUNCS := _main,_indirect_rv_halt,_get_input_buf,_get_input_buf_cap,_set_input_buf_size
 DEMO_DIR := demo
+
 WEB_FILES := $(BIN).js \
              $(BIN).wasm \
              $(BIN).worker.js \
              $(OUT)/elf_list.js
 
+# Only configure Emscripten settings when using emcc
 ifeq ("$(CC_IS_EMCC)", "1")
+
 BIN := $(BIN).js
 
-# TCO
+# Tail-call optimization
 CFLAGS += -mtail-call
 
-# Build emscripten-port SDL
-ifeq ($(call has, SDL), 1)
-# Disable STRICT mode to avoid -Werror in SDL2_mixer port compilation.
-# The emscripten-ports/SDL2_mixer was archived in Jan 2024 and has warnings
-# in music_modplug.c that become fatal errors under STRICT mode.
+# SDL configuration for Emscripten
+ifeq ($(CONFIG_SDL),y)
+# Disable STRICT mode to avoid -Werror in SDL2_mixer port compilation
 CFLAGS_emcc += -sSTRICT=0 -sUSE_SDL=2 -sSDL2_MIXER_FORMATS=wav,mid -sUSE_SDL_MIXER=2
 OBJS_EXT += syscall_sdl.o
 LDFLAGS += -pthread
 endif
 
-# More build flags
+# Emscripten build flags
 CFLAGS_emcc += -sINITIAL_MEMORY=2GB \
-	       -sALLOW_MEMORY_GROWTH \
-	       -s"EXPORTED_FUNCTIONS=$(EXPORTED_FUNCS)" \
-	       -sSTACK_SIZE=4MB \
-	       -sPTHREAD_POOL_SIZE=navigator.hardwareConcurrency \
-	       --embed-file build/timidity@/etc/timidity \
-	       -DMEM_SIZE=0x20000000 \
-	       -DCYCLE_PER_STEP=2000000 \
-	       -O3 \
-	       -w
+               -sALLOW_MEMORY_GROWTH \
+               -s"EXPORTED_FUNCTIONS=$(EXPORTED_FUNCS)" \
+               -sSTACK_SIZE=4MB \
+               -sPTHREAD_POOL_SIZE=navigator.hardwareConcurrency \
+               --embed-file build/timidity@/etc/timidity \
+               -DMEM_SIZE=0x20000000 \
+               -DCYCLE_PER_STEP=2000000 \
+               -O3 \
+               -w
 
-ifeq ($(call has, SYSTEM), 1)
+# System mode assets
+ifeq ($(CONFIG_SYSTEM),y)
 CFLAGS_emcc += --embed-file build/linux-image/Image@Image \
-	       --embed-file build/linux-image/rootfs.cpio@rootfs.cpio \
-	       --embed-file build/minimal.dtb@/minimal.dtb \
-	       --pre-js $(WEB_JS_RESOURCES)/system-pre.js
+               --embed-file build/linux-image/rootfs.cpio@rootfs.cpio \
+               --embed-file build/minimal.dtb@/minimal.dtb \
+               --pre-js $(WEB_JS_RESOURCES)/system-pre.js
 else
 CFLAGS_emcc += --embed-file build/jit-bf.elf@/jit-bf.elf \
-	       --embed-file build/coro.elf@/coro.elf \
-	       --embed-file build/fibonacci.elf@/fibonacci.elf \
-	       --embed-file build/hello.elf@/hello.elf \
-	       --embed-file build/ieee754.elf@/ieee754.elf \
-	       --embed-file build/perfcount.elf@/perfcount.elf \
-	       --embed-file build/readelf.elf@/readelf.elf \
-	       --embed-file build/smolnes.elf@/smolnes.elf \
-	       --embed-file build/riscv32@/riscv32 \
-	       --embed-file build/DOOM1.WAD@/DOOM1.WAD \
-	       --embed-file build/id1/pak0.pak@/id1/pak0.pak \
-	       --pre-js $(WEB_JS_RESOURCES)/user-pre.js
+               --embed-file build/coro.elf@/coro.elf \
+               --embed-file build/fibonacci.elf@/fibonacci.elf \
+               --embed-file build/hello.elf@/hello.elf \
+               --embed-file build/ieee754.elf@/ieee754.elf \
+               --embed-file build/perfcount.elf@/perfcount.elf \
+               --embed-file build/readelf.elf@/readelf.elf \
+               --embed-file build/smolnes.elf@/smolnes.elf \
+               --embed-file build/riscv32@/riscv32 \
+               --embed-file build/DOOM1.WAD@/DOOM1.WAD \
+               --embed-file build/id1/pak0.pak@/id1/pak0.pak \
+               --pre-js $(WEB_JS_RESOURCES)/user-pre.js
 endif
 
+# mimalloc support detection
+MIMALLOC_SUPPORT_SINCE_MAJOR := 3
+MIMALLOC_SUPPORT_SINCE_MINOR := 1
+MIMALLOC_SUPPORT_SINCE_PATCH := 50
+ifeq ($(call version_gte,$(EMCC_MAJOR),$(EMCC_MINOR),$(EMCC_PATCH),$(MIMALLOC_SUPPORT_SINCE_MAJOR),$(MIMALLOC_SUPPORT_SINCE_MINOR),$(MIMALLOC_SUPPORT_SINCE_PATCH)), 1)
+    CFLAGS_emcc += -sMALLOC=mimalloc
+else
+    $(warning mimalloc requires Emscripten $(MIMALLOC_SUPPORT_SINCE_MAJOR).$(MIMALLOC_SUPPORT_SINCE_MINOR).$(MIMALLOC_SUPPORT_SINCE_PATCH)+)
+endif
 
+# ELF list generator
 $(OUT)/elf_list.js: artifact tools/gen-elf-list-js.py
 	$(Q)tools/gen-elf-list-js.py > $@
 
-# used to download all dependencies of elf executable and bundle into single wasm
+# Dependencies for WASM build
 deps_emcc += artifact $(OUT)/elf_list.js $(DOOM_DATA) $(QUAKE_DATA) $(TIMIDITY_DATA)
 
-# check browser version if supports TCO
-CHROME_MAJOR :=
-CHROME_MAJOR_VERSION_CHECK_CMD :=
+# Browser TCO Support Detection
+
 CHROME_SUPPORT_TCO_AT_MAJOR := 112
-CHROME_SUPPORT_TCO_INFO := Chrome supports TCO, you can use Chrome to request the wasm
-CHROME_NO_SUPPORT_TCO_WARNING := Chrome not found or Chrome must have at least version $(CHROME_SUPPORT_TCO_AT_MAJOR) in MAJOR to support TCO in wasm
-
-FIREFOX_MAJOR :=
-FIREFOX_MAJOR_VERSION_CHECK_CMD :=
 FIREFOX_SUPPORT_TCO_AT_MAJOR := 121
-FIREFOX_SUPPORT_TCO_INFO := Firefox supports TCO, you can use Firefox to request the wasm
-FIREFOX_NO_SUPPORT_TCO_WARNING := Firefox not found or Firefox must have at least version $(FIREFOX_SUPPORT_TCO_AT_MAJOR) in MAJOR to support TCO in wasm
-
-# Check WebAssembly section at https://webkit.org/blog/16301/webkit-features-in-safari-18-2/
-ifeq ($(UNAME_S),Darwin)
-SAFARI_MAJOR :=
-SAFARI_MINOR :=
-SAFARI_VERSION_CHECK_CMD :=
 SAFARI_SUPPORT_TCO_AT_MAJOR := 18
 SAFARI_SUPPORT_TCO_AT_MINOR := 2
-SAFARI_SUPPORT_TCO_INFO := Safari supports TCO, you can use Safari to request the wasm
-SAFARI_NO_SUPPORT_TCO_WARNING := Safari not found or Safari must have at least version $(SAFARI_SUPPORT_TCO_AT_MAJOR).$(SAFARI_SUPPORT_TCO_AT_MINOR) to support TCO in wasm
-endif
 
-# FIXME: for Windows
+# Browser detection (platform-specific)
 ifeq ($(UNAME_S),Darwin)
-    CHROME_MAJOR_VERSION_CHECK_CMD := "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --version | awk '{print $$3}' | cut -f1 -d.
-    FIREFOX_MAJOR_VERSION_CHECK_CMD := /Applications/Firefox.app/Contents/MacOS/firefox --version | awk '{print $$3}' | cut -f1 -d.
-    SAFARI_VERSION_CHECK_CMD := mdls -name kMDItemVersion /Applications/Safari.app | sed 's/"//g' | awk '{print $$3}'
+    CHROME_MAJOR := $(shell "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --version 2>/dev/null | awk '{print $$3}' | cut -f1 -d.)
+    FIREFOX_MAJOR := $(shell /Applications/Firefox.app/Contents/MacOS/firefox --version 2>/dev/null | awk '{print $$3}' | cut -f1 -d.)
+    SAFARI_VERSION := $(shell mdls -name kMDItemVersion /Applications/Safari.app 2>/dev/null | sed 's/"//g' | awk '{print $$3}')
 else ifeq ($(UNAME_S),Linux)
-    CHROME_MAJOR_VERSION_CHECK_CMD := google-chrome --version | awk '{print $$3}' | cut -f1 -d.
-    FIREFOX_MAJOR_VERSION_CHECK_CMD := firefox -v | awk '{print $$3}' | cut -f1 -d.
+    CHROME_MAJOR := $(shell google-chrome --version 2>/dev/null | awk '{print $$3}' | cut -f1 -d.)
+    FIREFOX_MAJOR := $(shell firefox -v 2>/dev/null | awk '{print $$3}' | cut -f1 -d.)
 endif
-CHROME_MAJOR := $(shell $(CHROME_MAJOR_VERSION_CHECK_CMD))
-FIREFOX_MAJOR := $(shell $(FIREFOX_MAJOR_VERSION_CHECK_CMD))
 
-# Chrome
+# Browser support notifications
+ifneq ($(CHROME_MAJOR),)
 ifeq ($(call version_gte,$(CHROME_MAJOR),,,$(CHROME_SUPPORT_TCO_AT_MAJOR),,), 1)
-    $(info $(call noticex, $(CHROME_SUPPORT_TCO_INFO)))
+    $(info $(call noticex, Chrome $(CHROME_MAJOR) supports TCO))
 else
-    $(warning $(call warnx, $(CHROME_NO_SUPPORT_TCO_WARNING)))
+    $(warning Chrome $(CHROME_MAJOR) does not support TCO (requires $(CHROME_SUPPORT_TCO_AT_MAJOR)+))
+endif
 endif
 
-# Firefox
+ifneq ($(FIREFOX_MAJOR),)
 ifeq ($(call version_gte,$(FIREFOX_MAJOR),,,$(FIREFOX_SUPPORT_TCO_AT_MAJOR),,), 1)
-    $(info $(call noticex, $(FIREFOX_SUPPORT_TCO_INFO)))
+    $(info $(call noticex, Firefox $(FIREFOX_MAJOR) supports TCO))
 else
-    $(warning $(call warnx, $(FIREFOX_NO_SUPPORT_TCO_WARNING)))
-endif
-
-# Safari
-ifeq ($(UNAME_S),Darwin)
-# ignore PATCH because the expression with PATCH(e.g., double dots x.x.x) becomes invalid number for the following bc cmd
-SAFARI_VERSION := $(shell $(SAFARI_VERSION_CHECK_CMD))
-SAFARI_MAJOR := $(shell echo $(SAFARI_VERSION) | cut -f1 -d.)
-SAFARI_MINOR := $(shell echo $(SAFARI_VERSION) | cut -f2 -d.)
-ifeq ($(call version_gte,$(SAFARI_MAJOR),$(SAFARI_MINOR),,$(SAFARI_SUPPORT_TCO_AT_MAJOR),$(SAFARI_SUPPORT_TCO_AT_MINOR),), 1)
-    $(info $(call noticex, $(SAFARI_SUPPORT_TCO_INFO)))
-else
-    $(warning $(call warnx, $(SAFARI_NO_SUPPORT_TCO_WARNING)))
+    $(warning Firefox $(FIREFOX_MAJOR) does not support TCO (requires $(FIREFOX_SUPPORT_TCO_AT_MAJOR)+))
 endif
 endif
 
-# used to serve wasm locally
+# Web Demo Server
+
 DEMO_IP := 127.0.0.1
 DEMO_PORT := 8000
 
-# check if demo root directory exists and create it if not
 check-demo-dir-exist:
-	$(Q)if [ ! -d "$(DEMO_DIR)" ]; then \
-		mkdir -p "$(DEMO_DIR)"; \
-	fi
+	$(Q)if [ ! -d "$(DEMO_DIR)" ]; then mkdir -p "$(DEMO_DIR)"; fi
 
-# FIXME: without $(info) generates errors
 define cp-web-file
     $(Q)cp $(1) $(DEMO_DIR)
     $(info)
 endef
 
-# WEB_FILES could be cleaned and recompiled, thus do not mix these two files into WEB_FILES
 STATIC_WEB_FILES := $(WEB_JS_RESOURCES)/coi-serviceworker.min.js
-ifeq ($(call has, SYSTEM), 1)
+ifeq ($(CONFIG_SYSTEM),y)
 STATIC_WEB_FILES += $(WEB_HTML_RESOURCES)/system.html
 else
 STATIC_WEB_FILES += $(WEB_HTML_RESOURCES)/user.html
 endif
 
 start_web_deps := check-demo-dir-exist $(BIN)
-ifeq ($(call has, SYSTEM), 1)
+ifeq ($(CONFIG_SYSTEM),y)
 start_web_deps += $(BUILD_DTB) $(BUILD_DTB2C)
 endif
 
@@ -166,4 +152,6 @@ start-web: $(start_web_deps)
 
 .PHONY: check-demo-dir-exist start-web
 
-endif
+endif # CC_IS_EMCC
+
+endif # _MK_WASM_INCLUDED

--- a/tools/detect-env.py
+++ b/tools/detect-env.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""
+Environment Detection Script for rv32emu Build System
+
+Detects compilers, libraries, and toolchains for Kconfig integration.
+Called by Kconfig with $(shell,...) to populate configuration options.
+
+Usage:
+    python3 detect-env.py [OPTIONS]
+
+Options:
+    --compiler           Print detected compiler type (GCC/Clang/Emscripten)
+    --is-emcc           Check if compiler is Emscripten (prints y/n)
+    --is-clang          Check if compiler is Clang (prints y/n)
+    --is-gcc            Check if compiler is GCC (prints y/n)
+    --have-sdl2         Check if SDL2 is available (prints y/n)
+    --have-sdl2-mixer   Check if SDL2_mixer is available (prints y/n)
+    --have-llvm18       Check if LLVM 18 is available (prints y/n)
+    --have-riscv-toolchain  Check if RISC-V toolchain exists (prints y/n)
+    --summary           Print full environment summary
+"""
+
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+
+
+def run_cmd(cmd, timeout=5):
+    """Run a command and return (returncode, stdout, stderr)."""
+    try:
+        if isinstance(cmd, str):
+            cmd = shlex.split(cmd)
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout
+        )
+        return result.returncode, result.stdout, result.stderr
+    except (FileNotFoundError, subprocess.TimeoutExpired, ValueError, OSError):
+        return 1, "", ""
+
+
+def get_compiler_path():
+    """Determine compiler path from environment."""
+    cross_compile = os.environ.get("CROSS_COMPILE", "")
+    cc = os.environ.get("CC", "")
+
+    if cc:
+        return cc
+    elif cross_compile:
+        return f"{cross_compile}gcc"
+    else:
+        return "cc"
+
+
+def get_compiler_version(compiler):
+    """Get compiler version string."""
+    ret, stdout, _ = run_cmd(
+        [compiler, "--version"]
+        if not " " in compiler
+        else shlex.split(compiler) + ["--version"]
+    )
+    return stdout if ret == 0 else ""
+
+
+def detect_compiler_type(version_output):
+    """Detect compiler type from version string."""
+    lower = version_output.lower()
+
+    if "emcc" in lower:
+        return "Emscripten"
+    if "clang" in lower:
+        return "Clang"
+    if "gcc" in lower or "free software foundation" in lower:
+        return "GCC"
+    return "Unknown"
+
+
+def check_pkg_config(package):
+    """Check if a package exists via pkg-config."""
+    ret, _, _ = run_cmd(["pkg-config", "--exists", package])
+    return ret == 0
+
+
+def check_sdl2_config():
+    """Check if sdl2-config exists."""
+    return shutil.which("sdl2-config") is not None
+
+
+def have_sdl2():
+    """Check if SDL2 is available."""
+    return check_sdl2_config() or check_pkg_config("sdl2")
+
+
+def have_sdl2_mixer():
+    """Check if SDL2_mixer is available."""
+    return check_pkg_config("SDL2_mixer")
+
+
+def have_llvm18():
+    """Check if LLVM 18 is available."""
+    # Check for llvm-config-18
+    if shutil.which("llvm-config-18"):
+        return True
+
+    # Check Homebrew path on macOS (dynamic detection)
+    if shutil.which("brew"):
+        ret, stdout, _ = run_cmd(["brew", "--prefix", "llvm@18"])
+        if ret == 0:
+            homebrew_path = os.path.join(stdout.strip(), "bin", "llvm-config")
+            if os.access(homebrew_path, os.X_OK):
+                return True
+
+    # Check standard llvm-config and verify version
+    llvm_config = shutil.which("llvm-config")
+    if llvm_config:
+        ret, stdout, _ = run_cmd([llvm_config, "--version"])
+        if ret == 0 and stdout.strip().startswith("18."):
+            return True
+
+    return False
+
+
+def have_riscv_toolchain():
+    """Check if a RISC-V cross-compiler toolchain is available."""
+    toolchain_prefixes = [
+        "riscv-none-elf-",
+        "riscv32-unknown-elf-",
+        "riscv64-unknown-elf-",
+        "riscv-none-embed-",
+    ]
+
+    for prefix in toolchain_prefixes:
+        gcc = shutil.which(f"{prefix}gcc")
+        if gcc:
+            # Verify it's actually a RISC-V compiler by checking predefined macros
+            try:
+                result = subprocess.run(
+                    [gcc, "-dM", "-E", "-x", "c", "-"],
+                    input="",
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                if result.returncode == 0 and "__riscv" in result.stdout:
+                    return True
+            except (subprocess.TimeoutExpired, OSError):
+                pass
+
+            # Fallback: just check if --version mentions RISC-V
+            ret, stdout, _ = run_cmd([gcc, "--version"])
+            if ret == 0 and (
+                "riscv" in stdout.lower() or "risc-v" in stdout.lower()
+            ):
+                return True
+
+    return False
+
+
+def print_summary():
+    """Print full environment summary."""
+    compiler = get_compiler_path()
+    version = get_compiler_version(compiler)
+    comp_type = detect_compiler_type(version)
+
+    print(f"Compiler: {compiler}")
+    print(f"Type: {comp_type}")
+    print(f"SDL2: {'yes' if have_sdl2() else 'no'}")
+    print(f"SDL2_mixer: {'yes' if have_sdl2_mixer() else 'no'}")
+    print(f"LLVM 18: {'yes' if have_llvm18() else 'no'}")
+    print(f"RISC-V Toolchain: {'yes' if have_riscv_toolchain() else 'no'}")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print_summary()
+        return
+
+    compiler = get_compiler_path()
+    version = get_compiler_version(compiler)
+    comp_type = detect_compiler_type(version)
+
+    arg = sys.argv[1]
+
+    if arg == "--compiler":
+        print(comp_type)
+    elif arg == "--is-emcc":
+        print("y" if comp_type == "Emscripten" else "n")
+    elif arg == "--is-clang":
+        print("y" if comp_type == "Clang" else "n")
+    elif arg == "--is-gcc":
+        print("y" if comp_type == "GCC" else "n")
+    elif arg == "--have-sdl2":
+        print("y" if have_sdl2() else "n")
+    elif arg == "--have-sdl2-mixer":
+        print("y" if have_sdl2_mixer() else "n")
+    elif arg == "--have-llvm18":
+        print("y" if have_llvm18() else "n")
+    elif arg == "--have-riscv-toolchain":
+        print("y" if have_riscv_toolchain() else "n")
+    elif arg == "--summary":
+        print_summary()
+    else:
+        print(f"Unknown option: {arg}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This replaces ad-hoc build configuration with Linux kernel-style Kconfig system for better maintainability and user experience.
- Add Kconfig infrastructure with auto-download of kconfiglib tools
- Add predefined configurations (defconfig, jit, mini, system, wasm, ci)
- Add backward compatibility layer for ENABLE_* flags (mk/compat.mk)
- Add environment detection script

Usage:
  make defconfig      # Apply default configuration
  make config         # Interactive menu configuration
  make jit_defconfig  # Predefined JIT configuration
  make ENABLE_JIT=1   # Legacy command-line override (still works)

Close #473

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a Kconfig-based build system to replace ad-hoc flags, making configuration simpler, reproducible, and CI-friendly. Adds predefined configs while keeping legacy ENABLE_* overrides working.

- **New Features**
  - Kconfig integration with menuconfig and a generated config header (src/rv32emu_config.h).
  - Predefined configs: defconfig, jit_defconfig, mini_defconfig, system_defconfig, wasm_defconfig, ci_defconfig.
  - Backward compatibility layer for ENABLE_* and OPT_LEVEL, so existing scripts still work.
  - Environment detection (tools/detect-env.py) to auto-check compiler, SDL, LLVM 18, and RISC-V toolchain.
  - CI workflows updated to run defconfig targets for consistent builds (wasm/system/JIT paths).
  - Emscripten build streamlined via wasm_defconfig; SDL and mixer checks handled automatically.
  - Artifact-related targets can run without .config; network calls only when artifact goals are requested.
  - Fixed prebuilt platform naming on x86_64 runners to match expected “x86”.
  - Hardened stability: more robust compiler/emcc detection, correct JIT platform check, proper cleanup in distclean, and a CI patch for the RISCOF dbgen.py bug affecting arch tests.
  - Auto-generates .config and the config header when missing, so ENABLE_* flags and arch-test flows work without a prior defconfig.

- **Migration**
  - Run make defconfig before building; use jit_defconfig or system_defconfig for JIT/system.
  - Legacy overrides like ENABLE_JIT=1 and OPT_LEVEL still work.
  - Config outputs are .config and src/rv32emu_config.h; use make config for interactive setup.
  - Python 3 is required; Kconfig tools auto-download to tools/kconfig.

<sup>Written for commit 7040e91df53b88b631dffc5e94f4ddb30965894a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

