### PR TITLE
Enable T2C-based system emulation with thread-safe jit_cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -287,8 +287,8 @@ jobs:
     - name: undefined behavior test
       if: success() || failure()
       run: |
-            make cleanconfig && make defconfig && make ENABLE_UBSAN=1 check $PARALLEL
-            make cleanconfig && make jit_defconfig && make ENABLE_UBSAN=1 check $PARALLEL
+            make distclean && make defconfig && make ENABLE_UBSAN=1 check $PARALLEL
+            make distclean && make jit_defconfig && make ENABLE_UBSAN=1 check $PARALLEL
 
     - name: boot Linux kernel test
       if: success()
@@ -309,6 +309,20 @@ jobs:
             bash -c "${BOOT_LINUX_TEST}"
             make clean
 
+    - name: boot Linux kernel test (T2C)
+      if: success()
+      env:
+        CC: ${{ steps.install_cc.outputs.cc }}
+        BOOT_TIMEOUT: 150  # T2C LLVM compilation adds significant overhead
+      run: |
+            # Remove stale t2c.o before build to ensure fresh detection
+            rm -f build/t2c.o
+            make distclean && make system_jit_defconfig && make INITRD_SIZE=32 ENABLE_MOP_FUSION=0 $PARALLEL && make artifact $PARALLEL
+            # Verify T2C is actually compiled (build/t2c.o only exists when LLVM 18 detection succeeds)
+            test -f build/t2c.o || { echo "ERROR: T2C disabled (build/t2c.o missing) - LLVM 18 detection failed"; exit 1; }
+            bash -c "${BOOT_LINUX_TEST}"
+            make clean
+
     - name: Architecture test
       if: success()
       env:
@@ -322,7 +336,7 @@ jobs:
   host-arm64:
     needs: [detect-code-related-file-changes]
     if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
-    timeout-minutes: 30
+    timeout-minutes: 45
     runs-on: ubuntu-24.04-arm
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -352,7 +366,7 @@ jobs:
             }
             # Install packages with retry for critical ones
             sudo apt-get install -q=2 -y make curl wget libsdl2-dev libsdl2-mixer-dev \
-                 lsb-release software-properties-common gnupg bc || {
+                 lsb-release software-properties-common gnupg bc device-tree-compiler expect p7zip-full e2fsprogs || {
               echo "WARNING: Some packages failed, retrying critical ones..."
               sudo apt-get install -q=2 -y --no-download make curl wget || true
             }
@@ -367,7 +381,16 @@ jobs:
       run: echo "/usr/lib/llvm-${LLVM_VERSION}/bin" >> $GITHUB_PATH
 
     - name: Set parallel jobs variable
-      run: echo "PARALLEL=-j$(nproc)" >> "$GITHUB_ENV"
+      run: |
+            echo "PARALLEL=-j$(nproc)" >> "$GITHUB_ENV"
+            echo "BOOT_LINUX_TEST=TMP_FILE=\$(mktemp \"$RUNNER_TEMP/tmpfile.XXXXXX\"); \
+                                  sudo env TMP_FILE=\${TMP_FILE} .ci/boot-linux-prepare.sh setup; \
+                                  . \${TMP_FILE}; \
+                                  .ci/boot-linux.sh; \
+                                  EXIT_CODE=\$?; \
+                                  sudo env TMP_FILE=\${TMP_FILE} BLK_DEV_EXT4=\${BLK_DEV_EXT4} \
+                                           BLK_DEV_SIMPLEFS=\${BLK_DEV_SIMPLEFS} .ci/boot-linux-prepare.sh cleanup; \
+                                  exit \${EXIT_CODE};" >> "$GITHUB_ENV"
 
     - name: Fetch artifacts
       env:
@@ -375,6 +398,8 @@ jobs:
       run: |
             . .ci/common.sh
             fetch_artifact ELF
+            fetch_artifact Linux-Image ENABLE_SYSTEM=1
+            rm -f build/.config  # Clean config after ENABLE_SYSTEM=1 to prevent contamination
 
     # FIXME: gcc build fails on AArch64/Linux hosts
     - name: check + tests
@@ -395,6 +420,20 @@ jobs:
               echo "JIT test with ${ext}=0"
               make ENABLE_JIT=1 clean && make ${ext}=0 ENABLE_JIT=1 check $PARALLEL
             done
+
+    - name: boot Linux kernel test (T2C)
+      if: success()
+      env:
+        CC: clang-${{ env.LLVM_VERSION }}
+        BOOT_TIMEOUT: 150  # T2C LLVM compilation adds significant overhead
+      run: |
+            # Remove stale t2c.o before build to ensure fresh detection
+            rm -f build/t2c.o
+            make distclean && make system_jit_defconfig && make INITRD_SIZE=32 ENABLE_MOP_FUSION=0 $PARALLEL && make artifact $PARALLEL
+            # Verify T2C is actually compiled (build/t2c.o only exists when LLVM 18 detection succeeds)
+            test -f build/t2c.o || { echo "ERROR: T2C disabled (build/t2c.o missing) - LLVM 18 detection failed"; exit 1; }
+            bash -c "${BOOT_LINUX_TEST}"
+            make clean
 
   macOS-arm64:
     needs: [detect-code-related-file-changes]
@@ -561,8 +600,8 @@ jobs:
        env:
          CC: ${{ steps.install_cc.outputs.cc }}
        run: |
-             make cleanconfig && make defconfig && make ENABLE_UBSAN=1 check $PARALLEL
-             make cleanconfig && make jit_defconfig && make ENABLE_UBSAN=1 check $PARALLEL
+             make distclean && make defconfig && make ENABLE_UBSAN=1 check $PARALLEL
+             make distclean && make jit_defconfig && make ENABLE_UBSAN=1 check $PARALLEL
 
      - name: boot Linux kernel test
        if: success()

--- a/configs/Kconfig
+++ b/configs/Kconfig
@@ -248,9 +248,10 @@ config SYSTEM
 config GOLDFISH_RTC
     bool "Enable Goldfish RTC"
     default y
-    depends on SYSTEM
+    depends on SYSTEM && !ELF_LOADER
     help
       Enable Goldfish RTC peripheral when running the Linux system.
+      Only available in kernel boot mode (without ELF_LOADER).
 
 config ELF_LOADER
     bool "ELF Loader for System Mode"
@@ -258,7 +259,13 @@ config ELF_LOADER
     depends on SYSTEM
     help
       Use ELF loader in system mode instead of raw kernel image.
-      Required for running ELF executables in system mode tests.
+
+      This option changes the emulator's operating mode:
+      - Without ELF_LOADER: Kernel boot mode (-k/-i flags for kernel/initrd)
+      - With ELF_LOADER: User-mode ELF execution (runs ELF files directly)
+
+      Enable this for running 'make check' tests in system mode.
+      Disable this for booting Linux kernel images.
 
 endmenu
 

--- a/configs/system_jit_defconfig
+++ b/configs/system_jit_defconfig
@@ -1,0 +1,6 @@
+# System emulation with tiered JIT compilation
+# Enables T2C (LLVM-based tier-2 JIT) for system mode
+CONFIG_SYSTEM=y
+CONFIG_GOLDFISH_RTC=y
+CONFIG_JIT=y
+CONFIG_T2C=y

--- a/src/common.h
+++ b/src/common.h
@@ -207,6 +207,23 @@ static inline uint8_t ilog2(uint32_t x)
 #define PRESERVE_NONE
 #endif
 
+/* Disable UBSAN function pointer type checking.
+ * When LLVM-compiled code (T2C) is called via function pointers from
+ * non-LLVM code, UBSAN can emit false positives due to function type
+ * metadata mismatches. This attribute suppresses those checks.
+ *
+ * Note: GCC supports no_sanitize for some sanitizers but NOT for "function".
+ * Using __has_attribute(no_sanitize) would return true on GCC but applying
+ * no_sanitize("function") causes a warning/error. Therefore, we explicitly
+ * check for __clang__ only, which is the compiler that supports this variant.
+ */
+#if defined(__clang__) && defined(__has_attribute) && \
+    __has_attribute(no_sanitize)
+#define DISABLE_UBSAN_FUNC __attribute__((no_sanitize("function")))
+#else
+#define DISABLE_UBSAN_FUNC
+#endif
+
 /* Assume that all POSIX-compatible environments provide mmap system call.
  * Emscripten is excluded because it lacks signal-based demand paging support
  * and C11 atomics require special compilation flags not enabled by default.

--- a/src/decode.c
+++ b/src/decode.c
@@ -997,6 +997,7 @@ static inline bool op_system(rv_insn_t *ir, const uint32_t insn)
     /* decode I-type */
     decode_itype(ir, insn);
 
+
     /* dispatch from funct3 field */
     switch (decode_funct3(insn)) {
     case 0:

--- a/src/jit.c
+++ b/src/jit.c
@@ -1596,12 +1596,11 @@ void jit_mmu_handler(riscv_t *rv, uint32_t vreg_idx)
         __UNREACHABLE;
     }
 
-    /* CRITICAL: Set rv->PC to the faulting instruction's PC BEFORE calling
-     * mem_translate. This is necessary because if a page fault occurs,
-     * on_trap is called from inside mem_translate (via
-     * SET_CAUSE_AND_TVAL_THEN_TRAP) and the trap handler uses rv->PC to set
-     * sepc/mepc (the return address). Without this, the kernel would resume at
-     * the wrong instruction after sret.
+    /* Set rv->PC to the faulting instruction's PC BEFORE calling mem_translate.
+     * This is necessary because if a page fault occurs, on_trap is called from
+     * inside mem_translate (via SET_CAUSE_AND_TVAL_THEN_TRAP) and the trap
+     * handler uses rv->PC to set sepc/mepc (the return address). Without this,
+     * the kernel would resume at the wrong instruction after sret.
      */
     rv->PC = rv->jit_mmu.pc;
 

--- a/src/main.c
+++ b/src/main.c
@@ -297,6 +297,9 @@ int main(int argc, char **args)
         .profile_output_file = prof_out_file,
         .cycle_per_step = CYCLE_PER_STEP,
         .allow_misalign = opt_misaligned,
+        .fd_stdin = STDIN_FILENO,
+        .fd_stdout = STDOUT_FILENO,
+        .fd_stderr = STDERR_FILENO,
     };
 #if RV32_HAS(SYSTEM_MMIO)
     attr.data.system.kernel = opt_kernel_img;

--- a/src/riscv.h
+++ b/src/riscv.h
@@ -329,6 +329,23 @@ typedef void (*riscv_mem_write_b)(riscv_t *rv,
 typedef riscv_word_t (*riscv_mem_translate_t)(riscv_t *rv,
                                               riscv_word_t vaddr,
                                               bool rw);
+
+/* MMU memory access function pointers for T2C runtime binding.
+ * These avoid embedding compile-time function addresses in JIT code,
+ * which would break with ASLR on x86-64 Linux.
+ */
+typedef riscv_word_t (*riscv_mmu_read_w_t)(riscv_t *rv, riscv_word_t vaddr);
+typedef riscv_half_t (*riscv_mmu_read_s_t)(riscv_t *rv, riscv_word_t vaddr);
+typedef riscv_byte_t (*riscv_mmu_read_b_t)(riscv_t *rv, riscv_word_t vaddr);
+typedef void (*riscv_mmu_write_w_t)(riscv_t *rv,
+                                    riscv_word_t vaddr,
+                                    riscv_word_t val);
+typedef void (*riscv_mmu_write_s_t)(riscv_t *rv,
+                                    riscv_word_t vaddr,
+                                    riscv_half_t val);
+typedef void (*riscv_mmu_write_b_t)(riscv_t *rv,
+                                    riscv_word_t vaddr,
+                                    riscv_byte_t val);
 #endif
 
 /* system instruction handlers */
@@ -352,6 +369,14 @@ typedef struct {
 
 #if RV32_HAS(SYSTEM)
     riscv_mem_translate_t mem_translate;
+
+    /* MMU memory access functions for T2C runtime binding */
+    riscv_mmu_read_w_t mmu_read_w;
+    riscv_mmu_read_s_t mmu_read_s;
+    riscv_mmu_read_b_t mmu_read_b;
+    riscv_mmu_write_w_t mmu_write_w;
+    riscv_mmu_write_s_t mmu_write_s;
+    riscv_mmu_write_b_t mmu_write_b;
 #endif
 
     /* system */

--- a/src/riscv_private.h
+++ b/src/riscv_private.h
@@ -131,11 +131,16 @@ typedef struct block {
                        */
 #endif
 #if RV32_HAS(T2C)
-    bool compiled; /**< The T2C request is enqueued or not */
+    bool compiled;     /**< The T2C request is enqueued or not */
+    bool is_compiling; /**< T2C thread is currently processing this block */
+    bool should_free;  /**< Block was evicted while compiling, freed by T2C */
 #endif
     uint32_t offset;   /**< The machine code offset in T1 code cache */
     uint32_t n_invoke; /**< The invoking times of T1 machine code */
     void *func;        /**< The function pointer of T2 machine code */
+#if RV32_HAS(T2C)
+    void *llvm_engine; /**< LLVM execution engine (keeps func memory alive) */
+#endif
     struct list_head list;
 #endif
 } block_t;

--- a/src/system.c
+++ b/src/system.c
@@ -591,6 +591,14 @@ riscv_io_t mmu_io = {
     /* VA2PA handler */
     .mem_translate = mmu_translate,
 
+    /* MMU memory access functions for T2C runtime binding */
+    .mmu_read_w = mmu_read_w,
+    .mmu_read_s = mmu_read_s,
+    .mmu_read_b = mmu_read_b,
+    .mmu_write_w = mmu_write_w,
+    .mmu_write_s = mmu_write_s,
+    .mmu_write_b = mmu_write_b,
+
     /* system services or essential routines */
     .on_ecall = ecall_handler,
     .on_ebreak = ebreak_handler,


### PR DESCRIPTION
This implements seqlock pattern for lock-free jit_cache reads in T2C:
- Add seq field to jit_cache struct (odd=writing, even=stable)
- Writer: RELEASE stores on seq bracket RELAXED entry/key writes
- Reader (LLVM): ACQUIRE seq1 -> MONOTONIC data -> ACQ_REL fence -> seq2

SFENCE.VMA synchronization with T2C compilation thread:
- Hold cache_lock during block invalidation to prevent races
- Reset hot2 atomically when invalidating blocks
- Check block->invalidated after T2C compilation to discard stale code
- Add jit_cache_clear_page() for selective VA-based invalidation

CI changes:
- Add system_jit_defconfig (SYSTEM + JIT + T2C)
- Add T2C boot tests for host-x64 and host-arm64

Final Lock Flow Diagram:
```
  Main Thread (eviction)          T2C Thread (compilation)
  ─────────────────────           ────────────────────────
                                  lock(cache_lock)
                                  is_compiling = true
                                  unlock(cache_lock)
                                    │
  lock(cache_lock)                  │ LLVM compilation
  if is_compiling:                  │ (10-50ms)
    should_free = true              │
    clear jit_cache                 │
    remove from list                │
  unlock(cache_lock)                │
  return                            │
                                    ▼
                                  lock(cache_lock)
                                  is_compiling = false
                                  if should_free:
                                    free IRs
                                    free block
                                    dispose engine
                                  unlock(cache_lock)
                                  return
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables T2C system emulation with a seqlock-based jit_cache and safe LLVM engine lifetime, fixing SFENCE.VMA/FENCE.I coherency and ARM64 ordering issues. Adds CI to boot T2C on x64 and arm64.

- **New Features**
  - Seqlock-based jit_cache for lock-free T2C lookups (seq field, consistent key/entry reads).
  - SATP^PC-based jit_cache indexing to reduce collisions in system mode.
  - jit_cache_clear_page for targeted VA invalidation.
  - Batch cycle counter updates in T2C blocks to reduce memory traffic.
  - system_jit_defconfig and T2C boot tests in CI for host-x64 and host-arm64; verify T2C build (t2c.o) and increase boot timeout.

- **Bug Fixes**
  - Prevent SFENCE.VMA races by holding cache_lock during invalidation and atomically resetting hot2.
  - Honor FENCE.I by invalidating JIT for current SATP and clearing jit_cache.
  - Discard compiled code if the block was invalidated during T2C compilation.
  - Manage LLVM engine lifetime to prevent use-after-free; clear jit_cache entries on eviction; dispose engines on block eviction and shutdown.
  - Architecture fixes: acquire fences, ISB on ARM64 call chains, load entry as a pointer, and runtime-binding of MMU functions to avoid ASLR issues.
  - Correct VA-based invalidation for blocks spanning multiple pages.
  - System-mode boot stability: handle unset trap vectors by restoring PC and continuing; increase T2C thread stack to 8MB.
  - Fix UBSAN config contamination in CI by using distclean between builds.
  - Avoid UBSAN function-type false positives by disabling the function sanitizer on cleanup calls.

<sup>Written for commit c71701eee8a13001bdc47705cc1813f821d8a3fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

