### PR TITLE
Fix system emulation segfault with proper MMU

### DIFF
--- a/src/emulate.c
+++ b/src/emulate.c
@@ -994,15 +994,19 @@ static void match_pattern(riscv_t *rv, block_t *block)
                 break;
             }
             break;
-        /* If the memory addresses of a sequence of store or load instructions
-         * are contiguous, combine these instructions.
-         */
+            /* If the memory addresses of a sequence of store or load
+             * instructions are contiguous, combine these instructions.
+             * NOTE: Disabled in SYSTEM_MMIO because fused memory ops bypass
+             * MMU translation and bounds checking.
+             */
+#if !RV32_HAS(SYSTEM_MMIO)
         case rv_insn_sw:
             COMBINE_MEM_OPS(0);
             break;
         case rv_insn_lw:
             COMBINE_MEM_OPS(1);
             break;
+#endif
             /* TODO: mixture of SW and LW */
             /* TODO: reorder insturction to match pattern */
         case rv_insn_slli:

--- a/src/io.h
+++ b/src/io.h
@@ -14,6 +14,14 @@ typedef struct {
     uint64_t mem_size;
 } memory_t;
 
+/* Check if address range [addr, addr+size) is within guest RAM.
+ * Prevents buffer overflow on multi-byte accesses near memory boundary.
+ * Use size=0 for address-only validation (single byte or pre-validated size).
+ */
+#define GUEST_RAM_CONTAINS(mem, addr, size) \
+    ((uint64_t) (addr) < (mem)->mem_size && \
+     (uint64_t) (size) <= (mem)->mem_size - (uint64_t) (addr))
+
 /* create a memory instance */
 memory_t *memory_new(uint64_t size);
 


### PR DESCRIPTION
The system emulation crashed with SIGBUS/SIGSEGV during Linux boot due to flawed bounds checking logic in MMU memory access functions.

Root cause: The condition 'addr == vaddr || addr < mem_size' incorrectly passed when MMU was disabled (satp=0) because addr == vaddr is always true, but address could still exceed memory bounds, causing out-of-bounds host memory access.

The fix prevents buffer overflow on multi-byte accesses near memory boundaries by validating the full range [addr, addr+size).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes system emulation crashes (SIGBUS/SIGSEGV) during Linux boot by enforcing correct MMU bounds checks on memory accesses. Prevents out-of-bounds host memory access when MMU is off (satp=0).

- **Bug Fixes**
  - Added GUEST_RAM_CONTAINS to validate the full range [addr, addr+size) and used it in mmu_read/write and the JIT MMU handler.
  - Determined access size per instruction (1/2/4 bytes) to guard multi-byte accesses near RAM boundaries.
  - Disabled fused load/store combining in SYSTEM_MMIO to ensure MMU translation and bounds checks are not bypassed.

<sup>Written for commit fb3a0d6f34462718ec928572c9b353750a4d9165. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

