### PR TITLE
Fix T2C thread synchronization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ $(eval $(require-config))
 OUT ?= build
 BIN := $(OUT)/rv32emu
 
-CFLAGS = -std=gnu99 $(KCONFIG_CFLAGS) -Wall -Wextra -Werror
+CFLAGS = -std=gnu11 $(KCONFIG_CFLAGS) -Wall -Wextra -Werror
 CFLAGS += -Wno-unused-label -include src/common.h -Isrc/ $(CFLAGS_NO_CET)
 LDFLAGS += $(KCONFIG_LDFLAGS)
 OBJS_EXT :=

--- a/src/gdbstub.c
+++ b/src/gdbstub.c
@@ -78,7 +78,7 @@ static int rv_write_mem(void *args, size_t addr, size_t len, void *val)
 
 static inline bool rv_is_interrupt(riscv_t *rv)
 {
-    return __atomic_load_n(&rv->is_interrupted, __ATOMIC_RELAXED);
+    return ATOMIC_LOAD(&rv->is_interrupted, ATOMIC_RELAXED);
 }
 
 static gdb_action_t rv_cont(void *args)
@@ -94,7 +94,7 @@ static gdb_action_t rv_cont(void *args)
     }
 
     /* Clear the interrupt if it's pending */
-    __atomic_store_n(&rv->is_interrupted, false, __ATOMIC_RELAXED);
+    ATOMIC_STORE(&rv->is_interrupted, false, ATOMIC_RELAXED);
 
     return ACT_RESUME;
 }
@@ -133,7 +133,7 @@ static void rv_on_interrupt(void *args)
     riscv_t *rv = (riscv_t *) args;
 
     /* Notify the emulator to break out the for loop in rv_cont */
-    __atomic_store_n(&rv->is_interrupted, true, __ATOMIC_RELAXED);
+    ATOMIC_STORE(&rv->is_interrupted, true, ATOMIC_RELAXED);
 }
 
 const struct target_ops gdbstub_ops = {

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -206,26 +206,41 @@ static pthread_t t2c_thread;
 static void *t2c_runloop(void *arg)
 {
     riscv_t *rv = (riscv_t *) arg;
+    pthread_mutex_lock(&rv->wait_queue_lock);
     while (!rv->quit) {
-        queue_entry_t *entry = NULL;
+        /* Wait for work or quit signal */
+        while (list_empty(&rv->wait_queue) && !rv->quit)
+            pthread_cond_wait(&rv->wait_queue_cond, &rv->wait_queue_lock);
 
-        /* Acquire lock before checking and accessing the queue to prevent
-         * race conditions with the main thread adding entries.
-         */
-        pthread_mutex_lock(&rv->wait_queue_lock);
-        if (!list_empty(&rv->wait_queue)) {
-            entry = list_last_entry(&rv->wait_queue, queue_entry_t, list);
-            list_del_init(&entry->list);
-        }
+        if (rv->quit)
+            break;
+
+        /* Extract work item while holding the lock */
+        queue_entry_t *entry =
+            list_last_entry(&rv->wait_queue, queue_entry_t, list);
+        list_del_init(&entry->list);
         pthread_mutex_unlock(&rv->wait_queue_lock);
 
-        if (entry) {
-            pthread_mutex_lock(&rv->cache_lock);
-            t2c_compile(rv, entry->block);
-            pthread_mutex_unlock(&rv->cache_lock);
-            free(entry);
-        }
+        /* Perform compilation with cache lock */
+        pthread_mutex_lock(&rv->cache_lock);
+        /* Look up block from cache using the key (might have been evicted) */
+        uint32_t pc = (uint32_t) entry->key;
+        block_t *block = (block_t *) cache_get(rv->block_cache, pc, false);
+#if RV32_HAS(SYSTEM)
+        /* Verify SATP matches (for system mode) */
+        uint32_t satp = (uint32_t) (entry->key >> 32);
+        if (block && block->satp != satp)
+            block = NULL;
+#endif
+        /* Compile only if block still exists in cache */
+        if (block)
+            t2c_compile(rv, block);
+        pthread_mutex_unlock(&rv->cache_lock);
+        free(entry);
+
+        pthread_mutex_lock(&rv->wait_queue_lock);
     }
+    pthread_mutex_unlock(&rv->wait_queue_lock);
     return NULL;
 }
 #endif
@@ -851,6 +866,7 @@ riscv_t *rv_create(riscv_user_t rv_attr)
     /* prepare wait queue. */
     pthread_mutex_init(&rv->wait_queue_lock, NULL);
     pthread_mutex_init(&rv->cache_lock, NULL);
+    pthread_cond_init(&rv->wait_queue_cond, NULL);
     INIT_LIST_HEAD(&rv->wait_queue);
     /* activate the background compilation thread. */
     pthread_create(&t2c_thread, NULL, t2c_runloop, rv);
@@ -984,10 +1000,24 @@ void rv_delete(riscv_t *rv)
     block_map_destroy(rv);
 #else
 #if RV32_HAS(T2C)
+    /* Signal the thread to quit */
+    pthread_mutex_lock(&rv->wait_queue_lock);
     rv->quit = true;
+    pthread_cond_signal(&rv->wait_queue_cond);
+    pthread_mutex_unlock(&rv->wait_queue_lock);
+
     pthread_join(t2c_thread, NULL);
+
+    /* Clean up any remaining entries in wait queue */
+    queue_entry_t *entry, *safe;
+    list_for_each_entry_safe (entry, safe, &rv->wait_queue, list) {
+        list_del(&entry->list);
+        free(entry);
+    }
+
     pthread_mutex_destroy(&rv->wait_queue_lock);
     pthread_mutex_destroy(&rv->cache_lock);
+    pthread_cond_destroy(&rv->wait_queue_cond);
     jit_cache_exit(rv->jit_cache);
 #endif
     jit_state_exit(rv->jit_state);

--- a/src/riscv_private.h
+++ b/src/riscv_private.h
@@ -132,7 +132,7 @@ typedef struct block {
 /* T2C implies JIT (enforced by Kconfig and feature.h) */
 #if RV32_HAS(T2C)
 typedef struct {
-    block_t *block;
+    uint64_t key; /**< cache key (PC or PC|SATP) to look up block */
     struct list_head list;
 } queue_entry_t;
 #endif
@@ -253,7 +253,8 @@ struct riscv_internal {
 #if RV32_HAS(T2C)
     struct list_head wait_queue;
     pthread_mutex_t wait_queue_lock, cache_lock;
-    volatile bool quit; /**< Determine the main thread is terminated or not */
+    pthread_cond_t wait_queue_cond;
+    bool quit; /**< termination flag, protected by wait_queue_lock */
 #endif
     void *jit_state;
     void *jit_cache;


### PR DESCRIPTION
This addresses reliability issue in JIT parallel mode by fixing race conditions in the T2C.
- Add portable ATOMIC_* macros in common.h with GNU __atomic builtins as primary, C11 stdatomic fallback, and single-threaded fallback
- Replace busy-wait polling with proper pthread_cond_wait in t2c_runloop
- Change queue_entry_t from block pointer to cache key (PC|SATP) to prevent use-after-free when blocks are evicted during compilation
- Add defensive check in t2c_compile to skip already-compiled blocks
- Use atomic operations for shared block fields
- Proper shutdown sequence: signal under lock, join, cleanup queue

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes T2C JIT race conditions to make background compilation reliable and thread-safe. Replaces busy-waiting with condition variables, adds portable atomics, and prevents use-after-free in the compile queue.

- **Bug Fixes**
  - Replace busy-wait polling with pthread_cond_wait in t2c_runloop; signal on enqueue and during shutdown.
  - Add portable ATOMIC_* macros and use them for shared fields (hot2, compiled, n_invoke, is_interrupted) with acquire/release ordering.
  - Queue cache keys (PC | SATP) instead of block pointers to avoid use-after-free; look up and compile under the cache lock only if the block still exists.
  - Defensive checks to skip already-compiled blocks and atomic increment of n_invoke when T2C is enabled.

- **Dependencies**
  - Build with gnu11 instead of gnu99 to support the atomics fallback path.

<sup>Written for commit c2c6847a3739397b506e06da44a1ca2a007e8bb2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

