### PR TITLE
CI: Fix wasm-system-deploy failure

### DIFF
--- a/.github/workflows/deploy-wasm.yml
+++ b/.github/workflows/deploy-wasm.yml
@@ -61,10 +61,7 @@ jobs:
         shell: bash
       - name: fetch artifact
         run: |
-              make artifact
-              # get from rv32emu-prebuilt
-              .ci/fetch.sh -o build/shareware_doom_iwad.zip "https://raw.githubusercontent.com/sysprog21/rv32emu-prebuilt/doom-artifact/shareware_doom_iwad.zip"
-              unzip -o -d build/ build/shareware_doom_iwad.zip
+              make artifact ENABLE_SYSTEM=1
       - name: build with emcc and move application files to /tmp
         if: ${{ steps.changed-files.outputs.any_modified == 'true' ||
             github.event_name == 'workflow_dispatch' ||

--- a/mk/wasm.mk
+++ b/mk/wasm.mk
@@ -82,7 +82,13 @@ $(OUT)/elf_list.js: artifact tools/gen-elf-list-js.py
 	$(Q)tools/gen-elf-list-js.py > $@
 
 # Dependencies for WASM build
+# System mode only needs artifact (linux-image) and timidity (audio)
+# User mode needs elf_list.js for demo selection and game data for embedding
+ifeq ($(CONFIG_SYSTEM),y)
+deps_emcc += artifact $(TIMIDITY_DATA)
+else
 deps_emcc += artifact $(OUT)/elf_list.js $(DOOM_DATA) $(QUAKE_DATA) $(TIMIDITY_DATA)
+endif
 
 # Browser TCO Support Detection
 


### PR DESCRIPTION
The wasm-system-deploy job failed because 'make artifact' was invoked without ENABLE_SYSTEM=1, downloading benchmark artifacts instead of linux-image artifacts. When the subsequent build step ran with ENABLE_SYSTEM=1, it triggered artifact fetching again but failed because LATEST_RELEASE wasn't set (the conditional in mk/artifact.mk only triggers when MAKECMDGOALS includes artifact targets). Changes:
- Pass ENABLE_SYSTEM=1 to 'make artifact' in wasm-system-deploy job
- Remove unnecessary DOOM WAD download (not needed for system mode)
- Optimize deps_emcc in wasm.mk to skip game data for system builds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the wasm-system-deploy CI job by fetching the correct system artifacts and skipping game data in system builds. This prevents artifact re-fetch failures and speeds up the workflow.

- **Bug Fixes**
  - Pass ENABLE_SYSTEM=1 to make artifact in wasm-system-deploy.
  - Remove DOOM WAD download from the CI job (not needed in system mode).

- **Refactors**
  - Optimize deps_emcc in wasm.mk to exclude game data for CONFIG_SYSTEM=y; keep only linux-image artifact and timidity.

<sup>Written for commit 8d251bccd939f641fcea0b9f325d114fcbf35b66. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

