### PR TITLE
Fix artifact fetch regression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ build/softfloat
 build/cache/
 build/map/
 build/path/
+build/rv32emu-prebuilt.tar.gz
 build/linux-x86-softfp/
 build/riscv32/
 build/sail_cSim/


### PR DESCRIPTION
The 'make check' target was failing with "Error 8" because ARTIFACT_TARGETS did not include targets that depend on 'artifact'. When running 'make check', the MAKECMDGOALS filter didn't match, leaving LATEST_RELEASE empty and causing wget to use an invalid URL.

This introduces reusable macros to eliminate duplicate code:
* verify-prebuilt-files: validates SHA checksums with guard
* handle-sha1-result: handles verification result with re-fetch
* fetch-checksum-files: conditional download with error handling

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes artifact fetch regression that broke make check by ensuring release detection runs for dependent targets. Adds small make macros to simplify checksum verification and artifact download.

- **Bug Fixes**
  - Include check, misalign, doom, quake in ARTIFACT_TARGETS so LATEST_RELEASE is set before wget runs.
  - Prevent empty URL errors (wget exit 8) during make check.
  - Ignore build/rv32emu-prebuilt.tar.gz in .gitignore.

- **Refactors**
  - Add verify-prebuilt-files, handle-sha1-result, fetch-checksum-files macros to remove duplicate shell logic.
  - Centralize SHA-1 validation, conditional re-fetch, and checksum downloads with clear status and early guards.
  - Apply macros across artifact and fetch-checksum paths for x86, riscv32, linux-image, and sail builds.

<sup>Written for commit 8696d82f3ff10636856b15f18fff890db93385d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

