### PR TITLE
CI: Fix Linux images rebuild logic

### DIFF
--- a/.github/workflows/build-linux-artifacts.yml
+++ b/.github/workflows/build-linux-artifacts.yml
@@ -23,18 +23,24 @@ jobs:
         uses: tj-actions/changed-files@v47
         with:
           files: |
+            assets/system/configs/*
+            tools/build-linux-image.sh
             mk/external.mk
-            # Build system configuration
-            mk/kconfig.mk
-            mk/toolchain.mk
-            tools/detect-env.py
             tests/system/br_pkgs/rtc/*.c
       - name: Set alias
         id: has_changed_files
         run: |
           if [[ ${{ steps.test-linux-image-version-change.outputs.any_modified }} == true ]]; then
-            # Determine if the changes are from Buildroot or the Linux version (The Linux might have several patches, so also need to check the SHA value)
-            echo -n $(git --no-pager diff HEAD^ HEAD | grep -e "+BUILDROOT_VERSION" -e "+LINUX_VERSION" -e "+LINUX_PATCHLEVEL") >> linux-image-version-change
+            # Determine if the changes are from the Buildroot patching or the Buildroot or the Linux version
+            # Others file changes need to trigger the rebuilt via workflow_dispatch event
+            echo -n $(git --no-pager diff HEAD^ HEAD | grep \
+                        -e "assets/system/configs/" \
+                        -e "tools/build-linux-image.sh" \
+                        -e "tests/system/br_pkgs/rtc/" \
+                        -e "+BUILDROOT_VERSION" \
+                        -e "+LINUX_VERSION" \
+                        -e "+LINUX_PATCHLEVEL" \
+                     ) >> linux-image-version-change
             if [[ -s linux-image-version-change ]]; then
                 echo "has_changed_linux_image_version=true" >> $GITHUB_OUTPUT
             else


### PR DESCRIPTION
By monitoring the files is not enough to trigger rebuilding the Linux image because a filter is applied to ignore the non-relevent changes in the monitored files.

Thus, this commit updates the filter by detecting the Buildroot patching packages, system configs, Linux images build script, Buildroot version and Linux version and patchlevel.

Also, disable monitoring the non-relevent files:
- mk/kconfig.mk
- mk/toolchain.mk
- tools/detect-env.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI rebuild triggers for Linux images to only run on relevant changes and avoid missed or unnecessary builds. Adds detection for system configs, build script, and Buildroot/Linux version updates.

- **Bug Fixes**
  - Watch assets/system/configs/*, tools/build-linux-image.sh, mk/external.mk, and tests/system/br_pkgs/rtc/*.c.
  - Detect changes to BUILDROOT_VERSION, LINUX_VERSION, and LINUX_PATCHLEVEL in the diff.
  - Stop monitoring mk/kconfig.mk, mk/toolchain.mk, and tools/detect-env.py.
  - Non-relevant changes no longer auto-trigger; use workflow_dispatch if needed.

<sup>Written for commit 13f233598af44deca30ac466014ab92c2d978806. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

