### PR TITLE
Add build-linux-image target to CONFIG_TARGETS

### DIFF
--- a/mk/common.mk
+++ b/mk/common.mk
@@ -64,7 +64,7 @@ error_msg = $(PRINTF) "$(RED)$(strip $1)$(NC)\n"
 # Note: 'artifact' is included because it only downloads prebuilt binaries
 # and determines what to download from ENABLE_* flags (via compat.mk)
 CONFIG_TARGETS := config menuconfig defconfig oldconfig savedefconfig \
-                  clean distclean help env-check artifact fetch-checksum
+                  clean distclean help env-check artifact fetch-checksum build-linux-image
 
 # Targets that generate .config
 CONFIG_GENERATORS := config menuconfig defconfig oldconfig


### PR DESCRIPTION
make build-linux-image does not need .config. W/o this patch disables the make build-linux-image, the errors:

Run make build-linux-image
Makefile:77: *** Configuration required.  Stop.

*** Configuration file ".config" not found!
*** Please run 'make config' or 'make defconfig' first.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added build-linux-image to CONFIG_TARGETS so it can run without a .config file. Fixes the “Configuration required” error when running make build-linux-image on a clean tree.

<sup>Written for commit a09a9b918221285e52da8d084b914ddfa0b99e67. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

