### PR TITLE
Fix build system regressions in external/artifact

### DIFF
--- a/.ci/boot-linux.sh
+++ b/.ci/boot-linux.sh
@@ -72,7 +72,8 @@ for disk_img in "${VBLK_IMGS[@]}"; do
     fi
 done
 
-TIMEOUT=50
+# Allow timeout override for JIT tests (JIT compilation adds significant overhead)
+TIMEOUT=${BOOT_TIMEOUT:-50}
 OPTS_BASE=" -k build/linux-image/Image"
 OPTS_BASE+=" -i build/linux-image/rootfs.cpio"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -301,6 +301,7 @@ jobs:
       if: success()
       env:
         CC: ${{ steps.install_cc.outputs.cc }}
+        BOOT_TIMEOUT: 90  # JIT compilation adds significant overhead
       run: |
             make distclean && make system_defconfig && make INITRD_SIZE=32 ENABLE_JIT=1 ENABLE_MOP_FUSION=0 $PARALLEL && make artifact $PARALLEL
             bash -c "${BOOT_LINUX_TEST}"
@@ -581,6 +582,7 @@ jobs:
        if: success()
        env:
          CC: ${{ steps.install_cc.outputs.cc }}
+         BOOT_TIMEOUT: 90  # JIT compilation adds significant overhead
        run: |
              make distclean && make system_defconfig && make INITRD_SIZE=32 ENABLE_JIT=1 ENABLE_MOP_FUSION=0 $PARALLEL && make artifact $PARALLEL
              bash -c "${BOOT_LINUX_TEST}"

--- a/mk/artifact.mk
+++ b/mk/artifact.mk
@@ -246,7 +246,7 @@ else
 endif
 endif
 
-scimark2:
+scimark2: | $(BIN_DIR)/linux-x86-softfp $(BIN_DIR)/riscv32
 ifeq ($(call has, PREBUILT), 0)
 ifeq ($(call has, SYSTEM), 0)
 	$(call prologue,scimark2)

--- a/mk/external.mk
+++ b/mk/external.mk
@@ -130,7 +130,8 @@ TIMIDITY_DATA_SHA_CMD := $(SHA1SUM)
 
 # Buildroot (for Linux image building)
 BUILDROOT_VERSION := 2025.11
-BUILDROOT_DATA := /tmp/buildroot
+BUILDROOT_DATA_DEST := /tmp
+BUILDROOT_DATA := $(BUILDROOT_DATA_DEST)/buildroot
 BUILDROOT_DATA_URL := git clone https://github.com/buildroot/buildroot $(BUILDROOT_DATA) -b $(BUILDROOT_VERSION) --depth=1
 # find /tmp/buildroot -type f -not -path '*/.git/*' -print0 | \
 #	LC_ALL=C sort -z | \
@@ -151,7 +152,8 @@ LINUX_DATA_SHA_CMD := $(SHA256SUM)
 
 # simplefs kernel module
 SIMPLEFS_VERSION := rel2025.0
-SIMPLEFS_DATA := /tmp/simplefs
+SIMPLEFS_DATA_DEST := /tmp
+SIMPLEFS_DATA := $(SIMPLEFS_DATA_DEST)/simplefs
 SIMPLEFS_DATA_URL := git clone https://github.com/sysprog21/simplefs $(SIMPLEFS_DATA) -b $(SIMPLEFS_VERSION) --depth=1
 # find /tmp/simplefs -type f -not -path '*/.git/*' -print0 | \
 #	LC_ALL=C sort -z | \


### PR DESCRIPTION
- Add missing _DATA_DEST definitions for BUILDROOT and SIMPLEFS in mk/external.mk. The download-extract-verify template requires this variable for mkdir, causing "mkdir: missing operand" errors.
- Add order-only prerequisites to scimark2 target in mk/artifact.mk to ensure output directories exist before copying built binaries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes image build failures by setting missing data destination variables and ensuring scimark2 creates output directories before copying. Also stabilizes the CI JIT boot test by making the boot timeout configurable and increasing it to 90s for JIT runs.

- **Bug Fixes**
  - Define BUILDROOT_DATA_DEST and SIMPLEFS_DATA_DEST so the download-extract-verify template can mkdir correctly.
  - Add order-only prerequisites to scimark2 to require $(BIN_DIR)/linux-x86-softfp and $(BIN_DIR)/riscv32 exist before copying.
  - Make boot timeout configurable via BOOT_TIMEOUT (default 50s) and set 90s for JIT jobs in CI.

<sup>Written for commit 3bc90b3a69b410e4d68298494b897315f865de9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

