### PR TITLE
Lazy fetching Linux source code

### DIFF
--- a/mk/external.mk
+++ b/mk/external.mk
@@ -138,13 +138,19 @@ LINUX_CDN_BASE_URL = https://cdn.kernel.org/pub/linux/kernel
 LINUX_CDN_VERSION_URL = $(LINUX_CDN_BASE_URL)/v$(LINUX_VERSION).x
 $(shell mkdir -p /tmp/linux)
 LINUX_DATA_DEST = /tmp/linux
-LINUX_DATA := $(shell wget -q -O- $(LINUX_CDN_VERSION_URL) | \
-                     grep -o 'linux-$(LINUX_VERSION).$(LINUX_PATCHLEVEL).[0-9]\+\.tar.gz' | \
-                     sort -V | tail -n 1)
+# Only fetch Linux artifact for build-linux-image target
+ifneq ($(filter build-linux-image,$(MAKECMDGOALS)),)
+    LINUX_DATA := $(shell wget -q -O- $(LINUX_CDN_VERSION_URL) | \
+                         grep -o 'linux-$(LINUX_VERSION).$(LINUX_PATCHLEVEL).[0-9]\+\.tar.gz' | \
+                         sort -V | tail -n 1)
+    LINUX_DATA_SHA := $(shell wget -q -O- $(LINUX_CDN_VERSION_URL)/sha256sums.asc | \
+                             grep $(LINUX_DATA) | awk '{print $$1}')
+else
+    LINUX_DATA :=
+    LINUX_DATA_SHA :=
+endif
 LINUX_DATA_URL = $(LINUX_CDN_VERSION_URL)/$(LINUX_DATA)
 LINUX_DATA_SKIP_DIR_LEVEL = 1
-LINUX_DATA_SHA := $(shell wget -q -O- $(LINUX_CDN_VERSION_URL)/sha256sums.asc | \
-                         grep $(LINUX_DATA) | awk '{print $$1}')
 LINUX_DATA_SHA_CMD = $(SHA256SUM)
 
 # simplefs


### PR DESCRIPTION
The Linux source code is only needed for make build-linux-image target, thus, the fetch should be lazy until the target is fired.

This speedup the reconfiguration for various build and also the CI execution.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lazy-load Linux source artifacts by only fetching the tarball and SHA256 when running make build-linux-image. This avoids unnecessary network calls and speeds up local reconfiguration and CI.

- **Refactors**
  - Compute LINUX_DATA and LINUX_DATA_SHA only when build-linux-image is the target (via MAKECMDGOALS); otherwise leave them empty to skip wget.

<sup>Written for commit 4fb11b0f64c5b2d7c0fff300037a938081b48131. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

