### PR TITLE
Harden memory pool with NULL safety

### DIFF
--- a/src/mpool.h
+++ b/src/mpool.h
@@ -2,6 +2,14 @@
  * rv32emu is freely redistributable under the MIT License. See the file
  * "LICENSE" for information on usage and redistribution of this file.
  */
+
+/* Fixed-size memory pool allocator.
+ *
+ * Provides O(1) allocation/free for fixed-size objects. Uses mmap with
+ * demand paging when available, falling back to malloc. Pools auto-extend
+ * when exhausted. All functions are NULL-safe.
+ */
+
 #pragma once
 
 #include <stddef.h>
@@ -9,35 +17,39 @@
 struct mpool;
 
 /**
- * mpool_create - create a new memory pool
- * @pool_size: the size of memory pool
- * @chunk_size: the size of memory chunk, pool would be divided into several
- * chunks
+ * mpool_create - create a memory pool
+ * @pool_size: initial pool size in bytes
+ * @chunk_size: size of each allocation unit
+ *
+ * Returns pointer to pool, or NULL on failure.
  */
 struct mpool *mpool_create(size_t pool_size, size_t chunk_size);
 
 /**
- * mpool_alloc - allocate a memory chunk from target memory pool
- * @mp: a pointer points to the target memory pool
+ * mpool_alloc - allocate a chunk from the pool
+ * @mp: memory pool (NULL-safe)
+ *
+ * Returns pointer to chunk, or NULL if mp is NULL or allocation fails.
  */
 void *mpool_alloc(struct mpool *mp);
 
 /**
- * mpool_calloc - allocate a memory chunk from target memory pool and set it to
- * zero
- * @mp: a pointer points to the target memory pool
+ * mpool_calloc - allocate a zero-initialized chunk from the pool
+ * @mp: memory pool (NULL-safe)
+ *
+ * Returns pointer to zeroed chunk, or NULL if mp is NULL or allocation fails.
  */
 void *mpool_calloc(struct mpool *mp);
 
 /**
- * mpool_free - free a memory pool
- * @mp: a pointer points to target memory pool
- * @target: a pointer points to the target memory chunk
+ * mpool_free - return a chunk to the pool
+ * @mp: memory pool (NULL-safe)
+ * @target: chunk to free (NULL-safe)
  */
 void mpool_free(struct mpool *mp, void *target);
 
 /**
- * mpool_destroy - destroy a memory pool
- * @mp: a pointer points to the target memory pool
+ * mpool_destroy - destroy pool and release all memory
+ * @mp: memory pool (NULL-safe)
  */
 void mpool_destroy(struct mpool *mp);

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -739,9 +739,9 @@ riscv_t *rv_create(riscv_user_t rv_attr)
     assert(attr->rtc);
 #endif /* RV32_HAS(GOLDFISH_RTC) */
 
-    attr->vblk = malloc(sizeof(virtio_blk_state_t *) * attr->vblk_cnt);
+    attr->vblk = calloc(attr->vblk_cnt, sizeof(virtio_blk_state_t *));
     assert(attr->vblk);
-    attr->disk = malloc(sizeof(uint32_t *) * attr->vblk_cnt);
+    attr->disk = calloc(attr->vblk_cnt, sizeof(uint32_t *));
     assert(attr->disk);
 
     if (attr->vblk_cnt) {
@@ -832,6 +832,10 @@ riscv_t *rv_create(riscv_user_t rv_attr)
      */
     rv->fuse_mp = mpool_create(FUSE_SLOT_SIZE << BLOCK_IR_MAP_CAPACITY_BITS,
                                FUSE_SLOT_SIZE);
+    if (!rv->block_mp || !rv->block_ir_mp || !rv->fuse_mp) {
+        rv_log_fatal("Failed to create memory pool");
+        goto fail_mpool;
+    }
 
 #if !RV32_HAS(JIT)
     /* initialize the block map */
@@ -875,14 +879,33 @@ fail_block_cache:
     if (rv->jit_state)
         jit_state_exit(rv->jit_state);
 fail_jit_state:
+#endif
+fail_mpool:
     mpool_destroy(rv->block_ir_mp);
     mpool_destroy(rv->block_mp);
     mpool_destroy(rv->fuse_mp);
+#if RV32_HAS(SYSTEM_MMIO)
+    if (attr->uart)
+        u8250_delete(attr->uart);
+    if (attr->plic)
+        plic_delete(attr->plic);
+#if RV32_HAS(GOLDFISH_RTC)
+    if (attr->rtc)
+        rtc_delete(attr->rtc);
+#endif
+    if (attr->vblk) {
+        for (int i = 0; i < attr->vblk_cnt; i++) {
+            if (attr->vblk[i])
+                vblk_delete(attr->vblk[i]);
+        }
+        free(attr->vblk);
+    }
+    free(attr->disk);
+#endif
     map_delete(attr->fd_map);
     memory_delete(attr->mem);
     free(rv);
     return NULL;
-#endif
 }
 
 #if !RV32_HAS(SYSTEM_MMIO)


### PR DESCRIPTION
- Add NULL checks to mpool_{alloc,calloc,free,destroy}
- Add mpool_create failure check in rv_create with proper cleanup path
- Add SYSTEM_MMIO device cleanup on init failure
- Use calloc for vblk/disk arrays to ensure zero-initialization

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the memory pool and rv_create with NULL-safe checks and proper failure cleanup to prevent crashes and leaks. vblk/disk arrays now use calloc for zero-initialization.

- **Bug Fixes**
  - Added NULL checks to mpool_alloc, mpool_calloc, mpool_free, and mpool_destroy.
  - rv_create now handles mpool_create failure and cleans up SYSTEM_MMIO devices, vblk/disk arrays, maps, memory, and rv.
  - Switched vblk/disk allocation to calloc to avoid uninitialized pointers.

<sup>Written for commit 412a88d404aa29261b32cde925a07e545691b823. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

