### PR TITLE
Fix C23 compatibility

### DIFF
--- a/tests/dhrystone.c
+++ b/tests/dhrystone.c
@@ -312,7 +312,7 @@ void Proc5()
     BoolGlob = false;
 }
 
-extern boolean Func3();
+extern boolean Func3(Enumeration);
 
 void Proc6(Enumeration EnumParIn, Enumeration *EnumParOut)
 {


### PR DESCRIPTION
GCC 14/15 defaults to C23, where empty parentheses in function declarations mean "no parameters" (void) rather than "unspecified parameters" (K&R style). This causes build errors in dhrystone.c:
```
error: too many arguments to function 'Func3'; expected 0, have 1
```

Fix K&R-style declarations to use proper prototypes:
```
extern boolean Func3();  ->  extern boolean Func3(Enumeration);
```

Update [rv8-bench](https://github.com/sysprog21/rv8-bench) submodule to include the same fix.