### PR TITLE
Fix make format to show error message

### DIFF
--- a/mk/tools.mk
+++ b/mk/tools.mk
@@ -48,10 +48,10 @@ build-linux-image: $(LINUX_IMAGE_SRC)
 # Code Formatting (tool detection deferred to recipe)
 # Uses find -print0 | xargs -0 for safe handling of paths with special characters
 format:
-	$(Q)CLANG_FORMAT=$$(which clang-format-20 2>/dev/null) && \
-	SHFMT=$$(which shfmt 2>/dev/null) && \
-	DTSFMT=$$(which dtsfmt 2>/dev/null) && \
-	BLACK=$$(which black 2>/dev/null) && \
+	$(Q)CLANG_FORMAT=$$(which clang-format-20 2>/dev/null); \
+	SHFMT=$$(which shfmt 2>/dev/null); \
+	DTSFMT=$$(which dtsfmt 2>/dev/null); \
+	BLACK=$$(which black 2>/dev/null); \
 	if [ -z "$$CLANG_FORMAT" ]; then echo "clang-format-20 not found."; exit 1; fi && \
 	if [ -z "$$SHFMT" ]; then echo "shfmt not found."; exit 1; fi && \
 	if [ -z "$$DTSFMT" ]; then echo "dtsfmt not found."; exit 1; fi && \
@@ -69,4 +69,3 @@ format:
 .PHONY: build-linux-image format
 
 endif # _MK_TOOLS_INCLUDED
-


### PR DESCRIPTION
TL:DR

The error msg does not show w/o patch (for example no black installed): make: *** [mk/tools.mk:51: format] Error 1

w/ patch, the error msg is shown:
black not found.
make: *** [mk/tools.mk:51: format] Error 1

The root cause is that when some tools are not installed, the $() shell will return non-zero exit code which causes the && condition bail out early before echo the error msg. Thus, replace && with ; to not bail out too early.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the make format target so it prints clear “<tool> not found.” messages when required tools are missing. Replaces the &&-chained tool detection with separate commands, preventing early exit when which returns non-zero.

<sup>Written for commit c2d2ef9c34fb8a389d8ea1cec57edd01b14a0a1c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

