### PR TITLE
Fix gdbstub exit handling for fd close syscalls

### DIFF
--- a/.ci/gdbstub-test.sh
+++ b/.ci/gdbstub-test.sh
@@ -5,19 +5,19 @@ set -e -u -o pipefail
 export PATH=$(pwd)/toolchain/bin:$PATH
 
 GDB=
-prefixes=("${CROSS_COMPILE}" "riscv32-unknown-elf-" "riscv-none-elf-")
+prefixes=("${CROSS_COMPILE:-}" "riscv32-unknown-elf-" "riscv-none-elf-")
 for prefix in "${prefixes[@]}"; do
+    # Skip empty prefix to avoid matching host gdb
+    [ -z "${prefix}" ] && continue
     utility=${prefix}gdb
-    set +e # temporarily disable exit on error
-    command -v "${utility}" > /dev/null 2>&1
-    if [ $? = 0 ]; then
+    if command -v "${utility}" > /dev/null 2>&1; then
         GDB=${utility}
+        break
     fi
-    set -e
 done
 
 # Check if GDB is available
-if [ -z ${GDB} ]; then
+if [ -z "${GDB}" ]; then
     exit 1
 fi
 

--- a/.ci/gdbstub-test.sh
+++ b/.ci/gdbstub-test.sh
@@ -31,7 +31,11 @@ fi
 
 OPTS=
 tmpfile=/tmp/rv32emu-gdbstub.$PID
-breakpoints=(0x10500 0x10600 0x10700)
+# Use main() function addresses that are identical across platforms:
+# - 0x100e0: main entry (addi sp,sp,-16)
+# - 0x100e8: jal run_puzzle (call to puzzle solver)
+# - 0x100f0: li a0,0 (after run_puzzle returns, set exit code)
+breakpoints=(0x100e0 0x100e8 0x100f0)
 bkpt_count=${#breakpoints[@]}
 OPTS+="-ex 'file build/riscv32/puzzle' "
 OPTS+="-ex 'target remote :1234' "

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -1457,6 +1457,12 @@ void rv_step_debug(void *arg)
     rv_check_interrupt(rv);
 #endif
 
+#if !RV32_HAS(SYSTEM)
+    /* on exit */
+    if (unlikely(rv->PC == PRIV(rv)->exit_addr))
+        PRIV(rv)->on_exit = true;
+#endif
+
     rv_insn_t ir;
 
 retranslate:


### PR DESCRIPTION
This adds on_exit detection to `rv_step_debug()` to match the behavior in block-based execution. Without this, `syscall_close()` logs ERROR when the guest program closes fd 0, 1, 2 during exit, causing gdbstub-test to fail on macOS CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detect guest exit in rv_step_debug() by setting on_exit when PC == exit_addr to match block-based execution, avoid false ERROR logs when fd 0-2 close on exit, and fix gdbstub-test failures. Update gdbstub-test.sh to handle unset CROSS_COMPILE, skip empty prefixes to avoid host gdb, break on first match, fix quoting in -z checks, and use main() breakpoint addresses that are consistent across platforms.

<sup>Written for commit 0e88a5940692059a3867add50a0e78fcb9b888fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

