### PR TITLE
Use memory pool for macro-op fusion arrays

### DIFF
--- a/src/riscv_private.h
+++ b/src/riscv_private.h
@@ -23,6 +23,12 @@
 
 #define PRIV(x) ((vm_attr_t *) x->data)
 
+/* Maximum entries per fuse slot - limits fusion to 16 consecutive instructions.
+ * Larger sequences are rare and provide diminishing returns.
+ */
+#define FUSE_MAX_ENTRIES 16
+#define FUSE_SLOT_SIZE (FUSE_MAX_ENTRIES * sizeof(opcode_fuse_t))
+
 /* CSRs */
 enum {
     /* floating point */
@@ -258,7 +264,7 @@ struct riscv_internal {
     void *jit_state;
     void *jit_cache;
 #endif
-    struct mpool *block_mp, *block_ir_mp;
+    struct mpool *block_mp, *block_ir_mp, *fuse_mp;
 
 #if RV32_HAS(GDBSTUB)
     /* gdbstub instance */


### PR DESCRIPTION
This replaces malloc/free with mpool in macro-op fusion, eliminating per-allocation overhead and reduces memory fragmentation.

The fixed-size pool approach trades some memory (unused slot space for short sequences) for allocation speed and cache locality. Sequences exceeding 16 instructions gracefully degrade to non-fused execution.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch macro-op fusion arrays to a fixed-size memory pool to cut allocation overhead and fragmentation. Fused sequences are capped at 16 ops; longer sequences fall back to non-fused execution.

- **Refactors**
  - Replace malloc/free with mpool_alloc/mpool_free for ir->fuse arrays.
  - Add fuse_mp pool and FUSE_MAX_ENTRIES/FUSE_SLOT_SIZE constants.
  - Update cleanup paths: block_map_clear, block_map_destroy, rv_create failure handling, and rv_delete.

<sup>Written for commit 7dad6676ad06456001eded1c55b42e0571a4ebdb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

