### PR TITLE
Fix PyYAML build failure on Python 3.12

### DIFF
--- a/.ci/requirements.txt
+++ b/.ci/requirements.txt
@@ -17,9 +17,9 @@ pytablewriter==1.2.1
 pytest==8.3.4
 python-dateutil==2.9.0.post0
 pytz==2025.1
-PyYAML==5.4
+PyYAML==6.0.2
 riscof @ git+https://github.com/riscv/riscof.git@d38859f85fe407bcacddd2efcd355ada4683aee4
-riscv-config==3.18.3
+# riscv-config installed separately in riscv-tests.sh (--no-deps) due to pyyaml==5.2 conflict
 riscv-isac==0.18.0
 ruamel.yaml==0.18.10
 ruamel.yaml.clib==0.2.12

--- a/.ci/riscv-tests.sh
+++ b/.ci/riscv-tests.sh
@@ -7,7 +7,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 set -e -u -o pipefail
 
 # Install RISCOF
-pip3 install -r .ci/requirements.txt
+# Note: riscv-config 3.18.3 pins pyyaml==5.2, but PyYAML 5.x fails to build on
+# Python 3.12 (Cython compatibility). Since requirements.txt is a full freeze
+# of all transitive dependencies, use --no-deps to bypass resolver conflicts.
+# riscof also depends on riscv-config, so --no-deps prevents re-triggering.
+pip3 install --no-deps riscv-config==3.18.3
+pip3 install --no-deps -r .ci/requirements.txt
+# Smoke test: verify riscv-config works with PyYAML 6.x
+python3 -c "import riscv_config; print('riscv-config import OK')"
 
 # Workaround for RISCOF bug: dbgen.py line 158 uses 'list' (Python built-in)
 # instead of 'flist' (file list variable). This causes TypeError when the


### PR DESCRIPTION
PyYAML 5.4 fails to build from source on Python 3.12 due to Cython compatibility issues (AttributeError: cython_sources). Upgrade to 6.0.2 which provides pre-built wheels for Python 3.12 and includes all security fixes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade PyYAML in CI from 5.4 to 6.0.2 to fix Python 3.12 build failures and avoid the Cython error from source builds. Install riscv-config and the frozen requirements with --no-deps to bypass its pyyaml==5.2 pin, and add a smoke test to confirm compatibility.

<sup>Written for commit 805bdecd2822fac7a07b3d1da233c2f7a2e85a75. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

