### PR TITLE
Refine artifact build system

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,8 @@ jobs:
       matrix:
         compiler: [gcc, clang]
     runs-on: ubuntu-24.04
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v6
       with:
@@ -147,7 +149,6 @@ jobs:
     - name: Fetch artifacts
       env:
         CC: ${{ steps.install_cc.outputs.cc }}
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
             . .ci/common.sh
             fetch_artifact ELF
@@ -211,7 +212,7 @@ jobs:
       env:
         CC: ${{ steps.install_cc.outputs.cc }}
       run: |
-            make distclean
+            make cleanconfig
             make defconfig
             make check $PARALLEL
             make tests $PARALLEL
@@ -227,17 +228,18 @@ jobs:
             # Core extensions + bit manipulation + CSR/fence + performance features
             # Tests both interpreter and JIT modes (12 × 2 = 24 builds)
             # Consolidated from 25 separate builds (13 interpreter + 12 JIT)
+            # Use cleanconfig instead of distclean to preserve artifacts across iterations
             for ext in ENABLE_EXT_M ENABLE_EXT_A ENABLE_EXT_F ENABLE_EXT_C \
                        ENABLE_Zba ENABLE_Zbb ENABLE_Zbc ENABLE_Zbs \
                        ENABLE_Zicsr ENABLE_Zifencei \
                        ENABLE_MOP_FUSION ENABLE_BLOCK_CHAINING; do
               echo "Testing ${ext}=0 (interpreter)"
-              if ! (make distclean && make defconfig && make ${ext}=0 check $PARALLEL); then
+              if ! (make cleanconfig && make defconfig && make ${ext}=0 check $PARALLEL); then
                 echo "ERROR: Interpreter test failed with ${ext}=0"
                 exit 1
               fi
               echo "Testing ${ext}=0 (JIT)"
-              if ! (make distclean && make jit_defconfig && make ${ext}=0 check $PARALLEL); then
+              if ! (make cleanconfig && make jit_defconfig && make ${ext}=0 check $PARALLEL); then
                 echo "ERROR: JIT test failed with ${ext}=0"
                 exit 1
               fi
@@ -285,8 +287,8 @@ jobs:
     - name: undefined behavior test
       if: success() || failure()
       run: |
-            make distclean && make defconfig && make ENABLE_UBSAN=1 check $PARALLEL
-            make distclean && make jit_defconfig && make ENABLE_UBSAN=1 check $PARALLEL
+            make cleanconfig && make defconfig && make ENABLE_UBSAN=1 check $PARALLEL
+            make cleanconfig && make jit_defconfig && make ENABLE_UBSAN=1 check $PARALLEL
 
     - name: boot Linux kernel test
       if: success()
@@ -311,15 +313,9 @@ jobs:
       if: success()
       env:
         CC: ${{ steps.install_cc.outputs.cc }}
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
             . .ci/common.sh
-            export LATEST_RELEASE=$(download_with_headers "https://api.github.com/repos/sysprog21/rv32emu-prebuilt/releases" \
-                                                          "Authorization: Bearer ${GH_TOKEN}" \
-                                           | grep '"tag_name"' \
-                                           | grep "sail" \
-                                           | head -n 1 \
-                                           | sed -E 's/.*"tag_name": "([^"]+)".*/\1/')
+            export LATEST_RELEASE=$(fetch_latest_release sail)
             .ci/riscv-tests.sh
 
   # Native AArch64 on GitHub ARM runners - fast, no QEMU overhead
@@ -328,6 +324,8 @@ jobs:
     if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
     timeout-minutes: 30
     runs-on: ubuntu-24.04-arm
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - name: checkout code
       uses: actions/checkout@v6
@@ -374,27 +372,16 @@ jobs:
     - name: Fetch artifacts
       env:
         CC: clang-${{ env.LLVM_VERSION }}
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
             . .ci/common.sh
-            LATEST_RELEASE=$(download_with_headers "https://api.github.com/repos/sysprog21/rv32emu-prebuilt/releases" \
-                                                   "Authorization: Bearer ${GH_TOKEN}" \
-                            | grep '"tag_name"' \
-                            | grep "ELF" \
-                            | head -n 1 \
-                            | sed -E 's/.*"tag_name": "([^"]+)".*/\1/')
-            if [ -z "$LATEST_RELEASE" ]; then
-                echo "Error: Failed to fetch LATEST_RELEASE from GitHub API"
-                exit 1
-            fi
-            make LATEST_RELEASE=$LATEST_RELEASE artifact
+            fetch_artifact ELF
 
     # FIXME: gcc build fails on AArch64/Linux hosts
     - name: check + tests
       env:
         CC: clang-${{ env.LLVM_VERSION }}
       run: |
-            make distclean
+            make cleanconfig
             make defconfig
             make check $PARALLEL
 
@@ -418,6 +405,8 @@ jobs:
       matrix:
         compiler: [gcc-15, clang]
     runs-on: macos-latest # M1 chip
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
      - uses: actions/checkout@v6
        with:
@@ -484,10 +473,16 @@ jobs:
      - name: Symlink gcc-15 due to the default /usr/local/bin/gcc links to system's clang
        run: |
              ln -s /opt/homebrew/opt/gcc/bin/gcc-15 /usr/local/bin/gcc-15
+     - name: Cache build artifacts
+       uses: actions/cache@v5
+       with:
+         path: build/
+         key: rv32emu-artifacts-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('mk/artifact.mk', 'mk/external.mk') }}
+         restore-keys: |
+           rv32emu-artifacts-${{ runner.os }}-${{ runner.arch }}-
      - name: fetch artifact first to reduce HTTP requests
        env:
          CC: ${{ steps.install_cc.outputs.cc }}
-         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        run: |
              . .ci/common.sh
              fetch_artifact ELF
@@ -505,7 +500,7 @@ jobs:
        env:
          CC: ${{ steps.install_cc.outputs.cc }}
        run: |
-             make distclean
+             make cleanconfig
              make defconfig
              make check $PARALLEL
              make tests $PARALLEL
@@ -521,17 +516,18 @@ jobs:
              # Core extensions + bit manipulation + CSR/fence + performance features
              # Tests both interpreter and JIT modes (12 × 2 = 24 builds)
              # Consolidated from 25 separate builds (13 interpreter + 12 JIT)
+             # Use cleanconfig instead of distclean to preserve artifacts across iterations
              for ext in ENABLE_EXT_M ENABLE_EXT_A ENABLE_EXT_F ENABLE_EXT_C \
                         ENABLE_Zba ENABLE_Zbb ENABLE_Zbc ENABLE_Zbs \
                         ENABLE_Zicsr ENABLE_Zifencei \
                         ENABLE_MOP_FUSION ENABLE_BLOCK_CHAINING; do
                echo "Testing ${ext}=0 (interpreter)"
-               if ! (make distclean && make defconfig && make ${ext}=0 check $PARALLEL); then
+               if ! (make cleanconfig && make defconfig && make ${ext}=0 check $PARALLEL); then
                  echo "ERROR: Interpreter test failed with ${ext}=0"
                  exit 1
                fi
                echo "Testing ${ext}=0 (JIT)"
-               if ! (make distclean && make jit_defconfig && make ${ext}=0 check $PARALLEL); then
+               if ! (make cleanconfig && make jit_defconfig && make ${ext}=0 check $PARALLEL); then
                  echo "ERROR: JIT test failed with ${ext}=0"
                  exit 1
                fi
@@ -565,8 +561,8 @@ jobs:
        env:
          CC: ${{ steps.install_cc.outputs.cc }}
        run: |
-             make distclean && make defconfig && make ENABLE_UBSAN=1 check $PARALLEL
-             make distclean && make jit_defconfig && make ENABLE_UBSAN=1 check $PARALLEL
+             make cleanconfig && make defconfig && make ENABLE_UBSAN=1 check $PARALLEL
+             make cleanconfig && make jit_defconfig && make ENABLE_UBSAN=1 check $PARALLEL
 
      - name: boot Linux kernel test
        if: success()
@@ -592,15 +588,9 @@ jobs:
        if: success()
        env:
          CC: ${{ steps.install_cc.outputs.cc }}
-         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        run: |
              . .ci/common.sh
-             export LATEST_RELEASE=$(download_with_headers "https://api.github.com/repos/sysprog21/rv32emu-prebuilt/releases" \
-                                                           "Authorization: Bearer ${GH_TOKEN}" \
-                                            | grep '"tag_name"' \
-                                            | grep "sail" \
-                                            | head -n 1 \
-                                            | sed -E 's/.*"tag_name": "([^"]+)".*/\1/')
+             export LATEST_RELEASE=$(fetch_latest_release sail)
              python3 -m venv venv
              . venv/bin/activate
              .ci/riscv-tests.sh

--- a/mk/external.mk
+++ b/mk/external.mk
@@ -45,15 +45,15 @@ define is-git-clone
 $(filter git,$(firstword $(1)))
 endef
 
-# Detect wget --show-progress support (GNU wget extension)
-WGET_HAS_PROGRESS := $(shell wget --help 2>&1 | grep -q show-progress && echo yes)
+# HTTP utilities are provided by mk/http.mk (included before this file)
+# Provides: HTTP_TOOL, HTTP_GET, HTTP_DOWNLOAD, HTTP_DOWNLOAD_QUIET
 
-# Download from URL (supports git clone or wget)
+# Download from URL (supports git clone or HTTP download with retry)
 # $(1): URL or git command
 define download
 $(if $(call is-git-clone,$(1)),\
 	$(1),\
-	wget -q $(if $(WGET_HAS_PROGRESS),--show-progress) --continue "$(strip $(1))")
+	$(call HTTP_DOWNLOAD,"$(strip $(1))","$(notdir $(1))"))
 endef
 
 # Extract archive to destination

--- a/mk/http.mk
+++ b/mk/http.mk
@@ -1,0 +1,40 @@
+# HTTP download utilities
+#
+# Provides unified HTTP download macros for curl/wget with retry logic.
+# Include this file before any mk file that needs HTTP downloads.
+
+ifndef _MK_HTTP_INCLUDED
+_MK_HTTP_INCLUDED := 1
+
+# HTTP download tool detection (prefer curl, fallback to wget)
+CURL := $(shell command -v curl 2>/dev/null)
+WGET := $(shell command -v wget 2>/dev/null)
+
+# Detect wget --show-progress support (GNU wget extension)
+WGET_HAS_PROGRESS := $(if $(WGET),$(shell $(WGET) --help 2>&1 | grep -q show-progress && echo 1))
+
+# Select HTTP tool and define unified commands
+# Note: GH_TOKEN environment variable enables authenticated GitHub API requests
+# (avoids 60 requests/hour rate limit for unauthenticated requests)
+ifdef CURL
+    HTTP_TOOL := curl
+    # Fetch URL to stdout (for parsing API responses)
+    # Uses GH_TOKEN if available for authenticated requests
+    # $(1): URL
+    HTTP_GET = curl -fsSL $(if $(GH_TOKEN),-H "Authorization: Bearer $(GH_TOKEN)") $(1) 2>/dev/null
+    # Download file with progress bar and retry
+    # $(1): URL, $(2): output file
+    HTTP_DOWNLOAD = curl -fSL --retry 3 --retry-delay 2 --progress-bar $(1) -o $(2)
+    # Download file silently with retry
+    # $(1): URL, $(2): output file
+    HTTP_DOWNLOAD_QUIET = curl -fsSL --retry 3 --retry-delay 2 $(1) -o $(2)
+else ifdef WGET
+    HTTP_TOOL := wget
+    HTTP_GET = wget -q $(if $(GH_TOKEN),--header="Authorization: Bearer $(GH_TOKEN)") -O- $(1) 2>/dev/null
+    HTTP_DOWNLOAD = wget -q $(if $(WGET_HAS_PROGRESS),--show-progress) --tries=3 --waitretry=2 $(1) -O $(2)
+    HTTP_DOWNLOAD_QUIET = wget -q --tries=3 --waitretry=2 $(1) -O $(2)
+else
+    HTTP_TOOL :=
+endif
+
+endif # _MK_HTTP_INCLUDED

--- a/mk/kconfig.mk
+++ b/mk/kconfig.mk
@@ -37,12 +37,6 @@ env-check:
 	@echo "Checking build environment..."
 	@python3 tools/detect-env.py --summary
 	@echo ""
-	@if python3 tools/detect-env.py --have-emcc 2>/dev/null | grep -q y; then \
-		echo "[WebAssembly] Emscripten detected. 'WebAssembly' build target available in 'make config'."; \
-	else \
-		echo "[WebAssembly] Emscripten not found. Install emsdk to enable WASM builds."; \
-	fi
-	@echo ""
 
 # Interactive configuration
 config: env-check $(KCONFIG_DIR)/menuconfig.py


### PR DESCRIPTION
This consolidates prebuilt artifact handling with unified mode config:
- Introduce ACTIVE_* variables to eliminate repeated mode checks
- Centralize GitHub URLs into single PREBUILT_REPO source of truth
- Add stamp files (.stamp-prebuilt, .stamp-linux-image, .stamp-sail) to track successful artifact fetches
- Fix re-fetch path to use $(BIN_DIR) instead of hardcoded 'build/'
- Add re-verification after re-fetch before creating stamp file
- Handle edge case where checksum files exist but are empty
- Clean up distclean target to remove stamp and verify files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refined the prebuilt artifact flow with unified mode config and stamp-based tracking. Adds curl/wget with retry logic, preserves artifacts between CI builds to cut downloads, and improves SHA-1 verification and cleanup.

- **Refactors**
  - Centralized GitHub URLs with PREBUILT_REPO and prebuilt-url.
  - Introduced ACTIVE_* variables to select mode (ELF, SYSTEM, ARCH_TEST) without repeated checks.
  - Added stamp files (.stamp-prebuilt, .stamp-linux-image, .stamp-sail) to mark successful fetches.
  - Consolidated checksum fetching and verification into mode-specific specs.
  - Extracted HTTP utilities to mk/http.mk (prefer curl, fallback to wget, with retries) and reused across artifact/external downloads.
  - Added cleanconfig to preserve artifacts; CI switched from distclean to cleanconfig and caches build/ on macOS.

- **Bug Fixes**
  - Re-fetch now uses $(BIN_DIR) instead of hardcoded build/.
  - Re-verifies after re-fetch before creating stamp files.
  - Handles empty checksum files by refetching with tag lookup.
  - distclean removes stamp, verify, checksum, and cached artifact files.
  - Fixed sentinel check to require all checksum files before skipping tag fetch.
  - Ensured gdbstub-test fetches artifacts before running to prevent CI failures.
  - Use GH_TOKEN for authenticated GitHub API calls to avoid rate limiting.

<sup>Written for commit 5326a167a76900d2b0acf290a9077228982ee3db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

