### PR TITLE
CI: Fix C23 compatibility in Doom

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'true'
       - name: Test file change
         id: test-file-change
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v47
         with:
           fetch_additional_submodule_history: 'true'
           files: |
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'true'
       - name: Install dependencies


### PR DESCRIPTION
GCC 15+ promotes -Wincompatible-pointer-types to error under C23, breaking the legacy function pointer union pattern used in Doom.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes C23 build errors in the Doom tests under GCC 15+ by updating the Doom submodule to a C23-compatible revision. Also updates CI actions to their latest versions.

- **Dependencies**
  - Update tests/doom submodule to a C23-compatible version (fixes incompatible function pointer union usage).
  - Bump actions/checkout to v6.
  - Bump tj-actions/changed-files to v47.

<sup>Written for commit e8df224db35a7689331d403cab3c4cf04a89930b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

