### PR TITLE
Reduce interpreter/JIT overhead

### DIFF
--- a/mk/common.mk
+++ b/mk/common.mk
@@ -35,8 +35,9 @@ endef
 
 # Get specified feature (supports both ENABLE_* and CONFIG_*)
 POSITIVE_WORDS = 1 true yes y
+NEGATIVE_WORDS = 0 false no n
 define has
-$(if $(filter $(firstword $(ENABLE_$(strip $1))), $(POSITIVE_WORDS)),1,$(call config-to-feature,$1))
+$(if $(filter $(firstword $(ENABLE_$(strip $1))),$(NEGATIVE_WORDS)),0,$(if $(filter $(firstword $(ENABLE_$(strip $1))),$(POSITIVE_WORDS)),1,$(call config-to-feature,$1)))
 endef
 
 # Set compiler feature flag from config

--- a/src/cache.h
+++ b/src/cache.h
@@ -69,13 +69,6 @@ uint32_t cache_freq(const struct cache *cache, uint32_t key);
 
 #if RV32_HAS(JIT) && RV32_HAS(SYSTEM)
 
-/* Page index for O(1) cache invalidation by virtual address.
- * With page-bounded blocks, each block fits entirely within one 4KB page,
- * allowing direct lookup by page address instead of O(n) scan.
- */
-#define PAGE_INDEX_BITS 10
-#define PAGE_INDEX_SIZE (1 << PAGE_INDEX_BITS)
-
 /**
  * cache_invalidate_satp - invalidate all blocks matching the given SATP
  * @cache: a pointer to target cache
@@ -96,7 +89,19 @@ uint32_t cache_invalidate_satp(struct cache *cache, uint32_t satp);
  *
  * This is used by SFENCE.VMA with rs1!=0 (address-specific flush) to
  * invalidate JIT-compiled blocks in a specific virtual page.
- * Uses O(1) page-indexed lookup instead of O(n) scan.
+ * Uses O(1) page-indexed lookup when BLOCK_CHAINING is enabled,
+ * otherwise falls back to O(n) scan.
  */
 uint32_t cache_invalidate_va(struct cache *cache, uint32_t va, uint32_t satp);
-#endif
+
+#if RV32_HAS(BLOCK_CHAINING)
+/* Page index for O(1) cache invalidation by virtual address.
+ * With page-bounded blocks, each block fits entirely within one 4KB page,
+ * allowing direct lookup by page address instead of O(n) scan.
+ * Requires BLOCK_CHAINING for page-terminated blocks (see emulate.c).
+ */
+#define PAGE_INDEX_BITS 10
+#define PAGE_INDEX_SIZE (1 << PAGE_INDEX_BITS)
+#endif /* RV32_HAS(BLOCK_CHAINING) */
+
+#endif /* RV32_HAS(JIT) && RV32_HAS(SYSTEM) */

--- a/src/cache.h
+++ b/src/cache.h
@@ -68,6 +68,14 @@ void clear_cache_hot(const struct cache *cache, clear_func_t func);
 uint32_t cache_freq(const struct cache *cache, uint32_t key);
 
 #if RV32_HAS(JIT) && RV32_HAS(SYSTEM)
+
+/* Page index for O(1) cache invalidation by virtual address.
+ * With page-bounded blocks, each block fits entirely within one 4KB page,
+ * allowing direct lookup by page address instead of O(n) scan.
+ */
+#define PAGE_INDEX_BITS 10
+#define PAGE_INDEX_SIZE (1 << PAGE_INDEX_BITS)
+
 /**
  * cache_invalidate_satp - invalidate all blocks matching the given SATP
  * @cache: a pointer to target cache
@@ -88,6 +96,7 @@ uint32_t cache_invalidate_satp(struct cache *cache, uint32_t satp);
  *
  * This is used by SFENCE.VMA with rs1!=0 (address-specific flush) to
  * invalidate JIT-compiled blocks in a specific virtual page.
+ * Uses O(1) page-indexed lookup instead of O(n) scan.
  */
 uint32_t cache_invalidate_va(struct cache *cache, uint32_t va, uint32_t satp);
 #endif

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -1504,11 +1504,14 @@ static void match_pattern(riscv_t *rv, block_t *block)
                  * Common pattern for absolute/PC-relative stores.
                  * The lui result is used as base address for sw.
                  * Skip if rd == x0: LUI x0 produces 0, not imm << 12.
+                 * Skip if rd == rs2: JIT uses rd as scratch for address
+                 * calculation, which would overwrite the value to store.
                  *
                  * In SYSTEM mode, JIT uses MMU handler for address translation.
                  */
                 /* LUI + SW fusion (fuse10) */
-                if (ir->rd != rv_reg_zero && ir->rd == next_ir->rs1) {
+                if (ir->rd != rv_reg_zero && ir->rd == next_ir->rs1 &&
+                    ir->rd != next_ir->rs2) {
                     ir->imm2 = next_ir->imm; /* sw offset */
                     ir->rs1 = next_ir->rs2;  /* sw source (data to store) */
                     ir->opcode = rv_insn_fuse10;

--- a/src/jit.c
+++ b/src/jit.c
@@ -801,7 +801,7 @@ static inline void emit_alu64(struct jit_state *state, int op, int src, int dst)
 #endif
 }
 
-#if RV32_HAS(EXT_M) || defined(__aarch64__)
+#if RV32_HAS(EXT_M)
 static inline void emit_alu64_imm8(struct jit_state *state,
                                    int op,
                                    int src UNUSED,
@@ -1590,6 +1590,16 @@ void jit_mmu_handler(riscv_t *rv, uint32_t vreg_idx)
     else
         addr = rv->io.mem_translate(rv, rv->jit_mmu.vaddr, W);
 
+    /* Check for trap during address translation.
+     * mem_translate may trigger a page fault which sets is_trapped=true.
+     * In this case, mark as MMIO to skip direct memory access in JIT code,
+     * but don't actually perform any MMIO operation.
+     */
+    if (rv->is_trapped) {
+        rv->jit_mmu.is_mmio = 1;
+        return;
+    }
+
     /* Only treat as RAM if entire access range [addr, addr+size) is within
      * valid guest memory bounds. This prevents buffer overflow on multi-byte
      * accesses near the memory boundary.
@@ -2326,28 +2336,15 @@ void parse_branch_history_table(struct jit_state *state,
     }
 }
 
-void emit_jit_inc_timer(struct jit_state *state)
-{
-#if defined(__x86_64__)
-    /* Increment rv->timer. *rv pointer is stored in RDI register */
-    /* INC RDI, [rv + offsetof(riscv_t, timer)] */
-    emit_rex(state, 1, 0, 0, 0);
-    emit1(state, 0xff);
-    emit1(state, 0x87);
-    emit4(state, offsetof(riscv_t, timer));
-#elif defined(__aarch64__)
-    emit_load(state, S64, parameter_reg[0], temp_reg, offsetof(riscv_t, timer));
-    emit_alu64_imm8(state, 0, 0, temp_reg, 1);
-    emit_store(state, S64, temp_reg, parameter_reg[0],
-               offsetof(riscv_t, timer));
-#endif
-}
+/* Timer increment removed: timer is now derived from cycle counter at
+ * interrupt check points (rv_check_interrupt) rather than per-instruction.
+ * This eliminates per-instruction memory operations in the JIT hot path.
+ */
 
 #define GEN(inst, code)                                                       \
     static void do_##inst(struct jit_state *state UNUSED, riscv_t *rv UNUSED, \
                           rv_insn_t *ir UNUSED)                               \
     {                                                                         \
-        emit_jit_inc_timer(state);                                            \
         code;                                                                 \
     }
 #include "rv32_jit.c"
@@ -2500,9 +2497,59 @@ static void do_fuse9(struct jit_state *state, riscv_t *rv, rv_insn_t *ir)
 {
     memory_t *m = PRIV(rv)->mem;
     uint32_t addr = (uint32_t) ir->imm + (uint32_t) ir->imm2;
+#if RV32_HAS(SYSTEM_MMIO)
+    /* Store virtual address and type for MMU translation */
+    emit_load_imm(state, temp_reg, addr);
+    emit_store(state, S32, temp_reg, parameter_reg[0],
+               offsetof(riscv_t, jit_mmu.vaddr));
+    emit_load_imm(state, temp_reg, rv_insn_lw);
+    emit_store(state, S32, temp_reg, parameter_reg[0],
+               offsetof(riscv_t, jit_mmu.type));
+
+    store_back(state);
+    emit_jit_mmu_handler(state, ir->rs2);
+    reset_reg();
+
+    /* Check if trap occurred during MMU translation.
+     * If trapped, skip the load entirely to avoid loading garbage.
+     */
+    emit_load(state, S8, parameter_reg[0], temp_reg,
+              offsetof(riscv_t, is_trapped));
+    emit_cmp_imm32(state, temp_reg, 0);
+    uint32_t jump_trap = state->offset;
+    emit_jcc_offset(state, JCC_JNE); /* Jump to end if trapped */
+
+    /* If MMIO, value already in X[rd]; otherwise load from translated paddr */
+    emit_load(state, S8, parameter_reg[0], temp_reg,
+              offsetof(riscv_t, jit_mmu.is_mmio));
+    emit_cmp_imm32(state, temp_reg, 0);
+    vm_reg[0] = map_vm_reg(state, ir->rs2);
+    uint32_t jump_loc_0 = state->offset;
+    emit_jcc_offset(state, JCC_JE);
+
+    /* MMIO path: load from X[rd] */
+    emit_load(state, S32, parameter_reg[0], vm_reg[0],
+              offsetof(riscv_t, X) + 4 * ir->rs2);
+    uint32_t jump_loc_1 = state->offset;
+    emit_jcc_offset(state, JCC_JMP);
+
+    /* RAM path: load from mem_base + paddr */
+    emit_jump_target_offset(state, JUMP_LOC_0, state->offset);
+    emit_load(state, S32, parameter_reg[0], temp_reg,
+              offsetof(riscv_t, jit_mmu.paddr));
+    emit_load_imm_sext(state, vm_reg[0], (intptr_t) m->mem_base);
+    emit_alu64(state, ALU_OP_ADD, temp_reg, vm_reg[0]);
+    vm_reg[1] = map_vm_reg(state, ir->rs2);
+    emit_load(state, S32, vm_reg[0], vm_reg[1], 0);
+    emit_jump_target_offset(state, JUMP_LOC_1, state->offset);
+
+    /* Trap exit point */
+    emit_jump_target_offset(state, jump_trap, state->offset);
+#else
     emit_load_imm_sext(state, temp_reg, (intptr_t) (m->mem_base + addr));
     vm_reg[0] = map_vm_reg(state, ir->rs2);
     emit_load(state, S32, temp_reg, vm_reg[0], 0);
+#endif
 }
 
 /* fused LUI + SW: absolute address store
@@ -2513,9 +2560,50 @@ static void do_fuse10(struct jit_state *state, riscv_t *rv, rv_insn_t *ir)
 {
     memory_t *m = PRIV(rv)->mem;
     uint32_t addr = (uint32_t) ir->imm + (uint32_t) ir->imm2;
+#if RV32_HAS(SYSTEM_MMIO)
+    /* Store virtual address and type for MMU translation */
+    emit_load_imm(state, temp_reg, addr);
+    emit_store(state, S32, temp_reg, parameter_reg[0],
+               offsetof(riscv_t, jit_mmu.vaddr));
+    emit_load_imm(state, temp_reg, rv_insn_sw);
+    emit_store(state, S32, temp_reg, parameter_reg[0],
+               offsetof(riscv_t, jit_mmu.type));
+    store_back(state);
+    emit_jit_mmu_handler(state, ir->rs1);
+    reset_reg();
+
+    /* Check if trap occurred - skip store if trapped */
+    emit_load(state, S8, parameter_reg[0], temp_reg,
+              offsetof(riscv_t, is_trapped));
+    emit_cmp_imm32(state, temp_reg, 0);
+    uint32_t jump_trap = state->offset;
+    emit_jcc_offset(state, JCC_JNE); /* Jump to end if trapped */
+
+    /* If MMIO, skip store (handled by MMU handler) */
+    emit_load(state, S8, parameter_reg[0], temp_reg,
+              offsetof(riscv_t, jit_mmu.is_mmio));
+    emit_cmp_imm32(state, temp_reg, 1);
+    uint32_t jump_loc_0 = state->offset;
+    emit_jcc_offset(state, JCC_JE);
+
+    /* RAM path: store to mem_base + paddr */
+    vm_reg[0] = map_vm_reg(state, rv_reg_zero); /* Allocate scratch for paddr */
+    emit_load(state, S32, parameter_reg[0], vm_reg[0],
+              offsetof(riscv_t, jit_mmu.paddr));
+    emit_load_imm_sext(state, temp_reg, (intptr_t) m->mem_base);
+    emit_alu64(state, ALU_OP_ADD, vm_reg[0], temp_reg);
+    vm_reg[1] = ra_load(state, ir->rs1);
+    emit_store(state, S32, vm_reg[1], temp_reg, 0);
+    emit_jump_target_offset(state, JUMP_LOC_0, state->offset);
+
+    /* Trap exit point */
+    emit_jump_target_offset(state, jump_trap, state->offset);
+    reset_reg();
+#else
     vm_reg[0] = ra_load(state, ir->rs1);
     emit_load_imm_sext(state, temp_reg, (intptr_t) (m->mem_base + addr));
     emit_store(state, S32, vm_reg[0], temp_reg, 0);
+#endif
 }
 
 /* fused LW + ADDI (post-increment load)
@@ -2526,6 +2614,62 @@ static void do_fuse10(struct jit_state *state, riscv_t *rv, rv_insn_t *ir)
 static void do_fuse11(struct jit_state *state, riscv_t *rv, rv_insn_t *ir)
 {
     memory_t *m = PRIV(rv)->mem;
+#if RV32_HAS(SYSTEM_MMIO)
+    /* Compute virtual address: rs1 + imm */
+    vm_reg[0] = ra_load(state, ir->rs1);
+    emit_load_imm_sext(state, temp_reg, ir->imm);
+    emit_alu32(state, ALU_OP_ADD, vm_reg[0], temp_reg);
+    emit_store(state, S32, temp_reg, parameter_reg[0],
+               offsetof(riscv_t, jit_mmu.vaddr));
+    emit_load_imm(state, temp_reg, rv_insn_lw);
+    emit_store(state, S32, temp_reg, parameter_reg[0],
+               offsetof(riscv_t, jit_mmu.type));
+
+    store_back(state);
+    emit_jit_mmu_handler(state, ir->rd);
+    reset_reg();
+
+    /* Check if trap occurred during MMU translation.
+     * If trapped, skip the load and post-increment entirely.
+     * is_trapped is set by jit_mmu_handler when mem_translate faults.
+     */
+    emit_load(state, S8, parameter_reg[0], temp_reg,
+              offsetof(riscv_t, is_trapped));
+    emit_cmp_imm32(state, temp_reg, 0);
+    uint32_t jump_trap = state->offset;
+    emit_jcc_offset(state, JCC_JNE); /* Jump to end if trapped */
+
+    /* If MMIO, value already in X[rd]; otherwise load from translated paddr */
+    emit_load(state, S8, parameter_reg[0], temp_reg,
+              offsetof(riscv_t, jit_mmu.is_mmio));
+    emit_cmp_imm32(state, temp_reg, 0);
+    vm_reg[0] = map_vm_reg(state, ir->rd);
+    uint32_t jump_loc_0 = state->offset;
+    emit_jcc_offset(state, JCC_JE);
+
+    /* MMIO path: load from X[rd] */
+    emit_load(state, S32, parameter_reg[0], vm_reg[0],
+              offsetof(riscv_t, X) + 4 * ir->rd);
+    uint32_t jump_loc_1 = state->offset;
+    emit_jcc_offset(state, JCC_JMP);
+
+    /* RAM path: load from mem_base + paddr */
+    emit_jump_target_offset(state, JUMP_LOC_0, state->offset);
+    emit_load(state, S32, parameter_reg[0], temp_reg,
+              offsetof(riscv_t, jit_mmu.paddr));
+    emit_load_imm_sext(state, vm_reg[0], (intptr_t) m->mem_base);
+    emit_alu64(state, ALU_OP_ADD, temp_reg, vm_reg[0]);
+    vm_reg[1] = map_vm_reg(state, ir->rd);
+    emit_load(state, S32, vm_reg[0], vm_reg[1], 0);
+    emit_jump_target_offset(state, JUMP_LOC_1, state->offset);
+
+    /* Post-increment rs1 by imm2 (only executed if no trap) */
+    vm_reg[0] = map_vm_reg(state, ir->rs1);
+    emit_alu32_imm32(state, 0x81, 0, vm_reg[0], ir->imm2);
+
+    /* Trap exit point - skips load and post-increment */
+    emit_jump_target_offset(state, jump_trap, state->offset);
+#else
     vm_reg[0] = ra_load(state, ir->rs1);
     /* Compute address: mem_base + rs1 + imm */
     emit_load_imm_sext(state, temp_reg, (intptr_t) (m->mem_base + ir->imm));
@@ -2536,6 +2680,7 @@ static void do_fuse11(struct jit_state *state, riscv_t *rv, rv_insn_t *ir)
     /* Increment rs1 by imm2 */
     vm_reg[0] = map_vm_reg(state, ir->rs1);
     emit_alu32_imm32(state, 0x81, 0, vm_reg[0], ir->imm2);
+#endif
 }
 
 /* fused ADDI + BNE (loop counter decrement-branch)
@@ -2622,6 +2767,26 @@ static void translate(struct jit_state *state, riscv_t *rv, block_t *block)
         regs_refresh(idx);
         ((codegen_block_func_t) dispatch_table[ir->opcode])(state, rv, ir);
     }
+
+#if RV32_HAS(BLOCK_CHAINING)
+    /* Page-terminated block fallthrough: emit jump to next block or exit.
+     * Unlike branch-terminated blocks, page-terminated blocks always fall
+     * through to the next sequential address (pc_end).
+     */
+    if (block->page_terminated && !should_flush) {
+        ir = block->ir_tail;
+        store_back(state);
+        if (ir->branch_taken) {
+            /* Fallthrough chain established - jump to next block */
+            emit_jmp(state, block->pc_end, rv->csr_satp);
+        }
+        /* Store PC and exit for un-chained path */
+        emit_load_imm(state, temp_reg, block->pc_end);
+        emit_store(state, S32, temp_reg, parameter_reg[0],
+                   offsetof(riscv_t, PC));
+        emit_exit(state);
+    }
+#endif
 }
 
 static void resolve_jumps(struct jit_state *state)

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -1200,6 +1200,9 @@ void rv_reset(riscv_t *rv, riscv_word_t pc)
     /* reset the csrs */
     rv->csr_mtvec = 0;
     rv->csr_cycle = 0;
+#if RV32_HAS(SYSTEM)
+    rv->timer_offset = 0;
+#endif
     rv->csr_mstatus = 0;
     rv->csr_misa |= MISA_SUPER | MISA_USER;
     rv->csr_mvendorid = RV_MVENDORID;

--- a/src/riscv_private.h
+++ b/src/riscv_private.h
@@ -216,6 +216,7 @@ struct riscv_internal {
         uint32_t type;   /* instruction type for MMIO handler */
         uint32_t vaddr;
         uint32_t paddr;
+        uint32_t pc; /* PC of the instruction (for trap return address) */
     } jit_mmu;
 #endif
     /* user provided data */

--- a/src/rv32_jit.c
+++ b/src/rv32_jit.c
@@ -276,10 +276,10 @@
                 uint32_t jump_normal = state->offset;                         \
                 emit_jcc_offset(state, JCC_JMP);                              \
                 /* Trap exit point - exit JIT block for trap handling */      \
-                emit_jump_target_offset(state, jump_trap, state->offset);     \
+                emit_jump_target_offset(state, JUMP_TRAP, state->offset);     \
                 emit_exit(state);                                             \
                 /* Normal continuation point */                               \
-                emit_jump_target_offset(state, jump_normal, state->offset);   \
+                emit_jump_target_offset(state, JUMP_NORMAL, state->offset);   \
             },                                                                \
             {                                                                 \
                 emit_load_imm_sext(state, temp_reg,                           \
@@ -348,10 +348,10 @@
                 uint32_t jump_normal = state->offset;                         \
                 emit_jcc_offset(state, JCC_JMP);                              \
                 /* Trap exit point - exit JIT block for trap handling */      \
-                emit_jump_target_offset(state, jump_trap, state->offset);     \
+                emit_jump_target_offset(state, JUMP_TRAP, state->offset);     \
                 emit_exit(state);                                             \
                 /* Normal continuation point */                               \
-                emit_jump_target_offset(state, jump_normal, state->offset);   \
+                emit_jump_target_offset(state, JUMP_NORMAL, state->offset);   \
                 reset_reg();                                                  \
             },                                                                \
             {                                                                 \

--- a/src/rv32_jit.c
+++ b/src/rv32_jit.c
@@ -223,52 +223,61 @@
  *   size: memory access size (S8, S16, S32)
  *   load_fn: emit_load or emit_load_sext
  */
-#define GEN_LOAD(inst, insn_type, size, load_fn)                             \
-    GEN(inst, {                                                              \
-        memory_t *m = PRIV(rv)->mem;                                         \
-        vm_reg[0] = ra_load(state, ir->rs1);                                 \
-        IIF(RV32_HAS(SYSTEM_MMIO))(                                          \
-            {                                                                \
-                emit_load_imm_sext(state, temp_reg, ir->imm);                \
-                emit_alu32(state, ALU_OP_ADD, vm_reg[0], temp_reg);          \
-                emit_store(state, S32, temp_reg, parameter_reg[0],           \
-                           offsetof(riscv_t, jit_mmu.vaddr));                \
-                emit_load_imm(state, temp_reg, insn_type);                   \
-                emit_store(state, S32, temp_reg, parameter_reg[0],           \
-                           offsetof(riscv_t, jit_mmu.type));                 \
-                                                                             \
-                store_back(state);                                           \
-                emit_jit_mmu_handler(state, ir->rd);                         \
-                reset_reg();                                                 \
-                                                                             \
-                /* If MMIO, load from X[rd]; otherwise load from memory */   \
-                emit_load(state, S32, parameter_reg[0], temp_reg,            \
-                          offsetof(riscv_t, jit_mmu.is_mmio));               \
-                emit_cmp_imm32(state, temp_reg, 0);                          \
-                vm_reg[1] = map_vm_reg(state, ir->rd);                       \
-                uint32_t jump_loc_0 = state->offset;                         \
-                emit_jcc_offset(state, JCC_JE);                              \
-                                                                             \
-                emit_load(state, S32, parameter_reg[0], vm_reg[1],           \
-                          offsetof(riscv_t, X) + 4 * ir->rd);                \
-                uint64_t jump_loc_1 = state->offset;                         \
-                emit_jcc_offset(state, JCC_JMP);                             \
-                                                                             \
-                emit_jump_target_offset(state, JUMP_LOC_0, state->offset);   \
-                emit_load(state, S32, parameter_reg[0], vm_reg[0],           \
-                          offsetof(riscv_t, jit_mmu.paddr));                 \
-                emit_load_imm_sext(state, temp_reg, (intptr_t) m->mem_base); \
-                emit_alu64(state, ALU_OP_ADD, vm_reg[0], temp_reg);          \
-                load_fn(state, size, temp_reg, vm_reg[1], 0);                \
-                emit_jump_target_offset(state, JUMP_LOC_1, state->offset);   \
-            },                                                               \
-            {                                                                \
-                emit_load_imm_sext(state, temp_reg,                          \
-                                   (intptr_t) (m->mem_base + ir->imm));      \
-                emit_alu64(state, ALU_OP_ADD, vm_reg[0], temp_reg);          \
-                vm_reg[1] = map_vm_reg(state, ir->rd);                       \
-                load_fn(state, size, temp_reg, vm_reg[1], 0);                \
-            })                                                               \
+#define GEN_LOAD(inst, insn_type, size, load_fn)                              \
+    GEN(inst, {                                                               \
+        memory_t *m = PRIV(rv)->mem;                                          \
+        vm_reg[0] = ra_load(state, ir->rs1);                                  \
+        IIF(RV32_HAS(SYSTEM_MMIO))(                                           \
+            {                                                                 \
+                emit_load_imm_sext(state, temp_reg, ir->imm);                 \
+                emit_alu32(state, ALU_OP_ADD, vm_reg[0], temp_reg);           \
+                emit_store(state, S32, temp_reg, parameter_reg[0],            \
+                           offsetof(riscv_t, jit_mmu.vaddr));                 \
+                emit_load_imm(state, temp_reg, insn_type);                    \
+                emit_store(state, S32, temp_reg, parameter_reg[0],            \
+                           offsetof(riscv_t, jit_mmu.type));                  \
+                                                                              \
+                store_back(state);                                            \
+                emit_jit_mmu_handler(state, ir->rd);                          \
+                reset_reg();                                                  \
+                                                                              \
+                /* Check if trap occurred - skip load if trapped */           \
+                emit_load(state, S8, parameter_reg[0], temp_reg,              \
+                          offsetof(riscv_t, is_trapped));                     \
+                emit_cmp_imm32(state, temp_reg, 0);                           \
+                uint32_t jump_trap = state->offset;                           \
+                emit_jcc_offset(state, JCC_JNE);                              \
+                                                                              \
+                /* If MMIO, load from X[rd]; otherwise load from memory */    \
+                emit_load(state, S8, parameter_reg[0], temp_reg,              \
+                          offsetof(riscv_t, jit_mmu.is_mmio));                \
+                emit_cmp_imm32(state, temp_reg, 0);                           \
+                vm_reg[1] = map_vm_reg(state, ir->rd);                        \
+                uint32_t jump_loc_0 = state->offset;                          \
+                emit_jcc_offset(state, JCC_JE);                               \
+                                                                              \
+                emit_load(state, S32, parameter_reg[0], vm_reg[1],            \
+                          offsetof(riscv_t, X) + 4 * ir->rd);                 \
+                uint32_t jump_loc_1 = state->offset;                          \
+                emit_jcc_offset(state, JCC_JMP);                              \
+                                                                              \
+                emit_jump_target_offset(state, JUMP_LOC_0, state->offset);    \
+                emit_load(state, S32, parameter_reg[0], temp_reg,             \
+                          offsetof(riscv_t, jit_mmu.paddr));                  \
+                emit_load_imm_sext(state, vm_reg[1], (intptr_t) m->mem_base); \
+                emit_alu64(state, ALU_OP_ADD, temp_reg, vm_reg[1]);           \
+                load_fn(state, size, vm_reg[1], vm_reg[1], 0);                \
+                emit_jump_target_offset(state, JUMP_LOC_1, state->offset);    \
+                /* Trap exit point */                                         \
+                emit_jump_target_offset(state, jump_trap, state->offset);     \
+            },                                                                \
+            {                                                                 \
+                emit_load_imm_sext(state, temp_reg,                           \
+                                   (intptr_t) (m->mem_base + ir->imm));       \
+                emit_alu64(state, ALU_OP_ADD, vm_reg[0], temp_reg);           \
+                vm_reg[1] = map_vm_reg(state, ir->rd);                        \
+                load_fn(state, size, temp_reg, vm_reg[1], 0);                 \
+            })                                                                \
     })
 
 /* Store instruction handler macro - handles MMIO path when SYSTEM_MMIO enabled.
@@ -277,46 +286,56 @@
  *   insn_type: rv_insn_* constant for MMIO handler
  *   size: memory access size (S8, S16, S32)
  */
-#define GEN_STORE(inst, insn_type, size)                                     \
-    GEN(inst, {                                                              \
-        memory_t *m = PRIV(rv)->mem;                                         \
-        vm_reg[0] = ra_load(state, ir->rs1);                                 \
-        IIF(RV32_HAS(SYSTEM_MMIO))(                                          \
-            {                                                                \
-                emit_load_imm_sext(state, temp_reg, ir->imm);                \
-                emit_alu32(state, ALU_OP_ADD, vm_reg[0], temp_reg);          \
-                emit_store(state, S32, temp_reg, parameter_reg[0],           \
-                           offsetof(riscv_t, jit_mmu.vaddr));                \
-                emit_load_imm(state, temp_reg, insn_type);                   \
-                emit_store(state, S32, temp_reg, parameter_reg[0],           \
-                           offsetof(riscv_t, jit_mmu.type));                 \
-                store_back(state);                                           \
-                emit_jit_mmu_handler(state, ir->rs2);                        \
-                reset_reg();                                                 \
-                                                                             \
-                /* If MMIO, skip store (handled by MMIO handler) */          \
-                emit_load(state, S32, parameter_reg[0], temp_reg,            \
-                          offsetof(riscv_t, jit_mmu.is_mmio));               \
-                emit_cmp_imm32(state, temp_reg, 1);                          \
-                uint32_t jump_loc_0 = state->offset;                         \
-                emit_jcc_offset(state, JCC_JE);                              \
-                                                                             \
-                emit_load(state, S32, parameter_reg[0], vm_reg[0],           \
-                          offsetof(riscv_t, jit_mmu.paddr));                 \
-                emit_load_imm_sext(state, temp_reg, (intptr_t) m->mem_base); \
-                emit_alu64(state, ALU_OP_ADD, vm_reg[0], temp_reg);          \
-                vm_reg[1] = ra_load(state, ir->rs2);                         \
-                emit_store(state, size, vm_reg[1], temp_reg, 0);             \
-                emit_jump_target_offset(state, JUMP_LOC_0, state->offset);   \
-                reset_reg();                                                 \
-            },                                                               \
-            {                                                                \
-                emit_load_imm_sext(state, temp_reg,                          \
-                                   (intptr_t) (m->mem_base + ir->imm));      \
-                emit_alu64(state, ALU_OP_ADD, vm_reg[0], temp_reg);          \
-                vm_reg[1] = ra_load(state, ir->rs2);                         \
-                emit_store(state, size, vm_reg[1], temp_reg, 0);             \
-            })                                                               \
+#define GEN_STORE(inst, insn_type, size)                                      \
+    GEN(inst, {                                                               \
+        memory_t *m = PRIV(rv)->mem;                                          \
+        vm_reg[0] = ra_load(state, ir->rs1);                                  \
+        IIF(RV32_HAS(SYSTEM_MMIO))(                                           \
+            {                                                                 \
+                emit_load_imm_sext(state, temp_reg, ir->imm);                 \
+                emit_alu32(state, ALU_OP_ADD, vm_reg[0], temp_reg);           \
+                emit_store(state, S32, temp_reg, parameter_reg[0],            \
+                           offsetof(riscv_t, jit_mmu.vaddr));                 \
+                emit_load_imm(state, temp_reg, insn_type);                    \
+                emit_store(state, S32, temp_reg, parameter_reg[0],            \
+                           offsetof(riscv_t, jit_mmu.type));                  \
+                store_back(state);                                            \
+                emit_jit_mmu_handler(state, ir->rs2);                         \
+                reset_reg();                                                  \
+                                                                              \
+                /* Check if trap occurred - skip store if trapped */          \
+                emit_load(state, S8, parameter_reg[0], temp_reg,              \
+                          offsetof(riscv_t, is_trapped));                     \
+                emit_cmp_imm32(state, temp_reg, 0);                           \
+                uint32_t jump_trap = state->offset;                           \
+                emit_jcc_offset(state, JCC_JNE);                              \
+                                                                              \
+                /* If MMIO, skip store (handled by MMIO handler) */           \
+                emit_load(state, S8, parameter_reg[0], temp_reg,              \
+                          offsetof(riscv_t, jit_mmu.is_mmio));                \
+                emit_cmp_imm32(state, temp_reg, 1);                           \
+                uint32_t jump_loc_0 = state->offset;                          \
+                emit_jcc_offset(state, JCC_JE);                               \
+                                                                              \
+                emit_load(state, S32, parameter_reg[0], temp_reg,             \
+                          offsetof(riscv_t, jit_mmu.paddr));                  \
+                vm_reg[0] = map_vm_reg(state, rv_reg_zero);                   \
+                emit_load_imm_sext(state, vm_reg[0], (intptr_t) m->mem_base); \
+                emit_alu64(state, ALU_OP_ADD, temp_reg, vm_reg[0]);           \
+                vm_reg[1] = ra_load(state, ir->rs2);                          \
+                emit_store(state, size, vm_reg[1], vm_reg[0], 0);             \
+                emit_jump_target_offset(state, JUMP_LOC_0, state->offset);    \
+                /* Trap exit point */                                         \
+                emit_jump_target_offset(state, jump_trap, state->offset);     \
+                reset_reg();                                                  \
+            },                                                                \
+            {                                                                 \
+                emit_load_imm_sext(state, temp_reg,                           \
+                                   (intptr_t) (m->mem_base + ir->imm));       \
+                emit_alu64(state, ALU_OP_ADD, vm_reg[0], temp_reg);           \
+                vm_reg[1] = ra_load(state, ir->rs2);                          \
+                emit_store(state, size, vm_reg[1], temp_reg, 0);              \
+            })                                                                \
     })
 
 GEN(nop, {})


### PR DESCRIPTION
This introduces three optimizations:
1. Block-level cycle counting
   - Remove per-instruction cycle++ from RVOP macro
   - Pre-compute block->cycle_cost at translation time
   - Add cycle cost at block entry (interpreter) or exit (JIT)
   - Maintains accurate cycle counts with less overhead
2. Timer derivation from cycle counter
   - Remove per-instruction rv->timer++ in SYSTEM mode
   - Derive timer on-demand: timer = csr_cycle + timer_offset
   - Compute timer only at interrupt check points (rv_check_interrupt)
   - Extend CSR sync to TIME/TIMEH registers for correct derivation
3. Page-boundary block termination with fallthrough chaining
   - Terminate blocks at 4KB page boundaries
   - Add page_terminated flag to block_t structure
   - Implement fallthrough chaining for non-branch block endings
   - Use branch_taken pointer for fallthrough to next block
   - Enables future O(1) cache invalidation via page index

The combination maintains correctness while reducing per-instruction overhead. Block chaining still works across page-bounded blocks through the fallthrough mechanism.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces hot-path overhead by deriving TIME from CYCLE, page-bounding blocks with fallthrough chaining, and using block-level cycle counting in JIT. Improves performance and enables O(1) cache invalidation per virtual page.

- **New Features**
  - Block-level cycle counting (JIT): precompute cycle_cost; add at JIT exit; interpreter keeps per-instruction cycle++ to support chaining.
  - TIME derived from CYCLE: timer = csr_cycle + timer_offset; computed at interrupt checks; CSR sync extended to TIME/TIMEH.
  - Page-bounded blocks with fallthrough chaining and a page index for O(1) SFENCE.VMA invalidate (guarded by BLOCK_CHAINING; O(n) fallback when disabled or index incomplete).

- **Bug Fixes**
  - Correct JIT trap handling and x86-64 jump patching: set rv->PC before translation, record faulting PC, exit JIT blocks on trap, handle traps after JIT, and skip RAM/MMIO ops when a fault occurs.
  - Validate full access range before treating as RAM to prevent boundary overflows.
  - Fix JIT register allocation in GEN_LOAD/GEN_STORE; mark ALU outputs dirty and don’t save x0.
  - Fix fused LUI+LW/SW and LW+ADDI paths to write LUI before memory ops and exit JIT blocks on traps.

<sup>Written for commit 0f261dcb5a0b17a21d87fd7d9cf4b2556854863e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

