### PR TITLE
Fix scause handling in MMU test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -430,7 +430,7 @@ EXPECTED_misalign = MISALIGNED INSTRUCTION FETCH TEST PASSED!
 misalign-in-blk-emu: $(BIN)
 	$(call check-test, , tests/system/alignment/misalign.elf, misalign.elf, tail -n 1,$(EXPECTED_misalign))
 
-EXPECTED_mmu = STORE PAGE FAULT TEST PASSED!
+EXPECTED_mmu = Store page fault test passed!
 mmu-test: $(BIN)
 	$(call check-test, , tests/system/mmu/vm.elf, vm.elf, tail -n 1,$(EXPECTED_mmu))
 

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -606,10 +606,22 @@ static uint32_t peripheral_update_ctr = 64;
 #endif
 
 /* Interpreter-based execution path */
+#if RV32_HAS(SYSTEM)
+#define RVOP_SYNC_PC(rv, PC) \
+    do {                     \
+        (rv)->PC = (PC);     \
+    } while (0)
+#else
+#define RVOP_SYNC_PC(rv, PC) \
+    do {                     \
+    } while (0)
+#endif
+
 #define RVOP(inst, code, asm)                                             \
     static PRESERVE_NONE bool do_##inst(riscv_t *rv, const rv_insn_t *ir, \
                                         uint64_t cycle, uint32_t PC)      \
     {                                                                     \
+        RVOP_SYNC_PC(rv, PC);                                             \
         IIF(RV32_HAS(SYSTEM))(rv->timer++;, ) cycle++;                    \
         code;                                                             \
         IIF(RV32_HAS(SYSTEM))(                                            \
@@ -680,6 +692,7 @@ static PRESERVE_NONE bool do_fuse1(riscv_t *rv,
                                    uint64_t cycle,
                                    uint32_t PC)
 {
+    RVOP_SYNC_PC(rv, PC);
     cycle += ir->imm2;
     opcode_fuse_t *fuse = ir->fuse;
     for (int i = 0; i < ir->imm2; i++)
@@ -694,6 +707,7 @@ static PRESERVE_NONE bool do_fuse2(riscv_t *rv,
                                    uint64_t cycle,
                                    uint32_t PC)
 {
+    RVOP_SYNC_PC(rv, PC);
     cycle += 2;
     rv->X[ir->rd] = ir->imm;
     rv->X[ir->rs2] = rv->X[ir->rd] + rv->X[ir->rs1];
@@ -707,6 +721,7 @@ static PRESERVE_NONE bool do_fuse3(riscv_t *rv,
                                    uint64_t cycle,
                                    uint32_t PC)
 {
+    RVOP_SYNC_PC(rv, PC);
     cycle += ir->imm2;
     opcode_fuse_t *fuse = ir->fuse;
     for (int i = 0; i < ir->imm2; i++) {
@@ -728,6 +743,7 @@ static PRESERVE_NONE bool do_fuse4(riscv_t *rv,
                                    uint64_t cycle,
                                    uint32_t PC)
 {
+    RVOP_SYNC_PC(rv, PC);
     cycle += ir->imm2;
     opcode_fuse_t *fuse = ir->fuse;
     for (int i = 0; i < ir->imm2; i++) {
@@ -766,6 +782,7 @@ static PRESERVE_NONE bool do_fuse5(riscv_t *rv,
                                    uint64_t cycle,
                                    uint32_t PC)
 {
+    RVOP_SYNC_PC(rv, PC);
     cycle += ir->imm2;
     opcode_fuse_t *fuse = ir->fuse;
     for (int i = 0; i < ir->imm2; i++)
@@ -784,6 +801,7 @@ static PRESERVE_NONE bool do_fuse6(riscv_t *rv,
                                    uint64_t cycle,
                                    uint32_t PC)
 {
+    RVOP_SYNC_PC(rv, PC);
     cycle += 2;
     rv->X[rv_reg_a7] = ir->imm;
     rv->compressed = false;
@@ -815,6 +833,7 @@ static PRESERVE_NONE bool do_fuse7(riscv_t *rv,
                                    uint64_t cycle,
                                    uint32_t PC)
 {
+    RVOP_SYNC_PC(rv, PC);
     cycle += ir->imm2;
     opcode_fuse_t *fuse = ir->fuse;
     for (int i = 0; i < ir->imm2; i++)
@@ -838,6 +857,7 @@ static PRESERVE_NONE bool do_fuse8(riscv_t *rv,
                                    uint64_t cycle,
                                    uint32_t PC)
 {
+    RVOP_SYNC_PC(rv, PC);
     cycle += 2;
     /* Cast to uint32_t to avoid signed overflow UB */
     rv->X[ir->rd] = (uint32_t) ir->imm + (uint32_t) ir->imm2;
@@ -857,6 +877,7 @@ static PRESERVE_NONE bool do_fuse9(riscv_t *rv,
                                    uint64_t cycle,
                                    uint32_t PC)
 {
+    RVOP_SYNC_PC(rv, PC);
     cycle += 2;
     /* Write LUI result to rd - required when rd != LW destination.
      * LUI completes before LW, so this write happens even if LW faults.
@@ -882,6 +903,7 @@ static PRESERVE_NONE bool do_fuse10(riscv_t *rv,
                                     uint64_t cycle,
                                     uint32_t PC)
 {
+    RVOP_SYNC_PC(rv, PC);
     cycle += 2;
     /* Write LUI result to rd - SW doesn't write registers, so rd may be
      * used later. LUI completes before SW, so this write happens even if
@@ -912,6 +934,7 @@ static PRESERVE_NONE bool do_fuse11(riscv_t *rv,
                                     uint64_t cycle,
                                     uint32_t PC)
 {
+    RVOP_SYNC_PC(rv, PC);
     cycle += 2;
     uint32_t addr = rv->X[ir->rs1] + ir->imm;
     RV_EXC_MISALIGN_HANDLER(3, LOAD, false, 1);
@@ -939,6 +962,7 @@ static PRESERVE_NONE bool do_fuse12(riscv_t *rv,
                                     uint64_t cycle,
                                     uint32_t PC)
 {
+    RVOP_SYNC_PC(rv, PC);
     cycle += 2;
     rv->X[ir->rd] = rv->X[ir->rs1] + ir->imm;
 

--- a/src/system.c
+++ b/src/system.c
@@ -4,6 +4,7 @@
  */
 
 #include <assert.h>
+#include <stdio.h>
 #include <string.h>
 
 #include "system.h"

--- a/tests/system/mmu/Makefile
+++ b/tests/system/mmu/Makefile
@@ -1,3 +1,8 @@
+# MMU Test Build
+#
+# Build rv32emu with: make ENABLE_SYSTEM=1 ENABLE_ELF_LOADER=1
+# Run with: ./build/rv32emu tests/system/mmu/vm.elf
+
 PREFIX ?= riscv-none-elf-
 ARCH = -march=rv32izicsr
 LINKER_SCRIPT = linker.ld
@@ -20,9 +25,9 @@ LIBGCC_PATH = $(shell dirname $(LIBGCC))
 deps = main.o setup.o vm_setup.o
 
 all:
-	$(CC) $(DEBUG_CLAGS) $(CFLAGS) main.c
-	$(CC) $(DEBUG_CLAGS) $(CFLAGS) vm_setup.c
-	$(AS) $(DEBUG_CLAGS) $(ARCH) setup.S -o setup.o
+	$(CC) $(DEBUG_CFLAGS) $(CFLAGS) main.c
+	$(CC) $(DEBUG_CFLAGS) $(CFLAGS) vm_setup.c
+	$(AS) $(DEBUG_CFLAGS) $(ARCH) setup.S -o setup.o
 	$(LD) $(LDFLAGS) $(LINKER_SCRIPT) -o $(EXEC) $(deps) -L$(LIBGCC_PATH) -lgcc
 
 dump:

--- a/tests/system/mmu/linker.ld
+++ b/tests/system/mmu/linker.ld
@@ -2,8 +2,25 @@ OUTPUT_ARCH( "riscv" )
 
 ENTRY(_start)
 
+/* Memory Layout (compact - avoids 2GB sparse ELF problem):
+ *
+ * 0x00000000 - User code (.text.main) - intentionally unmapped at boot
+ *              to trigger instruction fetch page fault
+ * 0x00001000 - User data (.mystring, .data.main, .bss.main)
+ * 0x00400000 - FREE_FRAME_BASE (see vm_setup.c) - page allocation pool
+ * 0x00800000 - Kernel/supervisor code (.text.setup, .text.vm_setup)
+ *              Mapped to VA 0x80000000 via mega page in l1pt[512]
+ *
+ * The page table setup in vm_boot() maps:
+ * - l1pt[0]: L2 table for user VA 0x00000000 - 0x003FFFFF
+ * - l1pt[512]: Mega page mapping physical _start to VA 0x80000000
+ * - l1pt[1023]: Mega page mapping physical main to VA 0xFFC00000
+ *               (kernel uses this to copy pages on fault)
+ */
+
 SECTIONS
 {
+  /* User space code - starts at address 0, triggers page fault on first access */
   . = 0x00000000;
   .text.main : { *(.text.main) }
   . = ALIGN(0x1000);
@@ -11,12 +28,23 @@ SECTIONS
   .data.main : { *(.data.main) }
   .bss.main : { *(.bss.main) }
 
+  /* Kernel/supervisor code - placed at 8 MiB (was 0x7fffeffc causing 2GB ELF) */
+  . = 0x00800000;
+  _kernel_start = .;
   .text : {
-    . = 0x7fffeffc;
+    _text_start = .;
     *(.text.setup)
     *(.text.vm_setup)
+    _text_end = .;
   }
   . = ALIGN(0x1000);
+  .rodata : {
+    _rodata_start = .;
+    *(.rodata*)
+    _rodata_end = .;
+  }
+  . = ALIGN(0x1000);
+  _data_start = .;
   .data : {
     *(.data.setup)
     *(.data.vm_setup)
@@ -29,3 +57,6 @@ SECTIONS
   . = ALIGN(0x1000);
   _end = .;
 }
+
+/* Ensure kernel fits within 4 MiB mega page identity mapping */
+ASSERT((_end - _kernel_start) <= 0x400000, "Kernel exceeds 4 MiB identity map limit")

--- a/tests/system/mmu/main.c
+++ b/tests/system/mmu/main.c
@@ -1,22 +1,52 @@
+/*
+ * MMU Page Fault Test - User Space Component
+ *
+ * This code runs in user mode (U-mode) at virtual address 0x0. It tests
+ * three types of page faults that the MMU must handle via demand paging:
+ *
+ * 1. Instruction Fetch Page Fault (scause=12): Triggered when main() starts
+ *    executing, since user VA 0x0 has no valid PTE until the fault handler
+ *    allocates a frame and copies code from the kernel mapping.
+ *
+ * 2. Load Page Fault (scause=13): Triggered by reading from VA 0x1000,
+ *    which contains pf_str ("rv32emu"). The fault handler maps the page
+ *    and copies data so subsequent reads succeed.
+ *
+ * 3. Store Page Fault (scause=15): Triggered by writing to VA 0x2000.
+ *    The fault handler allocates a writable page and sets the Dirty bit.
+ *
+ * Memory Layout (defined in linker.ld):
+ *   0x0000 - User code (.text.main) - this file
+ *   0x1000 - User read-only data (.mystring) - pf_str
+ *   0x2000 - User read-write data (.data.main, .bss.main)
+ */
+
+/* Place code/data in user VA sections (mapped by vm_boot's L2 page table) */
 #define SECTION_TEXT_MAIN __attribute__((section(".text.main")))
 #define SECTION_DATA_MAIN __attribute__((section(".data.main")))
 #define SECTION_BSS_MAIN __attribute__((section(".bss.main")))
 
-#define printstr(ptr, length)                   \
-    do {                                        \
-        asm volatile(                           \
-            "add a7, x0, 0x40;"                 \
-            "add a0, x0, 0x1;" /* stdout */     \
-            "add a1, x0, %0;"                   \
-            "mv a2, %1;" /* length character */ \
-            "ecall;"                            \
-            :                                   \
-            : "r"(ptr), "r"(length)             \
-            : "a0", "a1", "a2", "a7");          \
+/* Write string to stdout via Linux write syscall (nr=64).
+ * The ecall traps to the emulator's syscall handler in ELF_LOADER mode.
+ */
+#define printstr(ptr, length)          \
+    do {                               \
+        asm volatile(                  \
+            "add a7, x0, 0x40;"        \
+            "add a0, x0, 0x1;"         \
+            "add a1, x0, %0;"          \
+            "mv a2, %1;"               \
+            "ecall;"                   \
+            :                          \
+            : "r"(ptr), "r"(length)    \
+            : "a0", "a1", "a2", "a7"); \
     } while (0)
 
 #define TEST_OUTPUT(msg, length) printstr(msg, length)
 
+/* Copy string literal to stack, then print. Stack must be in physical memory
+ * (not user VA) for emulator syscall handler compatibility.
+ */
 #define TEST_LOGGER(msg)                     \
     {                                        \
         char _msg[] = msg;                   \
@@ -26,77 +56,82 @@
 #define SUCCESS 0
 #define FAIL 1
 
-__attribute__((section(".mystring"))) const char pagefault_load_str[] =
-    "rv32emu";
+/* Test string placed in .mystring section at VA 0x1000.
+ * First read triggers load page fault; handler maps page with pf_str data.
+ */
+__attribute__((section(".mystring"))) const char pf_str[] = "rv32emu";
 
 extern void _exit(int status);
 
 int SECTION_TEXT_MAIN main()
 {
-    /* instruction fetch page fault test */
-    int x = 100; /* trigger instruction page fault */
+    /* TEST 1: Instruction Fetch Page Fault
+     *
+     * Reaching this point means the instruction fetch page fault was handled.
+     * When user_entry jumped to VA 0x0, the MMU found no valid PTE in user_l1pt
+     * and raised scause=12. The trap handler allocated a frame, copied main()
+     * from the kernel's direct mapping, and resumed execution here.
+     */
+    int x = 100;
     int y = 200;
     int z = x + y;
-    TEST_LOGGER("INSTRUCTION FETCH PAGE FAULT TEST PASSED!\n");
+    (void) z;
+    TEST_LOGGER("Instruction fetch page fault test passed!\n");
 
+    /* TEST 2: Load Page Fault
+     *
+     * Read from VA 0x1000 where pf_str ("rv32emu") is located. The first load
+     * triggers scause=13 since the page is unmapped. After the fault handler
+     * maps it, subsequent loads from the same page succeed without faulting.
+     */
     char buf[8];
-    /* data load page fault test */
-    /* Clear buffer */
-    for (int i = 0; i < 8; i++) {
+    for (int i = 0; i < 8; i++)
         buf[i] = 0;
-    }
 
-    char *qtr = (char *) 0x1000; /* first data page */
-    /* should trigger load page fault and load pagefault_load_str */
-    for (int i = 0; i < 8; i++) {
-        qtr = (char *) 0x1000; /* FIXME: weird result without this */
+    volatile char *qtr = (char *) 0x1000;
+    for (int i = 0; i < 8; i++)
         buf[i] = *(qtr + i);
-    }
 
-    for (int i = 0; i < 8; i++) { /* should not trigger load page fault */
+    /* Verify data integrity: re-read should return same values (no fault) */
+    for (int i = 0; i < 8; i++) {
         if (buf[i] != *(qtr + i)) {
-            TEST_LOGGER("[LOAD PAGE FAULT TEST] rv32emu string not match\n")
+            TEST_LOGGER("[Load page fault test] rv32emu string not match\n")
             _exit(FAIL);
         }
     }
-    TEST_LOGGER("LOAD PAGE FAULT TEST PASSED!\n");
+    TEST_LOGGER("Load page fault test passed!\n");
 
-    /* data store page fault test */
-    /* Clear buffer */
-    for (int i = 0; i < 8; i++) {
+    /* TEST 3: Store Page Fault
+     *
+     * Write to VA 0x2000, an unmapped writable page. The first store triggers
+     * scause=15. The fault handler allocates a frame with PTE_D (dirty) set,
+     * then subsequent stores and loads succeed without faulting.
+     */
+    for (int i = 0; i < 8; i++)
         buf[i] = 0;
-    }
 
-    char *ptr = (char *) 0x2000; /* second data page */
-    *ptr = 'r';                  /* trigger store page fault */
-    ptr = (char *) 0x2000;       /* FIXME: weird result without this */
-    *(ptr + 1) = 'v';            /* should not trigger store page fault */
-    ptr = (char *) 0x2000;       /* FIXME: weird result without this */
-    *(ptr + 2) = '3';            /* should not trigger store page fault */
-    ptr = (char *) 0x2000;       /* FIXME: weird result without this */
-    *(ptr + 3) = '2';            /* should not trigger store page fault */
-    ptr = (char *) 0x2000;       /* FIXME: weird result without this */
-    *(ptr + 4) = 'e';            /* should not trigger store page fault */
-    ptr = (char *) 0x2000;       /* FIXME: weird result without this */
-    *(ptr + 5) = 'm';            /* should not trigger store page fault */
-    ptr = (char *) 0x2000;       /* FIXME: weird result without this */
-    *(ptr + 6) = 'u';            /* should not trigger store page fault */
-    ptr = (char *) 0x2000;       /* FIXME: weird result without this */
-    *(ptr + 7) = '\0';           /* should not trigger store page fault */
+    volatile char *ptr = (char *) 0x2000;
+    *(ptr + 0) = 'r';
+    *(ptr + 1) = 'v';
+    *(ptr + 2) = '3';
+    *(ptr + 3) = '2';
+    *(ptr + 4) = 'e';
+    *(ptr + 5) = 'm';
+    *(ptr + 6) = 'u';
+    *(ptr + 7) = '\0';
 
-    /* should not trigger load page fault */
-    for (int i = 0; i < 8; i++) {
+    /* Read back written data to verify store succeeded */
+    for (int i = 0; i < 8; i++)
         buf[i] = *(ptr + i);
-    }
 
-    /* should not trigger load page fault */
+    /* Verify data integrity: what we wrote should match what we read */
     for (int i = 0; i < 8; i++) {
         if (buf[i] != *(ptr + i)) {
-            TEST_LOGGER("[STORE PAGE FAULT TEST] rv32emu string not match\n")
+            TEST_LOGGER("[Store page fault test] rv32emu string not match\n")
             _exit(FAIL);
         }
     }
-    TEST_LOGGER("STORE PAGE FAULT TEST PASSED!\n");
+    TEST_LOGGER("Store page fault test passed!\n");
 
     _exit(SUCCESS);
 }

--- a/tests/system/mmu/setup.S
+++ b/tests/system/mmu/setup.S
@@ -1,7 +1,19 @@
 .section .text.setup
 TRAPFRAME_SIZE = 35 * 4
 PG_SIZE = 4096
-STACK_TOP = _end + PG_SIZE
+/* Separate stack areas for user and kernel/trap handler to avoid corruption.
+ * Kernel stack: _end + PG_SIZE (for trap handler/trapframe)
+ * User stack: _end + 3*PG_SIZE (2 pages above kernel stack, grows down)
+ *
+ * Layout: [kernel BSS][gap][trapframe|kernel stack][gap][user stack grows down]
+ *                     _end  _end+PG_SIZE          _end+2*PG_SIZE  _end+3*PG_SIZE
+ *
+ * Note: User stack uses physical address for syscall compatibility.
+ * The emulator's syscall handlers (ELF_LOADER mode) access guest memory
+ * via physical addresses, not virtual addresses.
+ */
+KERNEL_STACK_TOP = _end + PG_SIZE
+USER_STACK_TOP = _end + 3 * PG_SIZE
 
 # FIXME: implement proper machine trap vector
 # Since I assume that all interrupts and exceptions are
@@ -45,7 +57,7 @@ _start:
     li x30, 0
     li x31, 0
 
-    la sp, STACK_TOP - TRAPFRAME_SIZE
+    la sp, KERNEL_STACK_TOP - TRAPFRAME_SIZE
     csrw mscratch, sp;
 
     #la t0, machine_trap_vector
@@ -62,8 +74,8 @@ _exit:
 
 .globl user_entry
 user_entry:
-    la sp, STACK_TOP - TRAPFRAME_SIZE
-    jalr x0, 0x4  # jump to user space main
+    la sp, USER_STACK_TOP  # Use separate user stack
+    jr x0  # jump to user space main at VA 0x0
 
 .globl supervisor_trap_entry
 supervisor_trap_entry:
@@ -99,7 +111,7 @@ supervisor_trap_entry:
     sw x27, 26*4(a0);
     sw x28, 27*4(a0);
     sw x29, 28*4(a0);
-    sw x20, 29*4(a0);
+    sw x30, 29*4(a0);
     sw x31, 30*4(a0);
 
     # load stack pointer and save trapframe pointer into scratch
@@ -153,10 +165,15 @@ pop_tf:
     lw x27, 26*4(a0)
     lw x28, 27*4(a0)
     lw x29, 28*4(a0)
-    lw x20, 29*4(a0)
+    lw x30, 29*4(a0)
     lw x31, 30*4(a0)
 
-    # save trapframe pointer to sscratch
-    csrrw a0, sscratch, a0;
+    # Properly restore a0: load saved a0 into sscratch before swap
+    lw t0, 9*4(a0)       # Load saved a0 from trapframe
+    csrw sscratch, t0    # Put saved a0 into sscratch
+    lw t0, 4*4(a0)       # Reload t0 (corrupted by above)
+
+    # swap trapframe pointer with restored a0
+    csrrw a0, sscratch, a0
 
     sret

--- a/tests/system/mmu/vm_setup.c
+++ b/tests/system/mmu/vm_setup.c
@@ -1,17 +1,36 @@
 /*
+ * MMU Page Fault Test - Supervisor/Kernel Component
+ *
+ * This file implements the S-mode (supervisor) trap handler and virtual memory
+ * setup for testing rv32emu's MMU page fault handling. It runs at VA 0x80000000
+ * (mapped from PA 0x00800000) and handles page faults from user code at VA 0x0.
+ *
+ * Key components:
+ *   - vm_boot(): Sets up Sv32 page tables, enables paging, delegates faults
+ *   - handle_trap(): Dispatches exceptions to appropriate handlers
+ *   - handle_fault(): Demand paging - allocates frames and populates PTEs
+ *
+ * Page Table Structure (Sv32, 2-level):
+ *   l1pt[0]    -> user_l1pt (L2 table for user VA 0x00000000-0x003FFFFF)
+ *   l1pt[2]    -> Identity map PA 0x00800000 (allows paging enable w/o
+ * trampoline) l1pt[512]  -> Kernel megapage at VA 0x80000000 l1pt[1023] ->
+ * Kernel direct map for copying user pages on fault
+ *
  * Reference:
- * 1. https://github.com/sifive/example-vm-test
- * 2. https://github.com/yutongshen/RISC-V-Simulator
+ *   1. https://github.com/sifive/example-vm-test
+ *   2. https://github.com/yutongshen/RISC-V-Simulator
  */
 
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
 
-#if !defined(__GNUC__) || !defined(__riscv) || 32 != __riscv_xlen
-#error "GNU Toolchain for 32-bit RISC-V is required"
+#if (!defined(__GNUC__) && !defined(__clang__)) || !defined(__riscv) || \
+    32 != __riscv_xlen
+#error "GCC or Clang toolchain for 32-bit RISC-V is required"
 #endif
 
+/* Place supervisor code/data in kernel sections at PA 0x00800000 */
 #define SECTION_TEXT_VMSETUP __attribute__((section(".text.vm_setup")))
 #define SECTION_DATA_VMSETUP __attribute__((section(".data.vm_setup")))
 #define SECTION_BSS_VMSETUP __attribute__((section(".bss.vm_setup")))
@@ -24,6 +43,7 @@
         }                                                             \
     } while (0)
 
+/* CSR access macros using RISC-V Zicsr instructions */
 #define read_csr(reg)                                 \
     ({                                                \
         uint32_t __tmp;                               \
@@ -92,75 +112,99 @@ typedef struct {
     uint32_t cause;
 } trapframe_t;
 
-#define SV32_MODE 0x80000000
-#define BARE_MODE 0x00000000
-#define PG_SHIFT 12
-#define PG_SIZE (1U << 12)
+/* Sv32 paging mode constants */
+#define SV32_MODE 0x80000000    /* SATP.MODE = Sv32 (bit 31) */
+#define BARE_MODE 0x00000000    /* SATP.MODE = Bare (no translation) */
+#define PG_SHIFT 12             /* 4 KiB page size = 2^12 */
+#define PG_SIZE (1U << 12)      /* 4096 bytes per page */
+#define MEGA_PG (PG_SIZE << 10) /* 4 MiB megapage (1024 * 4 KiB) */
+
+/* Physical frame allocator: 32 pages starting at 4 MiB for demand paging */
 #define FREE_FRAME_BASE 0x400000
-#define MAX_TEST_PG 32          /* FREE_FRAME_BASE - 0x41ffff */
-#define MEGA_PG (PG_SIZE << 10) /* 4 MiB */
+#define MAX_TEST_PG 32
 
-#define CAUSE_USER_ECALL (1U << 8)
-#define CAUSE_SUPERVISOR_ECALL (1U << 9)
-#define CAUSE_FETCH_PAGE_FAULT (1U << 12)
-#define CAUSE_LOAD_PAGE_FAULT (1U << 13)
-#define CAUSE_STORE_PAGE_FAULT (1U << 15)
+/* Exception cause codes (scause register values per RISC-V privilege spec) */
+#define CAUSE_USER_ECALL 8
+#define CAUSE_SUPERVISOR_ECALL 9
+#define CAUSE_FETCH_PAGE_FAULT 12 /* Instruction fetch from unmapped page */
+#define CAUSE_LOAD_PAGE_FAULT 13  /* Load from unmapped/non-readable page */
+#define CAUSE_STORE_PAGE_FAULT 15 /* Store to unmapped/non-writable page */
 
+/* sstatus.SUM: Supervisor User Memory access (allows S-mode to access U pages)
+ */
 #define SSTATUS_SUM (1U << 18)
 
-#define PTE_V (1U)
-#define PTE_R (1U << 1)
-#define PTE_W (1U << 2)
-#define PTE_X (1U << 3)
-#define PTE_U (1U << 4)
-#define PTE_G (1U << 5)
-#define PTE_A (1U << 6)
-#define PTE_D (1U << 7)
+/* Sv32 Page Table Entry (PTE) flag bits */
+#define PTE_V (1U)      /* Valid: PTE contains a valid translation */
+#define PTE_R (1U << 1) /* Readable: page can be read */
+#define PTE_W (1U << 2) /* Writable: page can be written */
+#define PTE_X (1U << 3) /* Executable: page can be executed */
+#define PTE_U (1U << 4) /* User: page accessible in U-mode */
+#define PTE_G (1U << 5) /* Global: mapping exists in all address spaces */
+#define PTE_A (1U << 6) /* Accessed: page has been read/executed */
+#define PTE_D (1U << 7) /* Dirty: page has been written */
 
-extern void main();
-extern void _start();
-extern int user_entry();
-extern void supervisor_trap_entry();
-extern void pop_tf(trapframe_t *);
-extern void _exit(int status);
+/* External symbols from setup.S and linker script */
+extern void main();                  /* User code entry at VA 0x0 */
+extern void _start();                /* Kernel entry at PA 0x00800000 */
+extern int user_entry();             /* Trampoline to jump to user space */
+extern void supervisor_trap_entry(); /* S-mode trap vector (saves context) */
+extern void pop_tf(trapframe_t *);   /* Restore context and sret */
+extern void _exit(int status);       /* Exit via ecall (syscall 93) */
 
 typedef uint32_t pte_t;
+
+/* Simple linked-list frame allocator for demand paging */
 typedef struct {
-    pte_t addr;
-    void *next;
+    pte_t addr; /* Physical address of this free frame */
+    void *next; /* Next node in freelist (NULL if last) */
 } freelist_t;
 
 freelist_t freelist_nodes[MAX_TEST_PG] SECTION_BSS_VMSETUP;
 freelist_t *SECTION_BSS_VMSETUP freelist_head;
 freelist_t *SECTION_BSS_VMSETUP freelist_tail;
 
+/* Sv32 page table layout:
+ *   l1pt (pt[0]): Root L1 page table, pointed to by SATP
+ *   user_l1pt (pt[1]): L2 table for user VA 0x0-0x3FFFFF (4 MiB)
+ */
 #define l1pt pt[0]
 #define user_l1pt pt[1]
 #define NPT 2
-#define PTES_PER_PT (1U << 10)
-#define PTE_PPN_SHIFT 10
+#define PTES_PER_PT (1U << 10) /* 1024 entries per page table */
+#define PTE_PPN_SHIFT 10       /* PPN starts at bit 10 in PTE */
 pte_t pt[NPT][PTES_PER_PT] SECTION_BSS_VMSETUP
     __attribute__((aligned(PG_SIZE)));
 
 #define MASK(n) (~((~0U << (n))))
+
+/* Address translation helpers for kernel access to user pages.
+ *
+ * The kernel megapage at l1pt[1023] maps PA starting at main() to VA
+ * 0xFFC00000. For user VA X, the corresponding kernel VA is X - MEGA_PG
+ * (0x400000).
+ *
+ * Example: User VA 0x1000 -> 0x1000 - 0x400000 = 0xFFC01000 (kernel VA)
+ *
+ * Note: The subtraction underflows for small values, but unsigned arithmetic
+ * wraparound produces the correct high address (e.g., 0 - 0x400000 =
+ * 0xFFC00000).
+ */
 #define pa2kva(x) (((pte_t) (x)) - ((pte_t) (_start)) - MEGA_PG)
 #define uva2kva(x) (((pte_t) (x)) - MEGA_PG)
 
 void *SECTION_TEXT_VMSETUP memcpy(void *ptr, void *src, size_t len)
 {
-    uint32_t *word_ptr = ptr;
-    uint32_t *word_src = src;
+    uint32_t *word_ptr = ptr, *word_src = src;
 
     while (len >= 4) {
         *word_ptr++ = *word_src++;
         len -= 4;
     }
 
-    char *byte_ptr = (char *) word_ptr;
-    char *byte_src = (char *) word_src;
-    while (len--) {
+    char *byte_ptr = (char *) word_ptr, *byte_src = (char *) word_src;
+    while (len--)
         *byte_ptr++ = *byte_src++;
-    }
 
     return ptr;
 }
@@ -227,8 +271,10 @@ char *SECTION_TEXT_VMSETUP itoa(uint32_t value,
                                 int min_len,
                                 char fill_char)
 {
-    static char digitals[16] = {'0', '1', '2', '3', '4', '5', '6', '7',
-                                '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+    static char digitals[16] = {
+        '0', '1', '2', '3', '4', '5', '6', '7',
+        '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
+    };
     static char str[64];
     char *ptr = str + 63;
     int tmp;
@@ -345,66 +391,131 @@ int SECTION_TEXT_VMSETUP printf(const char *format, ...)
     return res;
 }
 
+/* Demand paging: allocate a physical frame and map it to the faulting user VA.
+ *
+ * This implements a simple demand-paging scheme:
+ * 1. Round faulting address down to page boundary
+ * 2. Allocate a free physical frame from the freelist
+ * 3. Create PTE with appropriate permissions (RWX for user)
+ * 4. Flush TLB entry for the faulting address
+ * 5. Copy page contents from kernel's direct mapping of user memory
+ *
+ * The copy step populates the new page with data from the ELF sections
+ * (code from .text.main, data from .mystring, etc.) that were loaded at
+ * the corresponding physical addresses.
+ */
 void SECTION_TEXT_VMSETUP handle_fault(uint32_t addr, uint32_t cause)
 {
-    addr = addr >> PG_SHIFT << PG_SHIFT; /* round down page */
+    /* Page-align the faulting address */
+    addr = addr >> PG_SHIFT << PG_SHIFT;
+
+    /* Locate PTE in user L2 table: extract VPN[0] (bits 12-21) */
     pte_t *pte = user_l1pt + ((addr >> PG_SHIFT) & MASK(10));
 
-    /* create a new pte */
+    /* Allocate physical frame from freelist */
     assert(freelist_head);
     pte_t pa = freelist_head->addr;
     freelist_head = freelist_head->next;
+
+    /* Build PTE: PPN | flags. All user pages get RWXU permissions.
+     * Set Accessed bit; set Dirty bit only for store faults. */
     *pte = (pa >> PG_SHIFT << PTE_PPN_SHIFT) | PTE_A | PTE_U | PTE_R | PTE_W |
            PTE_X | PTE_V;
-    if ((1U << cause) == CAUSE_STORE_PAGE_FAULT)
+    if (cause == CAUSE_STORE_PAGE_FAULT)
         *pte |= PTE_D;
 
-    /* temporarily allow kernel to access user memory to copy data */
+    /* Invalidate stale TLB entry before accessing the new mapping */
+    asm volatile("sfence.vma %0" ::"r"(addr) : "memory");
+
+    /* Copy page contents from kernel's view of user memory.
+     * Enable SUM (Supervisor User Memory access) temporarily.
+     */
     set_csr(sstatus, SSTATUS_SUM);
-    /* page table is updated, so main should not cause trap here */
     memcpy((uint32_t *) addr, (uint32_t *) uva2kva(addr), PG_SIZE);
-    /* disallow kernel to access user memory */
     clear_csr(sstatus, SSTATUS_SUM);
 }
 
+/* S-mode trap handler entry point (called from supervisor_trap_entry in
+ * setup.S).
+ *
+ * Dispatches exceptions based on scause. For this test, only page faults are
+ * expected. After handling, restores user context via pop_tf() which executes
+ * sret to return to user mode at the faulting instruction (now mapped).
+ */
 void SECTION_TEXT_VMSETUP handle_trap(trapframe_t *tf)
 {
-    if ((1U << tf->cause) == CAUSE_FETCH_PAGE_FAULT ||
-        (1U << tf->cause) == CAUSE_LOAD_PAGE_FAULT ||
-        (1U << tf->cause) == CAUSE_STORE_PAGE_FAULT) {
+    if (tf->cause == CAUSE_FETCH_PAGE_FAULT ||
+        tf->cause == CAUSE_LOAD_PAGE_FAULT ||
+        tf->cause == CAUSE_STORE_PAGE_FAULT) {
         handle_fault(tf->badvaddr, tf->cause);
-    } else
+    } else {
         assert(!"Unknown exception");
+    }
 
+    /* Return to user mode: restore registers and sret */
     pop_tf(tf);
 }
 
+/* Initialize Sv32 page tables, enable paging, and jump to user mode.
+ *
+ * This is called from _start after basic register initialization. It sets up
+ * the two-level Sv32 page table structure, configures trap delegation, and
+ * enters user mode via sret.
+ */
 void SECTION_TEXT_VMSETUP vm_boot()
 {
-    /* map first page table entry to a next level page table for user */
+    /* L1[0]: Point to L2 table for user VA 0x00000000-0x003FFFFF.
+     * User pages are initially unmapped; PTEs populated on demand by faults.
+     */
     l1pt[0] = ((pte_t) user_l1pt >> PG_SHIFT << PTE_PPN_SHIFT) | PTE_V;
-    /* map last page table leaf entry for kernel which direct maps for user
-     * virtual memory, note that this is a trick of 2's complement, e.g., 0 -
-     * MEGA_PG = 0b1111111111xxx...x when page fault occurs after entering main
+
+    /* L1[1023]: Kernel direct map at VA 0xFFC00000 for accessing user memory.
+     * Maps PA of main() so kernel can copy user pages during fault handling.
+     * The uva2kva() macro relies on this mapping: uva - 0x400000 = kva.
+     * PTE_G marks this as global (not flushed on ASID change).
      */
     l1pt[PTES_PER_PT - 1] = ((pte_t) main >> PG_SHIFT << PTE_PPN_SHIFT) |
-                            PTE_V | PTE_R | PTE_W | PTE_X | PTE_A | PTE_D;
+                            PTE_V | PTE_R | PTE_W | PTE_X | PTE_G | PTE_A |
+                            PTE_D;
 
-    /* direct map kernel virtual memory */
+    /* L1[512]: Kernel megapage at VA 0x80000000, mapping PA 0x00800000.
+     * All kernel code runs at this VA after paging is enabled.
+     * PTE_G marks this as global (not flushed on ASID change).
+     */
     l1pt[PTES_PER_PT >> 1] = ((pte_t) _start >> PG_SHIFT << PTE_PPN_SHIFT) |
-                             PTE_V | PTE_R | PTE_W | PTE_X | PTE_A | PTE_D;
+                             PTE_V | PTE_R | PTE_W | PTE_X | PTE_G | PTE_A |
+                             PTE_D;
 
-    /* Enable paging */
+    /* L1[2]: Identity map PA 0x00800000 to VA 0x00800000.
+     * Required so the PC (still at physical address) remains valid immediately
+     * after SATP write enables paging. Without this, the next instruction
+     * fetch would fault before we can jump to kernel VA 0x80000000.
+     * PTE_G marks this as global (not flushed on ASID change).
+     */
+    l1pt[2] = ((pte_t) _start >> PG_SHIFT << PTE_PPN_SHIFT) | PTE_V | PTE_R |
+              PTE_W | PTE_X | PTE_G | PTE_A | PTE_D;
+
+    /* Enable Sv32 paging by writing SATP with mode=1 and PPN of root table */
     uintptr_t satp_val = ((pte_t) &l1pt >> PG_SHIFT) | SV32_MODE;
     write_csr(satp, satp_val);
 
-    /* set up supervisor trap handler */
+    /* Flush all TLB entries to ensure new translations take effect */
+    asm volatile("sfence.vma" ::: "memory");
+
+    /* Configure S-mode trap handling:
+     * - stvec: trap vector points to supervisor_trap_entry (in setup.S)
+     * - sscratch: holds trapframe pointer for register save/restore
+     */
     write_csr(stvec, supervisor_trap_entry);
     write_csr(sscratch, read_csr(mscratch));
-    /* No delegation */
-    /*write_csr(medeleg, CAUSE_FETCH_PAGE_FAULT | CAUSE_LOAD_PAGE_FAULT |
-                           CAUSE_STORE_PAGE_FAULT);*/
 
+    /* Delegate page fault exceptions from M-mode to S-mode.
+     * medeleg uses bit positions: bit N delegates exception code N. */
+    write_csr(medeleg, (1U << CAUSE_FETCH_PAGE_FAULT) |
+                           (1U << CAUSE_LOAD_PAGE_FAULT) |
+                           (1U << CAUSE_STORE_PAGE_FAULT));
+
+    /* Initialize frame allocator: linked list of 32 free 4KB frames */
     freelist_head = (void *) &freelist_nodes[0];
     freelist_tail = &freelist_nodes[MAX_TEST_PG - 1];
     for (uint32_t i = 0; i < MAX_TEST_PG; i++) {
@@ -413,6 +524,9 @@ void SECTION_TEXT_VMSETUP vm_boot()
     }
     freelist_nodes[MAX_TEST_PG - 1].next = 0;
 
+    /* Enter user mode: set up minimal trapframe and sret to user_entry,
+     * which will set up user stack and jump to VA 0x0 (main).
+     */
     trapframe_t tf;
     memset(&tf, 0, sizeof(tf));
     tf.epc = (uint32_t) &user_entry;


### PR DESCRIPTION
This resolves incorrect `CAUSE_*` macro definitions that used bit-shifted values instead of raw scause register values. The RISC-V privilege spec defines scause values as 12 (instruction page fault), 13 (load page fault), and 15 (store page fault), not their bit positions.

It adds documentation explaining the Sv32 two-level page table, PTE flag bits, and the demand paging test flow.

It fixes missing PTE_G (Global) flags on kernel megapage mappings, which should be set for mappings that exist across all address spaces.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes scause handling and stabilizes the MMU demand paging test so instruction, load, and store page faults behave per the RISC-V spec. Updates page tables, trap code, and emulator PC sync to make the test reliable.

- **Bug Fixes**
  - Use raw scause codes (8/9/12/13/15) and correct trap dispatch.
  - Set PTE_G on kernel megapage mappings and add a PA identity map for safe SATP enable.
  - Sync PC in interpreter paths for SYSTEM builds to ensure correct trap context.
  - Fix trapframe save/restore (x30/a0) and split kernel/user stacks.
  - Install demand-mapped pages with SUM + sfence.vma; copy data reliably.

- **Refactors**
  - Simplified the MMU test to cleanly exercise instruction, load, and store faults.
  - Documented Sv32 layout, PTE flags, and the demand paging flow; updated linker script to avoid sparse 2GB ELF and asserted kernel fits in 4 MiB.
  - Added a small freelist allocator (32 frames at 4 MiB) for demand paging.
  - Delegated page faults to S-mode and flushed TLB on updates.

<sup>Written for commit e228af4d459e497f9cd52b9520210eb3cc0ca679. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

