### PR TITLE
CI: Unify ASSERT for expect-style scripts

### DIFF
--- a/.ci/boot-linux.sh
+++ b/.ci/boot-linux.sh
@@ -6,11 +6,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 check_platform
 
-cleanup()
-{
-    sleep 1
-    pkill -9 rv32emu
-}
+# Register emulator cleanup for trap on EXIT
+register_cleanup cleanup_emulator
 
 check_image_for_file()
 {
@@ -53,15 +50,7 @@ check_image_for_file()
     return 1
 }
 
-ASSERT()
-{
-    $*
-    local RES=$?
-    if [ ${RES} -ne 0 ]; then
-        echo 'Assert failed: "' $* '"'
-        exit ${RES}
-    fi
-}
+# Use ASSERT from common.sh
 
 cleanup
 

--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -47,19 +47,27 @@ print_warning()
     echo -e "${YELLOW}[WARNING]${NC} $1"
 }
 
-# Assertion function for tests
-# Usage: ASSERT <condition> <error_message>
+# Assertion function for tests - executes command and exits on failure
+# Usage: ASSERT <command...>
+# Example: ASSERT expect <<- DONE
+#              spawn ./program
+#              expect "output"
+#          DONE
 ASSERT()
 {
-    local condition=$1
-    shift
-    local message="$*"
-
-    if ! eval "${condition}"; then
-        print_error "Assertion failed: ${message}"
-        print_error "Condition: ${condition}"
-        return 1
+    "$@"
+    local RES=$?
+    if [ ${RES} -ne 0 ]; then
+        print_error "Assert failed: $*"
+        exit ${RES}
     fi
+}
+
+# Kill rv32emu processes - use in test cleanup
+cleanup_emulator()
+{
+    sleep 1
+    pkill -9 rv32emu 2> /dev/null || true
 }
 
 # Cleanup function registry


### PR DESCRIPTION
ASSERT function in common.sh used eval-based condition checking, which was incompatible with expect heredoc patterns used in test scripts like boot-linux.sh. This caused failures when new scripts sourced common.sh and used ASSERT with expect commands.
Changes:
- Modify ASSERT in common.sh to execute commands directly ("$@") instead of evaluating conditions with eval
- Add cleanup_emulator() helper to centralize rv32emu process cleanup
- Update boot-linux.sh to use register_cleanup pattern instead of overriding cleanup function

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI test failures by making ASSERT execute commands directly, so expect heredoc patterns work in scripts like boot-linux.sh. Also centralizes emulator cleanup and adopts the cleanup registry.

- **Bug Fixes**
  - ASSERT in common.sh runs "$@" instead of eval, enabling expect-based tests and exiting on non‑zero status.

- **Refactors**
  - Added cleanup_emulator() and registered it via register_cleanup in boot-linux.sh.
  - Removed local ASSERT and custom cleanup from boot-linux.sh to use common helpers.

<sup>Written for commit 58bbab24d285e4a52b32126fd7ec02975e159b09. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

