### PR TITLE
Refine build system with Kconfig integration

### DIFF
--- a/.ci/riscv-tests.sh
+++ b/.ci/riscv-tests.sh
@@ -33,7 +33,8 @@ set -x
 export PATH=$(pwd)/toolchain/bin:$PATH
 
 make distclean
-# Rebuild with all RISC-V extensions (including B-extension: Zba/Zbb/Zbc/Zbs)
+# Generate config with all RISC-V extensions (including B-extension: Zba/Zbb/Zbc/Zbs)
+make defconfig
 make ENABLE_ARCH_TEST=1 ENABLE_EXT_M=1 ENABLE_EXT_A=1 ENABLE_EXT_F=1 ENABLE_EXT_C=1 \
     ENABLE_Zicsr=1 ENABLE_Zifencei=1 \
     ENABLE_Zba=1 ENABLE_Zbb=1 ENABLE_Zbc=1 ENABLE_Zbs=1 $PARALLEL
@@ -80,6 +81,7 @@ fi
 
 # Rebuild with RV32E
 make distclean
+make defconfig
 make ENABLE_ARCH_TEST=1 ENABLE_RV32E=1 $PARALLEL
 make ENABLE_ARCH_TEST=1 arch-test RISCV_DEVICE=E SKIP_PREREQ=1 $PARALLEL || exit 1
 
@@ -87,7 +89,8 @@ make ENABLE_ARCH_TEST=1 arch-test RISCV_DEVICE=E SKIP_PREREQ=1 $PARALLEL || exit
 # Do not run the architecture test with "Zicsr" extension. It ignores
 # the hardware misalignment (hw_data_misaligned_support) option.
 make distclean
-make ENABLE_ARCH_TEST=1 ENABLE_JIT=1 ENABLE_T2C=0 \
+make jit_defconfig
+make ENABLE_ARCH_TEST=1 ENABLE_T2C=0 \
     ENABLE_EXT_M=1 ENABLE_EXT_A=1 ENABLE_EXT_F=1 ENABLE_EXT_C=1 \
     ENABLE_Zicsr=1 ENABLE_Zifencei=1 $PARALLEL
 make ENABLE_ARCH_TEST=1 arch-test RISCV_DEVICE=IMC hw_data_misaligned_support=0 SKIP_PREREQ=1 $PARALLEL || exit 1

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -30,6 +30,10 @@ jobs:
               src/cache.c
               src/io.c
               src/jit.c
+              # Build system configuration (may affect optimization flags)
+              mk/kconfig.mk
+              mk/toolchain.mk
+              tools/detect-env.py
 
       - name: Cache benchmark artifacts
         if: steps.changed-files.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -25,6 +25,10 @@ jobs:
           fetch_additional_submodule_history: 'true'
           files: |
             mk/artifact.mk
+            # Build system configuration
+            mk/kconfig.mk
+            mk/toolchain.mk
+            tools/detect-env.py
             tests/ansibench/**
             tests/rv8-bench/**
             tests/doom/**

--- a/.github/workflows/build-linux-artifacts.yml
+++ b/.github/workflows/build-linux-artifacts.yml
@@ -24,6 +24,10 @@ jobs:
         with:
           files: |
             mk/external.mk
+            # Build system configuration
+            mk/kconfig.mk
+            mk/toolchain.mk
+            tools/detect-env.py
       - name: Set alias
         id: has_changed_files
         run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,54 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly on Monday at 6 AM UTC
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (c-cpp)
+    runs-on: ubuntu-24.04
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    env:
+      # Disable TRAP cache to avoid "No such file or directory" error
+      # in pre-finalize.sh when tarballs directory doesn't exist
+      CODEQL_EXTRACTOR_CPP_TRAP_CACHING: false
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+      with:
+        submodules: 'true'
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update -q=2
+        sudo apt-get install -q=2 libsdl2-dev libsdl2-mixer-dev
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v4
+      with:
+        languages: c-cpp
+        build-mode: manual
+
+    - name: Build
+      run: |
+        make defconfig
+        make -j$(nproc)
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:c-cpp"

--- a/.github/workflows/deploy-wasm.yml
+++ b/.github/workflows/deploy-wasm.yml
@@ -39,6 +39,11 @@ jobs:
               assets/wasm/html/system.html
               assets/wasm/js/system-pre.js
               src/em_runtime.c
+              # Build system configuration
+              mk/kconfig.mk
+              mk/wasm.mk
+              configs/wasm_defconfig
+              tools/detect-env.py
               # Files below may have a potential performance impact (reference from benchmark.yml)
               src/devices/*.c
               src/system.c
@@ -62,13 +67,14 @@ jobs:
       - name: fetch artifact
         run: |
               make artifact ENABLE_SYSTEM=1
+      # Note: wasm_defconfig sets CONFIG_BUILD_WASM=y which auto-selects CC=emcc
       - name: build with emcc and move application files to /tmp
         if: ${{ steps.changed-files.outputs.any_modified == 'true' ||
             github.event_name == 'workflow_dispatch' ||
             (github.event_name == 'repository_dispatch' && github.event.action == 'deploy_system_wasm') }}
         run: |
             make wasm_defconfig
-            make CC=emcc ENABLE_SYSTEM=1 INITRD_SIZE=32 -j
+            make ENABLE_SYSTEM=1 INITRD_SIZE=32 -j
             mkdir /tmp/rv32emu-system-demo
             mv assets/wasm/html/system.html /tmp/rv32emu-system-demo/index.html
             mv assets/wasm/js/coi-serviceworker.min.js /tmp/rv32emu-system-demo
@@ -144,6 +150,11 @@ jobs:
               build/*.elf
               tools/gen-elf-list-js.py
               src/em_runtime.c
+              # Build system configuration
+              mk/kconfig.mk
+              mk/wasm.mk
+              configs/wasm_defconfig
+              tools/detect-env.py
               # Files below may have a potential performance impact (reference from benchmark.yml)
               src/riscv.c
               src/decode.c
@@ -168,13 +179,14 @@ jobs:
               # get from rv32emu-prebuilt
               .ci/fetch.sh -o build/shareware_doom_iwad.zip "https://raw.githubusercontent.com/sysprog21/rv32emu-prebuilt/doom-artifact/shareware_doom_iwad.zip"
               unzip -o -d build/ build/shareware_doom_iwad.zip
+      # Note: wasm_defconfig sets CONFIG_BUILD_WASM=y which auto-selects CC=emcc
       - name: build with emcc and move application files to /tmp
         if: ${{ steps.changed-files.outputs.any_modified == 'true' ||
             github.event_name == 'workflow_dispatch' ||
             (github.event_name == 'repository_dispatch' && github.event.action == 'deploy_user_wasm') }}
         run: |
             make wasm_defconfig
-            make CC=emcc -j
+            make -j
             mkdir /tmp/rv32emu-demo
             mv assets/wasm/html/user.html /tmp/rv32emu-demo/index.html
             mv assets/wasm/js/coi-serviceworker.min.js /tmp/rv32emu-demo

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,10 @@ jobs:
               .clang-format
               Dockerfile
               Makefile
+              # Build system configuration
+              mk/kconfig.mk
+              mk/toolchain.mk
+              tools/detect-env.py
       - name: Set has_code_related_changes
         id: set_has_code_related_changes
         run: |
@@ -156,19 +160,20 @@ jobs:
 
     # emcc builds run on x64 only - WebAssembly output is platform-independent
     # This validates Emscripten compatibility without redundant builds on macOS
+    # Note: wasm_defconfig sets CONFIG_BUILD_WASM=y which auto-selects CC=emcc
     - name: default build using emcc
       if: success()
       run: |
             make distclean
             make wasm_defconfig
-            make CC=emcc $PARALLEL
+            make $PARALLEL
 
     - name: default build for system emulation using emcc
       if: success()
       run: |
             make distclean
             make wasm_defconfig
-            make CC=emcc ENABLE_SYSTEM=1 $PARALLEL
+            make ENABLE_SYSTEM=1 $PARALLEL
             make distclean
 
     - name: Build with various optimization levels

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,12 @@ WORKDIR /home/root/rv32emu
 COPY . .
 
 # build and rename executables: rv32emu-user, rv32emu-system, and rv32emu-histogram
-RUN make -j"$(nproc)"
+RUN make defconfig && make -j"$(nproc)"
 RUN make tool -j"$(nproc)"
 RUN mv ./build/rv32emu ./build/rv32emu-user
 RUN mv ./build/rv_histogram ./build/rv32emu-histogram
 RUN make distclean
-RUN make ENABLE_SYSTEM=1 INITRD_SIZE=32 -j"$(nproc)"
+RUN make system_defconfig && make INITRD_SIZE=32 -j"$(nproc)"
 
 FROM alpine:3.21 AS final
 

--- a/Makefile
+++ b/Makefile
@@ -5,243 +5,111 @@
 #   make              # Build rv32emu
 #   make check        # Run tests
 #
-# Configuration:
-#   make config       # Interactive menuconfig
-#   make defconfig    # Default (SDL, all extensions)
-#   make oldconfig    # Update config after Kconfig changes
-#   make savedefconfig # Save current config as defconfig
-#
-# Named configurations (in configs/):
-#   make defconfig CONFIG=mini       # Apply configs/mini_defconfig
-#   make defconfig CONFIG=system     # Apply configs/system_defconfig
-#   make defconfig CONFIG=jit        # Apply configs/jit_defconfig
-#   make defconfig CONFIG=wasm       # Apply configs/wasm_defconfig
-#   make defconfig CONFIG=ci         # Apply configs/ci_defconfig
+# See README for more options.
 
 .DEFAULT_GOAL := all
 
-# Build Framework Setup
-
-# Include build utilities first (sets Q, VECHO, OUT, etc.)
-include mk/common.mk
-include mk/toolchain.mk
-include mk/deps.mk
-
 # Verify GNU Make version (3.80+ required for order-only prerequisites)
-ifeq ($(filter 3.80 3.81 3.82 3.83 3.84 4.% 5.%,$(MAKE_VERSION)),)
+ifeq ($(filter 3.80 3.81 3.82 3.83 3.84 4.% 5.% 6.% 7.% 8.% 9.%,$(MAKE_VERSION)),)
 $(error GNU Make 3.80 or higher is required. Current version: $(MAKE_VERSION))
 endif
 
+# Build Framework
+include mk/common.mk
+
 # Kconfig Integration
+include mk/kconfig.mk
 
-KCONFIG_DIR := tools/kconfig
-KCONFIG := configs/Kconfig
-CONFIG_HEADER := src/rv32emu_config.h
-
-# Kconfig tool source (kconfiglib)
-KCONFIGLIB_REPO := https://github.com/sysprog21/Kconfiglib
-
-# Download and setup Kconfig tools if missing
-$(KCONFIG_DIR)/kconfiglib.py:
-	$(VECHO) "Downloading Kconfig tools...\n"
-	$(Q)git clone --depth=1 -q $(KCONFIGLIB_REPO) $(KCONFIG_DIR)
-	@echo "Kconfig tools installed to $(KCONFIG_DIR)"
-
-# Ensure all Kconfig tools exist
-$(KCONFIG_DIR)/menuconfig.py $(KCONFIG_DIR)/defconfig.py $(KCONFIG_DIR)/genconfig.py \
-$(KCONFIG_DIR)/oldconfig.py $(KCONFIG_DIR)/savedefconfig.py: $(KCONFIG_DIR)/kconfiglib.py
-
-# Load existing configuration (safe include)
+# Load configuration (before toolchain.mk so CONFIG_BUILD_WASM affects CC)
+# .config is required for build targets - run 'make defconfig' to generate
+ifeq ($(NEEDS_CONFIG),yes)
+ifeq ($(wildcard .config),)
+$(info )
+$(info No .config found. Please run one of:)
+$(info   make defconfig        - Apply default configuration)
+$(info   make config           - Interactive configuration menu)
+$(info   make ci_defconfig     - CI with architecture tests)
+$(info   make jit_defconfig    - Enable JIT compilation)
+$(info   make mini_defconfig   - Minimal build for embedded use)
+$(info   make system_defconfig - System emulation mode)
+$(info   make wasm_defconfig   - WebAssembly build)
+$(info )
+$(error .config required. Run 'make defconfig' first.)
+endif
+endif
 -include .config
-
-# Auto-generate .config at parse time if missing (for ENABLE_* backward compatibility)
-# This ensures CONFIG_* values from defconfig are available during set-feature evaluation.
-# Without this, features not explicitly passed via ENABLE_* would default to 0 instead
-# of their defconfig values.
-# Skip for config-related targets that don't need or will generate .config themselves.
-# Note: Empty MAKECMDGOALS means default goal (all), which needs .config
-ifneq ($(CONFIG_CONFIGURED),y)
-ifeq ($(filter $(CONFIG_TARGETS) $(DEFCONFIG_GOALS),$(MAKECMDGOALS)),)
-ifneq ($(wildcard $(KCONFIG_DIR)/defconfig.py),)
-$(shell python3 $(KCONFIG_DIR)/defconfig.py --kconfig $(KCONFIG) configs/defconfig >/dev/null 2>&1)
-# Re-include .config now that it's been generated
--include .config
-endif
-endif
-endif
-
-# Backward compatibility for ENABLE_* flags (allows CI to work without changes)
 include mk/compat.mk
 
-# Configuration validation (only for build targets)
+# Toolchain detection (after .config to support BUILD_WASM)
+include mk/toolchain.mk
+include mk/deps.mk
 $(eval $(require-config))
 
-# Kconfig Targets
-
-# Run environment detection before showing menu
-env-check:
-	@echo "Checking build environment..."
-	@python3 tools/detect-env.py --summary
-	@echo ""
-
-# Interactive configuration (depends on Kconfig tools)
-config: env-check $(KCONFIG_DIR)/menuconfig.py
-	@python3 $(KCONFIG_DIR)/menuconfig.py $(KCONFIG)
-	@python3 $(KCONFIG_DIR)/genconfig.py --header-path $(CONFIG_HEADER) $(KCONFIG)
-	@echo "Configuration saved to .config and $(CONFIG_HEADER)"
-
-# Apply default configuration (supports CONFIG=name for named configs)
-defconfig: $(KCONFIG_DIR)/defconfig.py
-	@if [ -n "$(CONFIG)" ]; then \
-		if [ -f "configs/$(CONFIG)_defconfig" ]; then \
-			echo "Applying configs/$(CONFIG)_defconfig..."; \
-			python3 $(KCONFIG_DIR)/defconfig.py --kconfig $(KCONFIG) configs/$(CONFIG)_defconfig; \
-		else \
-			echo "Error: configs/$(CONFIG)_defconfig not found"; \
-			exit 1; \
-		fi; \
-	else \
-		echo "Applying default configuration..."; \
-		python3 $(KCONFIG_DIR)/defconfig.py --kconfig $(KCONFIG) configs/defconfig; \
-	fi
-	@python3 $(KCONFIG_DIR)/genconfig.py --header-path $(CONFIG_HEADER) $(KCONFIG)
-	@echo "Configuration applied."
-
-# Pattern rule for named defconfigs (e.g., make jit_defconfig, make mini_defconfig)
-%_defconfig: $(KCONFIG_DIR)/defconfig.py
-	@if [ -f "configs/$*_defconfig" ]; then \
-		echo "Applying configs/$*_defconfig..."; \
-		python3 $(KCONFIG_DIR)/defconfig.py --kconfig $(KCONFIG) configs/$*_defconfig; \
-		python3 $(KCONFIG_DIR)/genconfig.py --header-path $(CONFIG_HEADER) $(KCONFIG); \
-		echo "Configuration applied."; \
-	else \
-		echo "Error: configs/$*_defconfig not found"; \
-		exit 1; \
-	fi
-
-# Update configuration after Kconfig changes
-oldconfig: $(KCONFIG_DIR)/oldconfig.py
-	@python3 $(KCONFIG_DIR)/oldconfig.py $(KCONFIG)
-	@python3 $(KCONFIG_DIR)/genconfig.py --header-path $(CONFIG_HEADER) $(KCONFIG)
-
-# Save current configuration as minimal defconfig
-savedefconfig: $(KCONFIG_DIR)/savedefconfig.py
-	@python3 $(KCONFIG_DIR)/savedefconfig.py --kconfig $(KCONFIG) --out defconfig.new
-	@echo "Saved minimal config to defconfig.new"
-
-# Explicit target to download/update Kconfig tools
-kconfig-tools: $(KCONFIG_DIR)/kconfiglib.py
-	@echo "Kconfig tools are ready in $(KCONFIG_DIR)"
-
-# Explicit rule to generate .config if missing (fallback for cases where
-# parse-time generation didn't run, e.g., kconfig tools weren't present yet)
-# Use order-only prerequisite (|) to only check existence, not timestamp,
-# so user-customized .config isn't overwritten when defconfig.py is updated.
-.config: | $(KCONFIG_DIR)/defconfig.py
-	@python3 $(KCONFIG_DIR)/defconfig.py --kconfig $(KCONFIG) configs/defconfig
-	@echo "Generated .config from default configuration"
-
-# Auto-generate config header from .config
-$(CONFIG_HEADER): .config $(KCONFIG_DIR)/genconfig.py
-	@python3 $(KCONFIG_DIR)/genconfig.py --header-path $(CONFIG_HEADER) $(KCONFIG)
-	@echo "Generated $(CONFIG_HEADER)"
-
 # Build Configuration
-
 OUT ?= build
 BIN := $(OUT)/rv32emu
 
 CFLAGS = -std=gnu99 $(KCONFIG_CFLAGS) -Wall -Wextra -Werror
-CFLAGS += -Wno-unused-label
-CFLAGS += -include src/common.h -Isrc/
-
-# Disable Intel CET for JIT compatibility
-CFLAGS += $(CFLAGS_NO_CET)
-
+CFLAGS += -Wno-unused-label -include src/common.h -Isrc/ $(CFLAGS_NO_CET)
 LDFLAGS += $(KCONFIG_LDFLAGS)
 OBJS_EXT :=
 deps :=
 
-# Feature Flags from Kconfig
+# Feature Flags (Kconfig -> RV32_FEATURE_*)
+$(call set-features, ELF_LOADER MOP_FUSION BLOCK_CHAINING LOG_COLOR)
+$(call set-features, SYSTEM ARCH_TEST)
+$(call set-features, EXT_M EXT_A EXT_F EXT_C RV32E)
+$(call set-features, Zicsr Zifencei Zba Zbb Zbc Zbs)
+$(call set-features, SDL SDL_MIXER GDBSTUB JIT)
 
-# Convert Kconfig options to RV32_FEATURE_* compiler flags
-$(call set-feature, ELF_LOADER)
-$(call set-feature, MOP_FUSION)
-$(call set-feature, BLOCK_CHAINING)
-$(call set-feature, LOG_COLOR)
-$(call set-feature, SYSTEM)
-$(call set-feature, ARCH_TEST)
-$(call set-feature, EXT_M)
-$(call set-feature, EXT_A)
-$(call set-feature, EXT_F)
-$(call set-feature, EXT_C)
-$(call set-feature, RV32E)
-$(call set-feature, Zicsr)
-$(call set-feature, Zifencei)
-$(call set-feature, Zba)
-$(call set-feature, Zbb)
-$(call set-feature, Zbc)
-$(call set-feature, Zbs)
-$(call set-feature, SDL)
-$(call set-feature, SDL_MIXER)
-$(call set-feature, GDBSTUB)
-$(call set-feature, JIT)
-# Note: T2C is set conditionally after LLVM detection in JIT section
-
-# Extension: Floating Point (F)
-
+# Extension: Floating Point
 ifeq ($(CONFIG_EXT_F),y)
 AR := ar
 ifeq ("$(CC_IS_CLANG)", "1")
     ifeq ($(UNAME_S),Darwin)
         # macOS: system ar is sufficient
+    else ifeq ($(CONFIG_LTO),y)
+        LLVM_AR := $(shell which llvm-ar 2>/dev/null)
+        ifeq ($(LLVM_AR),)
+            $(error llvm-ar required for LTO with Clang. Install LLVM or disable LTO.)
+        endif
+        AR = llvm-ar
     else
-        ifeq ($(CONFIG_LTO),y)
-            LLVM_AR := $(shell which llvm-ar 2>/dev/null)
-            ifeq ($(LLVM_AR),)
-                $(error llvm-ar required for LTO with Clang. Install LLVM or disable LTO.)
-            endif
+        LLVM_AR := $(shell which llvm-ar 2>/dev/null)
+        ifneq ($(LLVM_AR),)
             AR = llvm-ar
-        else
-            LLVM_AR := $(shell which llvm-ar 2>/dev/null)
-            ifneq ($(LLVM_AR),)
-                AR = llvm-ar
-            endif
         endif
     endif
 endif
 ifeq ("$(CC_IS_EMCC)", "1")
 AR = emar
 endif
-
-# Berkeley SoftFloat
 include mk/softfloat.mk
-
 OBJS_NEED_SOFTFLOAT := $(OUT)/decode.o $(OUT)/riscv.o
 ifeq ($(CONFIG_SYSTEM),y)
 DEV_OUT := $(OUT)/devices
 OBJS_NEED_SOFTFLOAT += $(DEV_OUT)/uart.o $(DEV_OUT)/plic.o
 endif
 $(OBJS_NEED_SOFTFLOAT): $(SOFTFLOAT_LIB)
-LDFLAGS += $(SOFTFLOAT_LIB)
-LDFLAGS += -lm
+LDFLAGS += $(SOFTFLOAT_LIB) -lm
 endif
 
 # Extension: SDL Graphics
-
 ifeq ($(CONFIG_SDL),y)
 ifneq ("$(CC_IS_EMCC)", "1")
-    # Native SDL
+    ifeq ($(SKIP_DEPS_CHECK),)
     ifeq ($(HAVE_SDL2),)
         $(warning SDL2 not found. Run 'make config' to disable SDL.)
-    else
+    endif
+    endif
+    ifneq ($(HAVE_SDL2),)
         OBJS_EXT += syscall_sdl.o
         $(OUT)/syscall_sdl.o: CFLAGS += $(SDL2_CFLAGS)
         LDFLAGS += $(SDL2_LIBS) -pthread
         ifeq ($(CONFIG_SDL_MIXER),y)
-            ifeq ($(HAVE_SDL2_MIXER),y)
+            ifneq ($(HAVE_SDL2_MIXER),)
                 LDFLAGS += $(SDL2_MIXER_LIBS)
-            else
+            else ifeq ($(SKIP_DEPS_CHECK),)
                 $(warning SDL2_mixer not found. Audio disabled.)
             endif
         endif
@@ -250,34 +118,32 @@ endif
 endif
 
 # Extension: GDB Stub
-
 ifeq ($(CONFIG_GDBSTUB),y)
 GDBSTUB_OUT = $(abspath $(OUT)/mini-gdbstub)
 GDBSTUB_COMM = 127.0.0.1:1234
-
 src/mini-gdbstub/Makefile:
 	git submodule update --init $(dir $@)
-
 GDBSTUB_LIB := $(GDBSTUB_OUT)/libgdbstub.a
 $(GDBSTUB_LIB): src/mini-gdbstub/Makefile
 	$(MAKE) -C $(dir $<) O=$(dir $@)
-
 OBJS_EXT += gdbstub.o breakpoint.o
 CFLAGS += -D'GDBSTUB_COMM="$(GDBSTUB_COMM)"'
 LDFLAGS += $(GDBSTUB_LIB) -pthread
-
 gdbstub-test: $(BIN)
 	$(Q).ci/gdbstub-test.sh && $(call notice, [OK])
 endif
 
 # Extension: JIT Compilation
-
 ifeq ($(CONFIG_JIT),y)
     OBJS_EXT += jit.o
-
-    # Tier-2 LLVM compiler - uses centralized detection from mk/toolchain.mk
     T2C_ENABLED := 0
     ifeq ($(CONFIG_T2C),y)
+        # LLVM 18 detection (only when T2C enabled)
+        LLVM_CONFIG := $(strip $(or \
+            $(shell which llvm-config-18 2>/dev/null),\
+            $(shell brew --prefix llvm@18 2>/dev/null | xargs -I{} sh -c 'test -x {}/bin/llvm-config && echo {}/bin/llvm-config' 2>/dev/null),\
+            $(shell which llvm-config 2>/dev/null | xargs -I{} sh -c '{} --version 2>/dev/null | grep -q "^18\." && echo {}' 2>/dev/null)))
+        HOMEBREW_LLVM_PREFIX := $(shell which brew >/dev/null 2>&1 && brew --prefix llvm@18 2>/dev/null)
         ifneq ($(LLVM_CONFIG),)
             CHECK_LLVM := $(shell $(LLVM_CONFIG) --libs 2>/dev/null 1>&2; echo $$?)
             ifeq ($(CHECK_LLVM),0)
@@ -285,6 +151,11 @@ ifeq ($(CONFIG_JIT),y)
                 OBJS_EXT += t2c.o
                 CFLAGS += -g $(shell $(LLVM_CONFIG) --cflags)
                 LDFLAGS += $(shell $(LLVM_CONFIG) --libfiles)
+                ifneq ($(HOMEBREW_LLVM_PREFIX),)
+                ifneq ($(findstring $(HOMEBREW_LLVM_PREFIX),$(LLVM_CONFIG)),)
+                    LDFLAGS += -L$(HOMEBREW_LLVM_PREFIX)/lib
+                endif
+                endif
             else
                 $(warning LLVM 18 libraries not found. T2C disabled.)
             endif
@@ -293,35 +164,29 @@ ifeq ($(CONFIG_JIT),y)
         endif
     endif
     CFLAGS += -DRV32_FEATURE_T2C=$(T2C_ENABLED)
-
-    # Platform check (use UNAME_M for raw architecture, not HOST_PLATFORM which maps for artifacts)
     ifneq ($(UNAME_M),$(filter $(UNAME_M),x86_64 aarch64 arm64))
         $(error JIT only supports x86_64 and ARM64 platforms.)
     endif
-
 $(OUT)/jit.o: src/jit.c src/rv32_jit.c $(CONFIG_HEADER)
 	$(VECHO) "  CC\t$@\n"
 	$(Q)$(CC) -o $@ $(CFLAGS) -c -MMD -MF $@.d $<
-
 $(OUT)/t2c.o: src/t2c.c src/t2c_template.c $(CONFIG_HEADER)
 	$(VECHO) "  CC\t$@\n"
 	$(Q)$(CC) -o $@ $(CFLAGS) -c -MMD -MF $@.d $<
 else
-    # T2C disabled when JIT is disabled
     CFLAGS += -DRV32_FEATURE_T2C=0
 endif
 
-# Tail-call optimization flags
+# Tail-call optimization
 $(OUT)/emulate.o: CFLAGS += -foptimize-sibling-calls -fomit-frame-pointer -fno-stack-check -fno-stack-protector
 
-# External Dependencies
+# External Dependencies & System Emulation
 include mk/external.mk
 include mk/artifact.mk
 include mk/system.mk
 include mk/wasm.mk
 
 # Build Targets
-
 DTB_DEPS :=
 ifeq ($(CONFIG_SYSTEM),y)
 ifneq ($(CONFIG_ELF_LOADER),y)
@@ -329,42 +194,21 @@ DTB_DEPS := $(BUILD_DTB) $(BUILD_DTB2C)
 endif
 endif
 
-# Core objects
-OBJS := \
-    map.o \
-    utils.o \
-    decode.o \
-    io.o \
-    syscall.o
-
-# Emscripten runtime (must precede emulate.o)
+OBJS := map.o utils.o decode.o io.o syscall.o
 ifeq ($(CC_IS_EMCC), 1)
 OBJS += em_runtime.o
 endif
-
-OBJS += \
-    emulate.o \
-    riscv.o \
-    log.o \
-    elf.o \
-    cache.o \
-    mpool.o \
-    $(OBJS_EXT) \
-    main.o
-
+OBJS += emulate.o riscv.o log.o elf.o cache.o mpool.o $(OBJS_EXT) main.o
 OBJS := $(addprefix $(OUT)/, $(OBJS))
 deps += $(OBJS:%.o=%.o.d)
 
-# Object dependencies
 ifeq ($(CONFIG_EXT_F),y)
 $(OBJS): $(SOFTFLOAT_LIB)
 endif
-
 ifeq ($(CONFIG_GDBSTUB),y)
 $(OBJS): $(GDBSTUB_LIB)
 endif
 
-# Compilation rules
 $(OUT)/%.o: src/%.c $(deps_emcc) $(CONFIG_HEADER) | $(OUT)
 	$(Q)mkdir -p $(dir $@)
 	$(VECHO) "  CC\t$@\n"
@@ -373,120 +217,22 @@ $(OUT)/%.o: src/%.c $(deps_emcc) $(CONFIG_HEADER) | $(OUT)
 $(OUT):
 	$(Q)mkdir -p $@
 
+# Link the final binary
 $(BIN): $(OBJS) $(DEV_OBJS) | $(OUT)
 	$(VECHO) "  LD\t$@\n"
 	$(Q)$(CC) -o $@ $(CFLAGS_emcc) $^ $(LDFLAGS)
 
-# Main target
 all: $(DTB_DEPS) $(BIN)
 	@$(call notice, Build complete: $(BIN))
 
-# Tools
+# Tools & Testing
 include mk/tools.mk
-tool: $(TOOLS_BIN)
-
-# Testing
-
 include mk/riscv-arch-test.mk
 include mk/tests.mk
 
-CHECK_ELF_FILES :=
-ifeq ($(CONFIG_EXT_M),y)
-CHECK_ELF_FILES += puzzle fcalc pi
-endif
-
-EXPECTED_hello = Hello World!
-EXPECTED_puzzle = success in 2005 trials
-EXPECTED_fcalc = Performed 12 tests, 0 failures, 100% success rate.
-EXPECTED_pi = 3.141592653589793238462643383279502884197169399375105820974944592307816406286208998628034825342117067982148086
-
-LOG_FILTER=sed -E '/^[0-9]{2}:[0-9]{2}:[0-9]{2} /d'
-
-define check-test
-$(Q)true; \
-$(PRINTF) "Running $(3) ... "; \
-OUTPUT_FILE="$$(mktemp)"; \
-if (LC_ALL=C $(BIN) $(1) $(2) > "$$OUTPUT_FILE") && \
-   [ "$$(cat "$$OUTPUT_FILE" | $(LOG_FILTER) | $(4))" = "$(5)" ]; then \
-    $(call notice, [OK]); \
-else \
-    $(PRINTF) "Failed.\n"; \
-    exit 1; \
-fi; \
-$(RM) "$$OUTPUT_FILE"
-endef
-
-check-hello: $(BIN)
-	$(call check-test, , $(OUT)/hello.elf, hello.elf, uniq,$(EXPECTED_hello))
-
-check: $(BIN) check-hello artifact
-	$(Q)$(foreach e, $(CHECK_ELF_FILES), $(call check-test, , $(OUT)/riscv32/$(e), $(e), uniq,$(EXPECTED_$(e))))
-
-EXPECTED_aes_sha1 = 89169ec034bec1c6bb2c556b26728a736d350ca3  -
-misalign: $(BIN) artifact
-	$(call check-test, -m, $(OUT)/riscv32/uaes, uaes.elf, $(SHA1SUM),$(EXPECTED_aes_sha1))
-
-EXPECTED_misalign = MISALIGNED INSTRUCTION FETCH TEST PASSED!
-misalign-in-blk-emu: $(BIN)
-	$(call check-test, , tests/system/alignment/misalign.elf, misalign.elf, tail -n 1,$(EXPECTED_misalign))
-
-EXPECTED_mmu = Store page fault test passed!
-mmu-test: $(BIN)
-	$(call check-test, , tests/system/mmu/vm.elf, vm.elf, tail -n 1,$(EXPECTED_mmu))
-
-# Demo Applications
-
-ifeq ($(CONFIG_SDL),y)
-doom_action := (cd $(OUT); LC_ALL=C ../$(BIN) riscv32/doom)
-doom_deps += $(DOOM_DATA) $(BIN)
-doom: artifact $(doom_deps)
-	$(doom_action)
-
-ifeq ($(CONFIG_EXT_F),y)
-quake_action := (cd $(OUT); LC_ALL=C ../$(BIN) riscv32/quake)
-quake_deps += $(QUAKE_DATA) $(BIN)
-quake: artifact $(quake_deps)
-	$(quake_action)
-endif
-endif
-
-# Code Formatting
-
-CLANG_FORMAT := $(shell which clang-format-20 2>/dev/null)
-SHFMT := $(shell which shfmt 2>/dev/null)
-DTSFMT := $(shell which dtsfmt 2>/dev/null)
-BLACK := $(shell which black 2>/dev/null)
-
-SUBMODULES := $(shell git config --file .gitmodules --get-regexp path 2>/dev/null | awk '{ print $$2 }')
-SUBMODULES_PRUNE_PATHS := $(shell for subm in $(SUBMODULES); do echo -n "-path \"./$$subm\" -o "; done | sed 's/ -o $$//')
-
-format:
-ifeq ($(CLANG_FORMAT),)
-	$(error clang-format-20 not found. Install clang-format version 20.)
-endif
-	$(Q)$(CLANG_FORMAT) -i $(shell find . \( $(SUBMODULES_PRUNE_PATHS) -o -path "./$(OUT)" \) \
-	                                   -prune -o -name "*.[ch]" -print)
-ifeq ($(SHFMT),)
-	$(error shfmt not found.)
-endif
-	$(Q)$(SHFMT) -w $(shell find . \( $(SUBMODULES_PRUNE_PATHS) -o -path "./$(OUT)" \) \
-	                            -prune -o -name "*.sh" -print)
-ifeq ($(DTSFMT),)
-	$(error dtsfmt not found.)
-endif
-	$(Q)for dts_src in $$(find . \( $(SUBMODULES_PRUNE_PATHS) -o -path "./$(OUT)" \) \
-	                -prune -o \( -name "*.dts" -o -name "*.dtsi" \) -print); do \
-		$(DTSFMT) $$dts_src; \
-	done
-ifeq ($(BLACK),)
-	$(error black not found. Install black version 25.1.0+.)
-endif
-	$(Q)$(BLACK) --quiet $(shell find . \( $(SUBMODULES_PRUNE_PATHS) -o -path "./$(OUT)" \) \
-	                             -prune -o \( -name "*.py" -o -name "*.pyi" \) -print)
-	$(Q)$(call notice, All files formatted.)
+tool: $(TOOLS_BIN)
 
 # Clean Targets
-
 clean:
 	$(VECHO) "Cleaning... "
 	$(Q)$(RM) $(BIN) $(OBJS) $(DEV_OBJS) $(BUILD_DTB) $(BUILD_DTB2C) $(HIST_BIN) $(HIST_OBJS) $(deps) $(WEB_FILES) $(CACHE_OUT)
@@ -495,17 +241,12 @@ clean:
 
 distclean: clean
 	$(VECHO) "Deleting all generated files... "
-	$(Q)$(RM) -r $(OUT)/id1
-	$(Q)$(RM) -r $(DEMO_DIR)
+	$(Q)$(RM) -r $(OUT)/id1 $(DEMO_DIR) $(OUT)/mini-gdbstub $(OUT)/devices
 	$(Q)$(RM) *.zip
-	$(Q)$(RM) -r $(OUT)/mini-gdbstub
-	$(Q)$(RM) -r $(OUT)/devices
 	$(Q)-$(RM) .config $(CONFIG_HEADER)
 	$(Q)-$(RM) -r $(SOFTFLOAT_DUMMY_PLAT) $(OUT)/softfloat
 	$(Q)$(call notice, [OK])
 
-.PHONY: all config defconfig oldconfig savedefconfig env-check kconfig-tools
-.PHONY: tool check check-hello misalign misalign-in-blk-emu mmu-test
-.PHONY: gdbstub-test doom quake format clean distclean artifact
+.PHONY: all tool clean distclean gdbstub-test
 
 -include $(deps)

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ $ make defconfig          # Default: SDL enabled, all extensions
 $ make mini_defconfig     # Minimal: no SDL, basic extensions only
 $ make jit_defconfig      # JIT: enables tiered JIT compilation
 $ make system_defconfig   # System: enables Linux system emulation
+$ make wasm_defconfig     # WebAssembly: build for browser deployment
 ```
 
 #### 2. Interactive Configuration

--- a/configs/Kconfig
+++ b/configs/Kconfig
@@ -12,8 +12,9 @@ config COMPILER_TYPE
     string
     default "$(shell,tools/detect-env.py --compiler 2>/dev/null || echo Unknown)"
 
-config CC_IS_EMCC
-    def_bool $(shell,tools/detect-env.py --is-emcc 2>/dev/null)
+config HAVE_EMCC
+    bool
+    default $(shell,tools/detect-env.py --have-emcc 2>/dev/null)
 
 config CC_IS_CLANG
     def_bool $(shell,tools/detect-env.py --is-clang 2>/dev/null)
@@ -21,11 +22,52 @@ config CC_IS_CLANG
 config CC_IS_GCC
     def_bool $(shell,tools/detect-env.py --is-gcc 2>/dev/null)
 
+comment "Emscripten detected - WebAssembly build available"
+    depends on HAVE_EMCC
+
+comment "Emscripten not found - install emsdk for WebAssembly builds"
+    depends on !HAVE_EMCC
+
+endmenu
+
+# Build Target Selection
+
+menu "Build Target"
+
+choice
+    prompt "Build Target"
+    default BUILD_NATIVE
+    help
+      Select the build target platform.
+
+config BUILD_NATIVE
+    bool "Native (Linux/macOS/Windows)"
+    help
+      Build native executable for the host platform.
+      Uses system compiler (GCC or Clang).
+
+config BUILD_WASM
+    bool "WebAssembly (Emscripten)"
+    depends on HAVE_EMCC
+    help
+      Build WebAssembly module for web browsers.
+      Requires Emscripten SDK (emsdk) to be installed and activated.
+
+      The build will use 'emcc' as the compiler.
+      Run in browser with: make start-web
+
+endchoice
+
+# Internal: Set CC_IS_EMCC when BUILD_WASM is selected
+config CC_IS_EMCC
+    bool
+    default BUILD_WASM
+
 comment "Build mode: WebAssembly (Emscripten)"
-    depends on CC_IS_EMCC
+    depends on BUILD_WASM
 
 comment "Build mode: Native"
-    depends on !CC_IS_EMCC
+    depends on BUILD_NATIVE
 
 endmenu
 

--- a/configs/wasm_defconfig
+++ b/configs/wasm_defconfig
@@ -1,3 +1,4 @@
 # WebAssembly build with Emscripten
+CONFIG_BUILD_WASM=y
 # CONFIG_LTO is not set
 CONFIG_OPTIMIZE_LEVEL=3

--- a/mk/external.mk
+++ b/mk/external.mk
@@ -1,178 +1,226 @@
-COMPRESSED_SUFFIX :=
-COMPRESSED_IS_ZIP :=
-COMPRESSED_IS_DIR :=
-EXTRACTOR :=
-VERIFIER :=
-
-# Temporary files to store correct SHA value and computed SHA value
-# respectively for verification of directory source
-SHA_FILE1 := $(shell mktemp)
-SHA_FILE2 := $(shell mktemp)
-
-# $(1): compressed source
-define prologue
-    $(eval _ := $(shell echo "  GET\t$(1)\n"))
-    $(info $(_))
-endef
-
-# $(1), $(2): files to be deleted
-define epilogue
-    $(RM) $(1) $(2)
-endef
-
-# $(1): compressed source URL
-# if URL contains git command, then use git
-define download
-    $(eval _ :=  \
-        $(if $(findstring git,$(1)), \
-            ($(eval _ := $(shell $(1)))), \
-            ($(eval _ := $(shell wget -q --show-progress --continue "$(strip $(1))"))) \
-    ))
-endef
-
-# $(1): destination directory
-# $(2): compressed source(.zip or.gz)
-# $(3): strip component level (only for tar)
-# For Buildroot and Linux kernel, no need to extract
-define extract
-    $(eval COMPRESSED_SUFFIX := $(suffix $(2)))
-    $(eval COMPRESSED_IS_ZIP := $(filter $(COMPRESSED_SUFFIX),.zip))
-    $(eval _ := \
-        $(if $(findstring git,$(2)), \
-            (# git is used, do nothing), \
-            ($(eval _ :=  \
-                $(if $(COMPRESSED_IS_ZIP), \
-                    ($(eval EXTRACTOR := unzip -d $(1) $(2))), \
-                    ($(eval EXTRACTOR := tar -xf $(2) --strip-components=$(3) -C $(1))) \
-            )) \
-            $(eval _ := $(shell $(EXTRACTOR))))
-        ) \
-    )
-endef
-
-# $(1): SHA algorithm command
-# $(2): correct SHA value
-# $(3): filename or directory path
-# $(4): (optional) returned result
+# External data dependencies (Doom, Quake, Linux kernel, etc.)
 #
-# Note:
-# 1. for regular file, $(1) command's -c option generates keyword "FAILED" for indicating an unmatch
-# 2. for directory, cmp command outputs keyword "differ" for indicating an unmatch
-define verify
-    $(eval COMPRESSED_IS_DIR := $(if $(wildcard $(3)/*),1,0))
-    $(eval _ := \
-        $(if $(filter 1,$(COMPRESSED_IS_DIR)), \
-            ($(eval VERIFIER :=  \
-                echo $(2) > $(SHA_FILE1) \
-                | find $(3) -type f -not -path '*/.git/*' -print0 \
-                | LC_ALL=C sort -z \
-                | xargs -0 $(1) \
-                | LC_ALL=C sort \
-                | $(1) \
-                | cut -f 1 -d ' ' > $(SHA_FILE2) && cmp $(SHA_FILE1) $(SHA_FILE2))), \
-            ($(eval VERIFIER := (ls $(3) >/dev/null 2>&1 || echo FAILED) && echo "$(strip $(2))  $(strip $(3))" | $(1) -c -)) \
-    ))
-    $(eval _ := $(shell $(VERIFIER) 2>&1))
-    $(eval _ := \
-        $(if $(filter FAILED differ:,$(_)), \
-            ($(if $(4), \
-                $(eval $(4) := 1), \
-                $(error $(_)) \
-            )), \
-            (# SHA value match, do nothing) \
-    ))
-endef
+# Provides templates for downloading, extracting, and verifying external assets.
 
-# For each external target, the following must be defined in advance:
-#   _DATA_URL : the hyperlink which points to archive.
-#   _DATA_DEST : the extract destination of the file (only for compressed file)
-#   _DATA : the file to be read by specific executable.
-#   _DATA_SKIP_DIR_LEVEL : the strip component level when using tar
-#   _DATA_SHA : the SHA value of the content in _DATA
-#   _DATA_SHA_CMD : the SHA command
+ifndef _MK_EXTERNAL_INCLUDED
+_MK_EXTERNAL_INCLUDED := 1
 
-# Doom
-# https://tipsmake.com/how-to-run-doom-on-raspberry-pi-without-emulator
-DOOM_DATA_URL = http://www.doomworld.com/3ddownloads/ports/shareware_doom_iwad.zip
-DOOM_DATA_DEST = $(OUT)
-DOOM_DATA = $(DOOM_DATA_DEST)/DOOM1.WAD
-DOOM_DATA_SHA = 5b2e249b9c5133ec987b3ea77596381dc0d6bc1d
-DOOM_DATA_SHA_CMD = $(SHA1SUM)
+# SHA Utilities (for verification)
+# Use command -v for POSIX compatibility (avoid 'which')
 
-# Quake
-QUAKE_DATA_URL = https://www.libsdl.org/projects/quake/data/quakesw-1.0.6.zip
-QUAKE_DATA_DEST = $(OUT)
-QUAKE_DATA = $(QUAKE_DATA_DEST)/id1/pak0.pak
-QUAKE_DATA_SHA = 36b42dc7b6313fd9cabc0be8b9e9864840929735
-QUAKE_DATA_SHA_CMD = $(SHA1SUM)
-
-# Timidity software synthesizer configuration for SDL2_mixer
-TIMIDITY_DATA_URL = https://www.libsdl.org/projects/old/SDL_mixer/timidity/timidity.tar.gz
-TIMIDITY_DATA_DEST = $(OUT)
-TIMIDITY_DATA = $(TIMIDITY_DATA_DEST)/timidity
-TIMIDITY_DATA_SKIP_DIR_LEVEL = 0
-# find $(TIMIDITY_DATA_DEST)/timidity -type f -not -path '*/.git/*' -print0 | \
-	LC_ALL=C sort -z | \
-	xargs -0 sha1sum | \
-	LC_ALL=C sort | \
-	sha1sum
-TIMIDITY_DATA_SHA = cf6217a5d824b717ec4a07e15e6c129a4657ca25
-TIMIDITY_DATA_SHA_CMD = $(SHA1SUM)
-
-# Buildroot
-BUILDROOT_VERSION = 2025.11
-BUILDROOT_DATA = /tmp/buildroot
-BUILDROOT_DATA_URL = git clone https://github.com/buildroot/buildroot $(BUILDROOT_DATA) -b $(BUILDROOT_VERSION) --depth=1
-# find /tmp/buildroot -type f -not -path '*/.git/*' -print0 | \
-	LC_ALL=C sort -z | \
-	xargs -0 sha1sum | \
-	LC_ALL=C sort | \
-	sha1sum
-BUILDROOT_DATA_SHA = 70999b51eb4034eb96457a0ac210365c9cc7c2bb
-BUILDROOT_DATA_SHA_CMD = $(SHA1SUM)
-
-# Linux kernel
-LINUX_VERSION = 6
-LINUX_PATCHLEVEL = 1
-LINUX_CDN_BASE_URL = https://cdn.kernel.org/pub/linux/kernel
-LINUX_CDN_VERSION_URL = $(LINUX_CDN_BASE_URL)/v$(LINUX_VERSION).x
-$(shell mkdir -p /tmp/linux)
-LINUX_DATA_DEST = /tmp/linux
-# Only fetch Linux artifact for build-linux-image target
-ifneq ($(filter build-linux-image,$(MAKECMDGOALS)),)
-    LINUX_DATA := $(shell wget -q -O- $(LINUX_CDN_VERSION_URL) | \
-                         grep -o 'linux-$(LINUX_VERSION).$(LINUX_PATCHLEVEL).[0-9]\+\.tar.gz' | \
-                         sort -V | tail -n 1)
-    LINUX_DATA_SHA := $(shell wget -q -O- $(LINUX_CDN_VERSION_URL)/sha256sums.asc | \
-                             grep $(LINUX_DATA) | awk '{print $$1}')
-else
-    LINUX_DATA :=
-    LINUX_DATA_SHA :=
+SHA1SUM := $(shell command -v sha1sum 2>/dev/null)
+ifndef SHA1SUM
+    SHA1SUM := $(shell command -v shasum 2>/dev/null)
 endif
-LINUX_DATA_URL = $(LINUX_CDN_VERSION_URL)/$(LINUX_DATA)
-LINUX_DATA_SKIP_DIR_LEVEL = 1
-LINUX_DATA_SHA_CMD = $(SHA256SUM)
+ifndef SHA1SUM
+    $(warning SHA1SUM tool not found - checksum verification will be skipped)
+endif
 
-# simplefs
-SIMPLEFS_VERSION = rel2025.0
-SIMPLEFS_DATA = /tmp/simplefs
-SIMPLEFS_DATA_URL = git clone https://github.com/sysprog21/simplefs $(SIMPLEFS_DATA) -b $(SIMPLEFS_VERSION) --depth=1
-# find /tmp/simplefs -type f -not -path '*/.git/*' -print0 | \
-	LC_ALL=C sort -z | \
-	xargs -0 sha1sum | \
-	LC_ALL=C sort | \
-	sha1sum
-SIMPLEFS_DATA_SHA = 863936f72e0781b240c5ec4574510c57f0394b99
-SIMPLEFS_DATA_SHA_CMD = $(SHA1SUM)
+SHA256SUM := $(shell command -v sha256sum 2>/dev/null)
+ifeq ($(SHA256SUM),)
+    SHA256SUM_SHASUM := $(shell command -v shasum 2>/dev/null)
+    ifneq ($(SHA256SUM_SHASUM),)
+        # Verify shasum supports -a 256 before using it
+        SHA256SUM_TEST := $(shell echo test | $(SHA256SUM_SHASUM) -a 256 >/dev/null 2>&1 && echo ok)
+        ifeq ($(SHA256SUM_TEST),ok)
+            SHA256SUM := $(SHA256SUM_SHASUM) -a 256
+        endif
+    endif
+endif
+ifeq ($(SHA256SUM),)
+    $(warning SHA256SUM tool not found - checksum verification will be skipped)
+endif
 
-define download-extract-verify
-$($(T)_DATA):
-	$(Q)$$(call prologue,$$@)
-	$(Q)$$(call download,$(strip $($(T)_DATA_URL)))
-	$(Q)$$(call extract,$($(T)_DATA_DEST),$(notdir $($(T)_DATA_URL)),$($(T)_DATA_SKIP_DIR_LEVEL))
-	$(Q)$$(call verify,$($(T)_DATA_SHA_CMD),$($(T)_DATA_SHA),$($(T)_DATA))
-	$(Q)$$(call epilogue,$(SHA_FILE1),$(SHA_FILE2))
+# Download/Extract/Verify Templates
+
+# Print download message
+# $(1): target file
+define prologue
+	$(VECHO) "  GET\t$(1)\n"
 endef
 
-EXTERNAL_DATA = DOOM QUAKE TIMIDITY BUILDROOT LINUX SIMPLEFS
-$(foreach T,$(EXTERNAL_DATA),$(eval $(download-extract-verify)))
+# Check if command is a git clone (first word is 'git')
+# $(1): URL or git command
+define is-git-clone
+$(filter git,$(firstword $(1)))
+endef
+
+# Detect wget --show-progress support (GNU wget extension)
+WGET_HAS_PROGRESS := $(shell wget --help 2>&1 | grep -q show-progress && echo yes)
+
+# Download from URL (supports git clone or wget)
+# $(1): URL or git command
+define download
+$(if $(call is-git-clone,$(1)),\
+	$(1),\
+	wget -q $(if $(WGET_HAS_PROGRESS),--show-progress) --continue "$(strip $(1))")
+endef
+
+# Extract archive to destination
+# $(1): destination directory
+# $(2): archive file (.zip or .tar.gz)
+# $(3): strip component level (for tar only)
+define extract
+$(if $(filter .zip,$(suffix $(2))),\
+	unzip -q -d $(1) $(2),\
+	tar -xf $(2) --strip-components=$(3) -C $(1))
+endef
+
+# Verify SHA checksum (auto-detects file vs directory at runtime)
+# $(1): SHA command (sha1sum or sha256sum, may be empty if tool unavailable)
+# $(2): expected SHA value
+# $(3): path to verify (file or directory)
+# Returns: exits with error if verification fails; skips if no SHA tool
+define verify-sha
+	@if [ -z "$(1)" ]; then \
+		echo "Skipping SHA verification for $(3) (no SHA tool available)"; \
+	elif [ -d "$(3)" ]; then \
+		FILE_HASHES=$$(find "$(3)" -type f -not -path '*/.git/*' -print0 | LC_ALL=C sort -z | xargs -0 $(1) 2>/dev/null | LC_ALL=C sort); \
+		if [ -z "$$FILE_HASHES" ]; then \
+			echo "SHA verification failed for directory $(3): no files found"; \
+			exit 1; \
+		fi; \
+		COMPUTED=$$(echo "$$FILE_HASHES" | $(1) | cut -f1 -d' '); \
+		if [ "$$COMPUTED" != "$(2)" ]; then \
+			echo "SHA verification failed for directory $(3)"; \
+			exit 1; \
+		fi; \
+	else \
+		if ! echo "$(2)  $(3)" | $(1) -c - >/dev/null 2>&1; then \
+			echo "SHA verification failed for $(3)"; \
+			exit 1; \
+		fi; \
+	fi
+endef
+
+# Clean up downloaded archive
+# $(1): archive filename
+define epilogue
+	$(Q)$(RM) $(1)
+endef
+
+# External Data Definitions
+
+# Doom WAD file
+DOOM_DATA_URL := https://www.doomworld.com/3ddownloads/ports/shareware_doom_iwad.zip
+DOOM_DATA_DEST := $(OUT)
+DOOM_DATA := $(DOOM_DATA_DEST)/DOOM1.WAD
+DOOM_DATA_SHA := 5b2e249b9c5133ec987b3ea77596381dc0d6bc1d
+DOOM_DATA_SHA_CMD := $(SHA1SUM)
+
+# Quake PAK file
+QUAKE_DATA_URL := https://www.libsdl.org/projects/quake/data/quakesw-1.0.6.zip
+QUAKE_DATA_DEST := $(OUT)
+QUAKE_DATA := $(QUAKE_DATA_DEST)/id1/pak0.pak
+QUAKE_DATA_SHA := 36b42dc7b6313fd9cabc0be8b9e9864840929735
+QUAKE_DATA_SHA_CMD := $(SHA1SUM)
+
+# Timidity software synthesizer (for MIDI in SDL2_mixer)
+TIMIDITY_DATA_URL := https://www.libsdl.org/projects/old/SDL_mixer/timidity/timidity.tar.gz
+TIMIDITY_DATA_DEST := $(OUT)
+TIMIDITY_DATA := $(TIMIDITY_DATA_DEST)/timidity
+TIMIDITY_DATA_SKIP_DIR_LEVEL := 0
+# find $(TIMIDITY_DATA_DEST)/timidity -type f -not -path '*/.git/*' -print0 | \
+#	LC_ALL=C sort -z | \
+#	xargs -0 sha1sum | \
+#	LC_ALL=C sort | \
+#	sha1sum
+TIMIDITY_DATA_SHA := cf6217a5d824b717ec4a07e15e6c129a4657ca25
+TIMIDITY_DATA_SHA_CMD := $(SHA1SUM)
+
+# Buildroot (for Linux image building)
+BUILDROOT_VERSION := 2025.11
+BUILDROOT_DATA := /tmp/buildroot
+BUILDROOT_DATA_URL := git clone https://github.com/buildroot/buildroot $(BUILDROOT_DATA) -b $(BUILDROOT_VERSION) --depth=1
+# find /tmp/buildroot -type f -not -path '*/.git/*' -print0 | \
+#	LC_ALL=C sort -z | \
+#	xargs -0 sha1sum | \
+#	LC_ALL=C sort | \
+#	sha1sum
+BUILDROOT_DATA_SHA := 70999b51eb4034eb96457a0ac210365c9cc7c2bb
+BUILDROOT_DATA_SHA_CMD := $(SHA1SUM)
+
+# Linux kernel (uses lazy evaluation to avoid parse-time network calls)
+LINUX_VERSION := 6
+LINUX_PATCHLEVEL := 1
+LINUX_CDN_BASE_URL := https://cdn.kernel.org/pub/linux/kernel
+LINUX_CDN_VERSION_URL := $(LINUX_CDN_BASE_URL)/v$(LINUX_VERSION).x
+LINUX_DATA_DEST := /tmp/linux
+LINUX_DATA_SKIP_DIR_LEVEL := 1
+LINUX_DATA_SHA_CMD := $(SHA256SUM)
+
+# simplefs kernel module
+SIMPLEFS_VERSION := rel2025.0
+SIMPLEFS_DATA := /tmp/simplefs
+SIMPLEFS_DATA_URL := git clone https://github.com/sysprog21/simplefs $(SIMPLEFS_DATA) -b $(SIMPLEFS_VERSION) --depth=1
+# find /tmp/simplefs -type f -not -path '*/.git/*' -print0 | \
+#	LC_ALL=C sort -z | \
+#	xargs -0 sha1sum | \
+#	LC_ALL=C sort | \
+#	sha1sum
+SIMPLEFS_DATA_SHA := 863936f72e0781b240c5ec4574510c57f0394b99
+SIMPLEFS_DATA_SHA_CMD := $(SHA1SUM)
+
+# Download Rules Template
+
+# Generate download/extract/verify rules for each external target
+# $(1): target name (DOOM, QUAKE, etc.)
+define download-extract-verify
+$($(1)_DATA):
+	$$(call prologue,$$@)
+	$(Q)mkdir -p $($(1)_DATA_DEST)
+	$(Q)$$(call download,$($(1)_DATA_URL))
+	$(Q)$(if $(call is-git-clone,$($(1)_DATA_URL)),,\
+		$$(call extract,$($(1)_DATA_DEST),$(notdir $($(1)_DATA_URL)),$(or $($(1)_DATA_SKIP_DIR_LEVEL),0)))
+	$$(call verify-sha,$($(1)_DATA_SHA_CMD),$($(1)_DATA_SHA),$($(1)_DATA))
+	$(if $(call is-git-clone,$($(1)_DATA_URL)),,\
+		$$(call epilogue,$(notdir $($(1)_DATA_URL))))
+endef
+
+# Generate rules for static external data (known URLs at parse time)
+EXTERNAL_DATA_STATIC := DOOM QUAKE TIMIDITY BUILDROOT SIMPLEFS
+$(foreach T,$(EXTERNAL_DATA_STATIC),$(eval $(call download-extract-verify,$(T))))
+
+# Linux kernel: special rule with lazy network detection (avoids parse-time wget)
+# Detects latest patch version and SHA only when this target is actually built
+# Note: Uses awk for portable version sorting (sort -V is GNU-specific)
+$(LINUX_DATA_DEST)/linux-$(LINUX_VERSION).$(LINUX_PATCHLEVEL).%.tar.gz:
+	$(Q)mkdir -p $(LINUX_DATA_DEST)
+	$(VECHO) "  GET\t$@\n"
+	$(Q)LINUX_TARBALL=$$(wget -q -O- $(LINUX_CDN_VERSION_URL) 2>/dev/null | \
+		grep -oE 'linux-$(LINUX_VERSION)\.$(LINUX_PATCHLEVEL)\.[0-9]+\.tar\.gz' | \
+		awk -F'[.-]' '{print $$4, $$0}' | sort -rn | head -1 | awk '{print $$2}'); \
+	if [ -z "$$LINUX_TARBALL" ]; then \
+		echo "Error: Failed to detect Linux kernel tarball from $(LINUX_CDN_VERSION_URL)"; \
+		exit 1; \
+	fi; \
+	LINUX_SHA=$$(wget -q -O- $(LINUX_CDN_VERSION_URL)/sha256sums.asc 2>/dev/null | \
+		grep "$$LINUX_TARBALL" | awk '{print $$1}'); \
+	if [ -z "$$LINUX_SHA" ]; then \
+		echo "Error: Failed to fetch SHA256 for $$LINUX_TARBALL"; \
+		exit 1; \
+	fi; \
+	wget -q --show-progress --continue "$(LINUX_CDN_VERSION_URL)/$$LINUX_TARBALL" && \
+	tar -xf "$$LINUX_TARBALL" --strip-components=$(LINUX_DATA_SKIP_DIR_LEVEL) -C $(LINUX_DATA_DEST) && \
+	if [ -z "$(LINUX_DATA_SHA_CMD)" ]; then \
+		echo "Skipping SHA verification for $$LINUX_TARBALL (no SHA tool available)"; \
+	elif ! echo "$$LINUX_SHA  $$LINUX_TARBALL" | $(LINUX_DATA_SHA_CMD) -c - >/dev/null 2>&1; then \
+		echo "SHA verification failed for $$LINUX_TARBALL"; exit 1; \
+	fi && \
+	$(RM) "$$LINUX_TARBALL"
+
+# Demo Applications (Doom, Quake)
+
+ifeq ($(CONFIG_SDL),y)
+doom: artifact $(DOOM_DATA) $(BIN)
+	(cd $(OUT); LC_ALL=C ../$(BIN) riscv32/doom)
+
+ifeq ($(CONFIG_EXT_F),y)
+quake: artifact $(QUAKE_DATA) $(BIN)
+	(cd $(OUT); LC_ALL=C ../$(BIN) riscv32/quake)
+endif
+endif
+
+.PHONY: doom quake
+
+endif # _MK_EXTERNAL_INCLUDED

--- a/mk/kconfig.mk
+++ b/mk/kconfig.mk
@@ -1,0 +1,106 @@
+# Kconfig Integration
+#
+# Provides configuration menu and .config management using kconfiglib.
+
+ifndef _MK_KCONFIG_INCLUDED
+_MK_KCONFIG_INCLUDED := 1
+
+KCONFIG_DIR := tools/kconfig
+KCONFIG := configs/Kconfig
+CONFIG_HEADER := src/rv32emu_config.h
+KCONFIGLIB_REPO := https://github.com/sysprog21/Kconfiglib
+
+# Download Kconfig tools if missing
+# Handles partial clones by removing incomplete directory before re-cloning
+# Safety: validates KCONFIG_DIR is non-empty and under project root before rm -rf
+$(KCONFIG_DIR)/kconfiglib.py:
+	$(VECHO) "Downloading Kconfig tools...\n"
+	$(Q)if [ -z "$(KCONFIG_DIR)" ]; then \
+		echo "Error: KCONFIG_DIR is empty"; exit 1; \
+	fi
+	$(Q)case "$(KCONFIG_DIR)" in \
+		/*|..*) echo "Error: KCONFIG_DIR must be relative path under project"; exit 1 ;; \
+	esac
+	$(Q)if [ -d "$(KCONFIG_DIR)" ] && [ ! -f "$(KCONFIG_DIR)/kconfiglib.py" ]; then \
+		echo "Removing incomplete Kconfig directory..."; \
+		rm -rf "$(KCONFIG_DIR)"; \
+	fi
+	$(Q)git clone --depth=1 -q $(KCONFIGLIB_REPO) $(KCONFIG_DIR)
+	@echo "Kconfig tools installed to $(KCONFIG_DIR)"
+
+# Ensure all Kconfig tools exist
+$(KCONFIG_DIR)/menuconfig.py $(KCONFIG_DIR)/defconfig.py $(KCONFIG_DIR)/genconfig.py \
+$(KCONFIG_DIR)/oldconfig.py $(KCONFIG_DIR)/savedefconfig.py: $(KCONFIG_DIR)/kconfiglib.py
+
+# Run environment detection before showing menu
+env-check:
+	@echo "Checking build environment..."
+	@python3 tools/detect-env.py --summary
+	@echo ""
+	@if python3 tools/detect-env.py --have-emcc 2>/dev/null | grep -q y; then \
+		echo "[WebAssembly] Emscripten detected. 'WebAssembly' build target available in 'make config'."; \
+	else \
+		echo "[WebAssembly] Emscripten not found. Install emsdk to enable WASM builds."; \
+	fi
+	@echo ""
+
+# Interactive configuration
+config: env-check $(KCONFIG_DIR)/menuconfig.py
+	@python3 $(KCONFIG_DIR)/menuconfig.py $(KCONFIG)
+	@python3 $(KCONFIG_DIR)/genconfig.py --header-path $(CONFIG_HEADER) $(KCONFIG)
+	@echo "Configuration saved to .config and $(CONFIG_HEADER)"
+
+# Apply default configuration (supports CONFIG=name for named configs)
+defconfig: $(KCONFIG_DIR)/defconfig.py
+	@if [ -n "$(CONFIG)" ]; then \
+		if [ -f "configs/$(CONFIG)_defconfig" ]; then \
+			echo "Applying configs/$(CONFIG)_defconfig..."; \
+			python3 $(KCONFIG_DIR)/defconfig.py --kconfig $(KCONFIG) configs/$(CONFIG)_defconfig; \
+		else \
+			echo "Error: configs/$(CONFIG)_defconfig not found"; exit 1; \
+		fi; \
+	else \
+		echo "Applying default configuration..."; \
+		python3 $(KCONFIG_DIR)/defconfig.py --kconfig $(KCONFIG) configs/defconfig; \
+	fi
+	@python3 $(KCONFIG_DIR)/genconfig.py --header-path $(CONFIG_HEADER) $(KCONFIG)
+	@echo "Configuration applied."
+
+# Pattern rule for named defconfigs (e.g., make jit_defconfig)
+%_defconfig: $(KCONFIG_DIR)/defconfig.py
+	@if [ -f "configs/$*_defconfig" ]; then \
+		echo "Applying configs/$*_defconfig..."; \
+		python3 $(KCONFIG_DIR)/defconfig.py --kconfig $(KCONFIG) configs/$*_defconfig; \
+		python3 $(KCONFIG_DIR)/genconfig.py --header-path $(CONFIG_HEADER) $(KCONFIG); \
+		echo "Configuration applied."; \
+	else \
+		echo "Error: configs/$*_defconfig not found"; exit 1; \
+	fi
+
+# Update configuration after Kconfig changes
+oldconfig: $(KCONFIG_DIR)/oldconfig.py
+	@python3 $(KCONFIG_DIR)/oldconfig.py $(KCONFIG)
+	@python3 $(KCONFIG_DIR)/genconfig.py --header-path $(CONFIG_HEADER) $(KCONFIG)
+
+# Save current configuration as minimal defconfig
+savedefconfig: $(KCONFIG_DIR)/savedefconfig.py
+	@python3 $(KCONFIG_DIR)/savedefconfig.py --kconfig $(KCONFIG) --out defconfig.new
+	@echo "Saved minimal config to defconfig.new"
+
+# Explicit target to download/update Kconfig tools
+kconfig-tools: $(KCONFIG_DIR)/kconfiglib.py
+	@echo "Kconfig tools are ready in $(KCONFIG_DIR)"
+
+# Generate .config if missing (order-only to preserve user customizations)
+.config: | $(KCONFIG_DIR)/defconfig.py
+	@python3 $(KCONFIG_DIR)/defconfig.py --kconfig $(KCONFIG) configs/defconfig
+	@echo "Generated .config from default configuration"
+
+# Auto-generate config header from .config
+$(CONFIG_HEADER): .config $(KCONFIG_DIR)/genconfig.py
+	@python3 $(KCONFIG_DIR)/genconfig.py --header-path $(CONFIG_HEADER) $(KCONFIG)
+	@echo "Generated $(CONFIG_HEADER)"
+
+.PHONY: config defconfig oldconfig savedefconfig env-check kconfig-tools
+
+endif # _MK_KCONFIG_INCLUDED

--- a/mk/riscv-arch-test.mk
+++ b/mk/riscv-arch-test.mk
@@ -1,3 +1,10 @@
+# RISC-V Architecture Compliance Testing
+#
+# Uses riscof framework to run official RISC-V architecture tests.
+
+ifndef _MK_RISCV_ARCH_TEST_INCLUDED
+_MK_RISCV_ARCH_TEST_INCLUDED := 1
+
 riscof-check:
 	$(Q)if [ "$(shell pip show riscof 2>&1 | head -n 1 | cut -d' ' -f1)" = "WARNING:" ]; then \
 		$(PRINTF) "Run 'pip3 install -r requirements.txt' to install dependencies.\n"; \
@@ -7,7 +14,8 @@ riscof-check:
 ARCH_TEST_DIR ?= tests/riscv-arch-test
 ARCH_TEST_SUITE ?= $(ARCH_TEST_DIR)/riscv-test-suite
 export RISCV_TARGET := tests/arch-test-target
-export TARGETDIR := $(shell pwd)
+# Use built-in CURDIR instead of $(shell pwd) to avoid shell invocation
+export TARGETDIR := $(CURDIR)
 export RISCV_DEVICE ?= IMACFZicsrZifencei
 # Use device-specific work directory to enable parallel arch-test execution
 export WORK := $(TARGETDIR)/build/arch-test-$(RISCV_DEVICE)
@@ -53,3 +61,5 @@ endif
 			--env=$(ARCH_TEST_DIR)/riscv-test-suite/env
 
 .PHONY: riscof-check arch-test
+
+endif # _MK_RISCV_ARCH_TEST_INCLUDED

--- a/mk/softfloat.mk
+++ b/mk/softfloat.mk
@@ -1,3 +1,10 @@
+# Berkeley SoftFloat library for floating-point emulation
+#
+# Provides IEEE 754 compliant software floating-point for F extension.
+
+ifndef _MK_SOFTFLOAT_INCLUDED
+_MK_SOFTFLOAT_INCLUDED := 1
+
 SOFTFLOAT_DIR := src/softfloat/source
 
 # FIXME: Suppress compilation warnings in upstream SoftFloat 3
@@ -330,7 +337,7 @@ $(SOFTFLOAT_SENTINEL):
 	$(Q)git submodule update --init $(dir $@)
 SOFTFLOAT_DUMMY_PLAT := $(OUT)/softfloat/platform.h
 $(SOFTFLOAT_DUMMY_PLAT):
-	$(Q)mkdir -p $(shell dirname $@)
+	$(Q)mkdir -p $(dir $@)
 	$(Q)touch $@
 
 $(SOFTFLOAT_FILES): $(SOFTFLOAT_SENTINEL)
@@ -345,3 +352,5 @@ SOFTFLOAT_LIB := $(OUT)/softfloat/softfloat.a
 $(SOFTFLOAT_LIB): $(SOFTFLOAT_OBJS)
 	$(VECHO) "  AR\t$@\n"
 	$(Q)$(AR) crs $@ $(SOFTFLOAT_OBJS)
+
+endif # _MK_SOFTFLOAT_INCLUDED

--- a/src/devices/uart.c
+++ b/src/devices/uart.c
@@ -107,7 +107,7 @@ static uint8_t u8250_handle_in(u8250_state_t *uart)
         }
     }
 
-#if RV32_HAS(SDL) && RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SDL) && RV32_HAS(SYSTEM_MMIO)
     /*
      * The guestOS may repeatedly open and close the SDL window,
      * and the user could close the application by pressing the ctrl-c key.

--- a/src/em_runtime.c
+++ b/src/em_runtime.c
@@ -22,7 +22,7 @@ EM_JS(void, disable_run_button, (), {
 });
 #endif
 
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
 extern uint8_t input_buf_size;
 
 char *get_input_buf();

--- a/src/em_runtime.h
+++ b/src/em_runtime.h
@@ -11,7 +11,7 @@
 /* To terminate the main loop of CPU */
 void indirect_rv_halt();
 
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
 /* To bridge xterm.js terminal with UART */
 extern uint8_t input_buf_size;
 

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -600,7 +600,7 @@ static set_t pc_set;
 static bool has_loops = false;
 #endif
 
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
 extern void emu_update_uart_interrupts(riscv_t *rv);
 static uint32_t peripheral_update_ctr = 64;
 #endif
@@ -1898,7 +1898,7 @@ static bool runtime_profiler(riscv_t *rv, block_t *block)
 }
 #endif
 
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
 static bool rv_has_plic_trap(riscv_t *rv)
 {
     return ((rv->csr_sstatus & SSTATUS_SIE || !rv->priv_mode) &&
@@ -1962,7 +1962,7 @@ void rv_step(void *arg)
 
     /* loop until hitting the cycle target */
     while (rv->csr_cycle < cycles_target && !rv->halt) {
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
         /* check for any interrupt after every block emulation */
         rv_check_interrupt(rv);
 #endif
@@ -2137,7 +2137,7 @@ void rv_step_debug(void *arg)
     assert(arg);
     riscv_t *rv = arg;
 
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
     rv_check_interrupt(rv);
 #endif
 
@@ -2321,7 +2321,7 @@ void ecall_handler(riscv_t *rv)
             rv->PC += 4;
             break;
         default:
-#if RV32_HAS(SDL) && RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SDL) && RV32_HAS(SYSTEM_MMIO)
             /*
              * The guestOS may repeatedly open and close the SDL window,
              * and the user could close the application using the application’s

--- a/src/main.c
+++ b/src/main.c
@@ -22,7 +22,7 @@
 #include "utils.h"
 
 /* enable program trace mode */
-#if !RV32_HAS(SYSTEM) || (RV32_HAS(SYSTEM) && RV32_HAS(ELF_LOADER))
+#if !RV32_HAS(SYSTEM_MMIO)
 static bool opt_trace = false;
 #endif
 
@@ -57,7 +57,7 @@ static bool opt_misaligned = false;
 static bool opt_prof_data = false;
 static char *prof_out_file;
 
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
 /* Linux kernel data */
 static char *opt_kernel_img;
 static char *opt_rootfs_img;
@@ -74,13 +74,13 @@ static void print_usage(const char *filename)
         "\nRV32I[MAFC] Emulator which loads an ELF file to execute.\n"
         "Usage: %s [options] [filename] [arguments]\n"
         "Options:\n"
-#if !RV32_HAS(SYSTEM) || (RV32_HAS(SYSTEM) && RV32_HAS(ELF_LOADER))
+#if !RV32_HAS(SYSTEM_MMIO)
         "  -t : print executable trace\n"
 #endif
 #if RV32_HAS(GDBSTUB)
         "  -g : allow remote GDB connections (as gdbstub)\n"
 #endif
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
         "  -k <image> : use <image> as kernel image\n"
         "  -i <image> : use <image> as rootfs\n"
         "  -x vblk:<image>[,readonly]: use "
@@ -109,7 +109,7 @@ static bool parse_args(int argc, char **args)
         emu_argc++;
 
         switch (opt) {
-#if !RV32_HAS(SYSTEM) || (RV32_HAS(SYSTEM) && RV32_HAS(ELF_LOADER))
+#if !RV32_HAS(SYSTEM_MMIO)
         case 't':
             opt_trace = true;
             break;
@@ -119,7 +119,7 @@ static bool parse_args(int argc, char **args)
             opt_gdbstub = true;
             break;
 #endif
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
         case 'k':
             opt_kernel_img = optarg;
             emu_argc++;
@@ -278,7 +278,7 @@ int main(int argc, char **args)
     }
 
     int run_flag = 0;
-#if !RV32_HAS(SYSTEM) || (RV32_HAS(SYSTEM) && RV32_HAS(ELF_LOADER))
+#if !RV32_HAS(SYSTEM_MMIO)
     run_flag |= opt_trace;
 #endif
 #if RV32_HAS(GDBSTUB)
@@ -298,7 +298,7 @@ int main(int argc, char **args)
         .cycle_per_step = CYCLE_PER_STEP,
         .allow_misalign = opt_misaligned,
     };
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
     attr.data.system.kernel = opt_kernel_img;
     attr.data.system.initrd = opt_rootfs_img;
     attr.data.system.bootargs = opt_bootargs;

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -12,7 +12,7 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
 #include <termios.h>
 #include "dtc/libfdt/libfdt.h"
 #endif
@@ -230,7 +230,7 @@ static void *t2c_runloop(void *arg)
 }
 #endif
 
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
 /* Map a file into memory at the specified location.
  * If max_size > 0, validates that file size does not exceed max_size.
  * Returns the actual file size on success, or -1 when file exceeds max_size
@@ -458,7 +458,7 @@ static void capture_keyboard_input()
 
 #endif
 
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
 /*
  *
  * atexit() registers void (*)(void) callbacks, so no parameters can be passed.
@@ -521,7 +521,7 @@ static void rv_fsync_device()
         free(attr->disk);
     }
 }
-#endif /* RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER) */
+#endif /* RV32_HAS(SYSTEM_MMIO) */
 
 riscv_t *rv_create(riscv_user_t rv_attr)
 {
@@ -532,7 +532,7 @@ riscv_t *rv_create(riscv_user_t rv_attr)
         return NULL;
     assert(rv);
 
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
     /* register cleaning callback for CTRL+a+x exit */
     atexit(rv_async_block_clear);
     /* register device sync callback for CTRL+a+x exit */
@@ -569,7 +569,7 @@ riscv_t *rv_create(riscv_user_t rv_attr)
     rv_log_set_level(attr->log_level);
     rv_log_info("Log level: %s", rv_log_level_string(attr->log_level));
 
-#if !RV32_HAS(SYSTEM) || (RV32_HAS(SYSTEM) && RV32_HAS(ELF_LOADER))
+#if !RV32_HAS(SYSTEM_MMIO)
     elf_t *elf = elf_new();
     assert(elf);
 
@@ -786,7 +786,7 @@ riscv_t *rv_create(riscv_user_t rv_attr)
     }
 
     capture_keyboard_input();
-#endif /* !RV32_HAS(SYSTEM) || (RV32_HAS(SYSTEM) && RV32_HAS(ELF_LOADER)) */
+#endif /* !RV32_HAS(SYSTEM_MMIO) */
 
     /* create block and IRs memory pool */
     rv->block_mp = mpool_create(sizeof(block_t) << BLOCK_MAP_CAPACITY_BITS,
@@ -845,7 +845,7 @@ fail_jit_state:
 #endif
 }
 
-#if !RV32_HAS(SYSTEM) || (RV32_HAS(SYSTEM) && RV32_HAS(ELF_LOADER))
+#if !RV32_HAS(SYSTEM_MMIO)
 /*
  * TODO: enable to trace Linux kernel symbol
  */
@@ -887,7 +887,7 @@ void rv_run(riscv_t *rv)
 
     vm_attr_t *attr = PRIV(rv);
     assert(attr &&
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
            attr->data.system.kernel && attr->data.system.initrd
 #else
            attr->data.user.elf_program
@@ -903,7 +903,7 @@ void rv_run(riscv_t *rv)
             rv_step(rv);            /* step instructions */
 #endif
     }
-#if !RV32_HAS(SYSTEM) || (RV32_HAS(SYSTEM) && RV32_HAS(ELF_LOADER))
+#if !RV32_HAS(SYSTEM_MMIO)
     else if (attr->run_flag & RV_RUN_TRACE)
         rv_run_and_trace(rv);
 #endif
@@ -943,7 +943,7 @@ void rv_set_fromhost_addr(riscv_t *rv, uint32_t addr)
 void rv_delete(riscv_t *rv)
 {
     assert(rv);
-#if !RV32_HAS(JIT) || (RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER))
+#if !RV32_HAS(JIT) || (RV32_HAS(SYSTEM_MMIO))
     vm_attr_t *attr = PRIV(rv);
 #endif
 #if !RV32_HAS(JIT)
@@ -961,7 +961,7 @@ void rv_delete(riscv_t *rv)
     jit_state_exit(rv->jit_state);
     cache_free(rv->block_cache);
 #endif
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
     u8250_delete(attr->uart);
     plic_delete(attr->plic);
     /* sync device, cleanup inside the callee */

--- a/src/riscv.h
+++ b/src/riscv.h
@@ -481,16 +481,16 @@ typedef struct {
 #endif /* RV32_HAS(SYSTEM) */
 
 typedef struct {
-#if !RV32_HAS(SYSTEM) || (RV32_HAS(SYSTEM) && RV32_HAS(ELF_LOADER))
+#if !RV32_HAS(SYSTEM_MMIO)
     vm_user_t user;
 #else
     vm_system_t system;
-#endif /* !RV32_HAS(SYSTEM) || (RV32_HAS(SYSTEM) && RV32_HAS(ELF_LOADER)) */
+#endif /* !RV32_HAS(SYSTEM_MMIO) */
 
 } vm_data_t;
 
 typedef struct {
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
     /* uart object */
     u8250_state_t *uart;
 
@@ -505,7 +505,7 @@ typedef struct {
     uint32_t vblk_mmio_max_hi;
     int vblk_irq_base;
     int vblk_cnt;
-#endif /* RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER) */
+#endif /* RV32_HAS(SYSTEM_MMIO) */
 
     /* vm memory object */
     memory_t *mem;
@@ -576,7 +576,7 @@ typedef struct {
     bool on_exit;
 #endif
 
-#if RV32_HAS(SDL) && RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SDL) && RV32_HAS(SYSTEM_MMIO)
     /* flag to determine if running SDL program in guestOS */
     bool running_sdl;
 #endif /* SDL */

--- a/src/riscv_private.h
+++ b/src/riscv_private.h
@@ -129,7 +129,8 @@ typedef struct block {
 #endif
 } block_t;
 
-#if RV32_HAS(JIT) && RV32_HAS(T2C)
+/* T2C implies JIT (enforced by Kconfig and feature.h) */
+#if RV32_HAS(T2C)
 typedef struct {
     block_t *block;
     struct list_head list;

--- a/src/syscall_sdl.c
+++ b/src/syscall_sdl.c
@@ -43,7 +43,7 @@
 #define R 1
 #define W 0
 
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
 #define get_offset_by_addr(addr) (addr) & (MASK(RV_PG_SHIFT))
 static uint32_t offset;
 static uint32_t curr_page_data_size;
@@ -355,7 +355,7 @@ void syscall_draw_frame(riscv_t *rv)
         return;
 
     uint32_t total_size = width * height * 4;
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
     static uint8_t tmp_buf[256 * RV_PG_SIZE];
     uint8_t *tmp_buf_ptr = &tmp_buf[0];
     uint32_t screen_vaddr = screen;
@@ -369,7 +369,7 @@ void syscall_draw_frame(riscv_t *rv)
     void *pixels_ptr;
     if (SDL_LockTexture(texture, NULL, &pixels_ptr, &pitch))
         exit(EXIT_FAILURE);
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
     memcpy(pixels_ptr, tmp_buf_ptr, total_size);
 #else
     memory_read(attr->mem, pixels_ptr, screen, total_size);
@@ -385,7 +385,7 @@ void syscall_draw_frame(riscv_t *rv)
 
 void syscall_setup_queue(riscv_t *rv)
 {
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
     /*
      * The guestOS might exit and execute the SDL-based program again
      * thus clearing the queue is required to avoid using the
@@ -401,7 +401,7 @@ void syscall_setup_queue(riscv_t *rv)
     queues_capacity = rv_get_reg(rv, rv_reg_a1);
     event_count = rv_get_reg(rv, rv_reg_a2);
 
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
     uint32_t submission_queue_addr =
         rv->io.mem_translate(rv, base + sizeof(event_t) * queues_capacity, R);
 
@@ -443,7 +443,7 @@ void syscall_submit_queue(riscv_t *rv)
             if (unlikely(!title))
                 return;
 
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
             uint32_t addr = rv->io.mem_translate(rv, submission.title.title, R);
             memory_read(PRIV(rv)->mem, (uint8_t *) title, addr,
                         submission.title.size);
@@ -809,7 +809,7 @@ static void play_sfx(riscv_t *rv)
 
     sfxinfo_t sfxinfo;
     uint8_t sfx_data[SFX_SAMPLE_SIZE];
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
     uint32_t addr = rv->io.mem_translate(rv, sfxinfo_addr, R);
     memory_read(attr->mem, (uint8_t *) &sfxinfo, addr, sizeof(sfxinfo_t));
 
@@ -866,7 +866,7 @@ static void play_music(riscv_t *rv)
 
     musicinfo_t musicinfo;
     uint8_t music_data[MUSIC_MAX_SIZE];
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
     uint32_t addr = rv->io.mem_translate(rv, musicinfo_addr, R);
     memory_read(attr->mem, (uint8_t *) &musicinfo, addr, sizeof(musicinfo_t));
 

--- a/src/system.c
+++ b/src/system.c
@@ -347,7 +347,7 @@ static uint32_t mmu_ifetch(riscv_t *rv, const uint32_t vaddr)
     pte_t *pte = mmu_walk(rv, vaddr, &level);
     bool ok = MMU_FAULT_CHECK(ifetch, rv, pte, vaddr, PTE_X);
     if (unlikely(!ok)) {
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
         CHECK_PENDING_SIGNAL(rv, need_handle_signal);
         if (need_handle_signal)
             return 0;
@@ -381,7 +381,7 @@ uint32_t mmu_read_w(riscv_t *rv, const uint32_t vaddr)
 #if RV32_HAS(SYSTEM) && RV32_HAS(ELF_LOADER)
     if (need_retranslate)
         return 0;
-#elif RV32_HAS(SYSTEM)
+#elif RV32_HAS(SYSTEM_MMIO)
     if (need_handle_signal)
         return 0;
 #endif
@@ -389,7 +389,7 @@ uint32_t mmu_read_w(riscv_t *rv, const uint32_t vaddr)
     if (GUEST_RAM_CONTAINS(PRIV(rv)->mem, addr, 4))
         return memory_read_w(addr);
 
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
     MMIO_READ();
 #endif
 
@@ -403,7 +403,7 @@ uint16_t mmu_read_s(riscv_t *rv, const uint32_t vaddr)
 #if RV32_HAS(SYSTEM) && RV32_HAS(ELF_LOADER)
     if (need_retranslate)
         return 0;
-#elif RV32_HAS(SYSTEM)
+#elif RV32_HAS(SYSTEM_MMIO)
     if (need_handle_signal)
         return 0;
 #endif
@@ -411,7 +411,7 @@ uint16_t mmu_read_s(riscv_t *rv, const uint32_t vaddr)
     if (GUEST_RAM_CONTAINS(PRIV(rv)->mem, addr, 2))
         return memory_read_s(addr);
 
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
     MMIO_READ();
 #endif
 
@@ -425,7 +425,7 @@ uint8_t mmu_read_b(riscv_t *rv, const uint32_t vaddr)
 #if RV32_HAS(SYSTEM) && RV32_HAS(ELF_LOADER)
     if (need_retranslate)
         return 0;
-#elif RV32_HAS(SYSTEM)
+#elif RV32_HAS(SYSTEM_MMIO)
     if (need_handle_signal)
         return 0;
 #endif
@@ -433,7 +433,7 @@ uint8_t mmu_read_b(riscv_t *rv, const uint32_t vaddr)
     if (GUEST_RAM_CONTAINS(PRIV(rv)->mem, addr, 1))
         return memory_read_b(addr);
 
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
     MMIO_READ();
 #endif
 
@@ -447,7 +447,7 @@ void mmu_write_w(riscv_t *rv, const uint32_t vaddr, const uint32_t val)
 #if RV32_HAS(SYSTEM) && RV32_HAS(ELF_LOADER)
     if (need_retranslate)
         return;
-#elif RV32_HAS(SYSTEM)
+#elif RV32_HAS(SYSTEM_MMIO)
     if (need_handle_signal)
         return;
 #endif
@@ -457,7 +457,7 @@ void mmu_write_w(riscv_t *rv, const uint32_t vaddr, const uint32_t val)
         return;
     }
 
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
     MMIO_WRITE();
 #endif
 
@@ -471,7 +471,7 @@ void mmu_write_s(riscv_t *rv, const uint32_t vaddr, const uint16_t val)
 #if RV32_HAS(SYSTEM) && RV32_HAS(ELF_LOADER)
     if (need_retranslate)
         return;
-#elif RV32_HAS(SYSTEM)
+#elif RV32_HAS(SYSTEM_MMIO)
     if (need_handle_signal)
         return;
 #endif
@@ -481,7 +481,7 @@ void mmu_write_s(riscv_t *rv, const uint32_t vaddr, const uint16_t val)
         return;
     }
 
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
     MMIO_WRITE();
 #endif
 
@@ -495,7 +495,7 @@ void mmu_write_b(riscv_t *rv, const uint32_t vaddr, const uint8_t val)
 #if RV32_HAS(SYSTEM) && RV32_HAS(ELF_LOADER)
     if (need_retranslate)
         return;
-#elif RV32_HAS(SYSTEM)
+#elif RV32_HAS(SYSTEM_MMIO)
     if (need_handle_signal)
         return;
 #endif
@@ -505,7 +505,7 @@ void mmu_write_b(riscv_t *rv, const uint32_t vaddr, const uint8_t val)
         return;
     }
 
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
     MMIO_WRITE();
 #endif
 
@@ -529,7 +529,7 @@ uint32_t mmu_translate(riscv_t *rv, uint32_t vaddr, bool rw)
     bool ok = rw ? MMU_FAULT_CHECK(read, rv, pte, vaddr, PTE_R)
                  : MMU_FAULT_CHECK(write, rv, pte, vaddr, PTE_W);
     if (unlikely(!ok)) {
-#if RV32_HAS(SYSTEM) && !RV32_HAS(ELF_LOADER)
+#if RV32_HAS(SYSTEM_MMIO)
         CHECK_PENDING_SIGNAL(rv, need_handle_signal);
         if (need_handle_signal)
             return 0;

--- a/tools/detect-env.py
+++ b/tools/detect-env.py
@@ -13,6 +13,7 @@ Options:
     --is-emcc           Check if compiler is Emscripten (prints y/n)
     --is-clang          Check if compiler is Clang (prints y/n)
     --is-gcc            Check if compiler is GCC (prints y/n)
+    --have-emcc         Check if Emscripten (emcc) is available (prints y/n)
     --have-sdl2         Check if SDL2 is available (prints y/n)
     --have-sdl2-mixer   Check if SDL2_mixer is available (prints y/n)
     --have-llvm18       Check if LLVM 18 is available (prints y/n)
@@ -97,6 +98,19 @@ def have_sdl2_mixer():
     return check_pkg_config("SDL2_mixer")
 
 
+def have_emcc():
+    """Check if Emscripten (emcc) is available."""
+    emcc = shutil.which("emcc")
+    if emcc:
+        # Verify it works by checking version
+        # Some Emscripten builds emit version info to stderr, so check both
+        ret, stdout, stderr = run_cmd([emcc, "--version"])
+        combined = (stdout + stderr).lower()
+        if ret == 0 and "emcc" in combined:
+            return True
+    return False
+
+
 def have_llvm18():
     """Check if LLVM 18 is available."""
     # Check for llvm-config-18
@@ -165,6 +179,7 @@ def print_summary():
 
     print(f"Compiler: {compiler}")
     print(f"Type: {comp_type}")
+    print(f"Emscripten: {'yes' if have_emcc() else 'no'}")
     print(f"SDL2: {'yes' if have_sdl2() else 'no'}")
     print(f"SDL2_mixer: {'yes' if have_sdl2_mixer() else 'no'}")
     print(f"LLVM 18: {'yes' if have_llvm18() else 'no'}")
@@ -190,6 +205,8 @@ def main():
         print("y" if comp_type == "Clang" else "n")
     elif arg == "--is-gcc":
         print("y" if comp_type == "GCC" else "n")
+    elif arg == "--have-emcc":
+        print("y" if have_emcc() else "n")
     elif arg == "--have-sdl2":
         print("y" if have_sdl2() else "n")
     elif arg == "--have-sdl2-mixer":


### PR DESCRIPTION
Build System Improvements:
- Add mk/common.mk with reusable define templates (compile-rule, test-framework, make-dir) reducing code duplication
- Add mk/kconfig.mk for Kconfig menu integration with environment detection
- Refactor mk/tests.mk using test-framework template (~50% reduction)
- Refactor mk/external.mk with unified download/verify patterns

Kconfig Enhancements:
- Add BUILD_TARGET choice menu (Native/WebAssembly) in configs/Kconfig
- Add HAVE_EMCC detection via tools/detect-env.py --have-emcc
- Auto-select CC=emcc when CONFIG_BUILD_WASM=y in mk/toolchain.mk
- Add consistency warning when CC override conflicts with BUILD_WASM

Source Code Simplification:
- Simplify preprocessor conditionals in src/ based on Kconfig constraints (JIT requires !EMCC, T2C requires JIT, etc.)
- Replace nested #if with flattened logic where Kconfig guarantees valid combinations

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Kconfig-driven build target selection and environment checks, auto-configuring Emscripten for WebAssembly. Builds now require an explicit .config and checksum verification for external assets is hardened to prevent silent bypass, improving artifact reliability.

- **New Features**
  - Kconfig adds a Build Target choice: Native or WebAssembly.
  - Detects Emscripten (HAVE_EMCC) and auto-sets CC=emcc when BUILD_WASM is selected.
  - Requires .config for builds; clear guidance is shown to run make defconfig or make config (named *_defconfig targets supported).
  - Reusable Make templates (compile-rule, test-framework, make-dir); tests and external asset rules refactored to use them.
  - Skips expensive dependency checks for clean/distclean; SDL flags computed only when enabled.
  - Source guards simplified with SYSTEM_MMIO and enforced T2C/JIT constraints; flattened conditionals in src/.
  - CI updated: uses wasm_defconfig, tracks mk/*, drops CC=emcc overrides, and adds a CodeQL workflow (manual build; TRAP caching disabled).

- **Migration**
  - For WASM: run “make wasm_defconfig” then “make -j” (do not pass CC=emcc).
  - If CONFIG_BUILD_WASM=y but CC isn’t emcc, a warning is shown; remove CC overrides or rerun “make defconfig”.
  - Replace any custom checks of SYSTEM && !ELF_LOADER with SYSTEM_MMIO.
  - Run “make defconfig” (or “make config”) before building; the env check shows if Emscripten is available.
  - If using the new CodeQL workflow, disable GitHub’s default code scanning setup.

<sup>Written for commit 3a86a89ca260210889895cc037e59d069d8461a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

