### PR TITLE
Add inline caching for T2C indirect jump

### DIFF
--- a/src/emulate.c
+++ b/src/emulate.c
@@ -1944,15 +1944,16 @@ static block_t *block_find_or_translate(riscv_t *rv)
         /* Clear jit_cache to prevent new executions, but don't dispose engine
          * or free memory yet. T2C thread owns the engine and block memory.
          */
-        if (replaced_blk->func) {
 #if RV32_HAS(SYSTEM)
-            uint64_t key = (uint64_t) replaced_blk->pc_start |
-                           ((uint64_t) replaced_blk->satp << 32);
+        uint64_t key = (uint64_t) replaced_blk->pc_start |
+                       ((uint64_t) replaced_blk->satp << 32);
 #else
-            uint64_t key = (uint64_t) replaced_blk->pc_start;
+        uint64_t key = (uint64_t) replaced_blk->pc_start;
 #endif
+        if (replaced_blk->func) {
             jit_cache_update(rv->jit_cache, key, NULL);
         }
+        inline_cache_clear_key(rv->inline_cache, key);
 
         /* Remove from global block list so it's not found/traversed */
         list_del_init(&replaced_blk->list);
@@ -1978,15 +1979,16 @@ static block_t *block_find_or_translate(riscv_t *rv)
      * function pointers. The jit_cache key includes SATP for system mode.
      * cache_lock is already held by caller.
      */
-    if (replaced_blk->func) {
 #if RV32_HAS(SYSTEM)
-        uint64_t key = (uint64_t) replaced_blk->pc_start |
-                       ((uint64_t) replaced_blk->satp << 32);
+    uint64_t key = (uint64_t) replaced_blk->pc_start |
+                   ((uint64_t) replaced_blk->satp << 32);
 #else
-        uint64_t key = (uint64_t) replaced_blk->pc_start;
+    uint64_t key = (uint64_t) replaced_blk->pc_start;
 #endif
+    if (replaced_blk->func) {
         jit_cache_update(rv->jit_cache, key, NULL);
     }
+    inline_cache_clear_key(rv->inline_cache, key);
     /* Dispose LLVM execution engine before freeing the block.
      * The engine owns the memory where block->func points.
      */

--- a/src/jit.c
+++ b/src/jit.c
@@ -2834,6 +2834,7 @@ static void code_cache_flush(struct jit_state *state, riscv_t *rv)
     clear_cache_hot(rv->block_cache, (clear_func_t) clear_hot);
 #if RV32_HAS(T2C)
     jit_cache_clear(rv->jit_cache);
+    inline_cache_clear(rv->inline_cache);
 #endif
     return;
 }

--- a/src/riscv_private.h
+++ b/src/riscv_private.h
@@ -282,6 +282,9 @@ struct riscv_internal {
 #endif
     void *jit_state;
     void *jit_cache;
+#if RV32_HAS(T2C)
+    void *inline_cache; /* Inline cache for fast indirect jump resolution */
+#endif
 #endif
     struct mpool *block_mp, *block_ir_mp, *fuse_mp;
 

--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -636,6 +636,7 @@ RVOP(sfencevma, {
         cache_invalidate_satp(rv->block_cache, rv->csr_satp);
 #if RV32_HAS(T2C)
         jit_cache_clear(rv->jit_cache);
+        inline_cache_clear(rv->inline_cache);
         pthread_mutex_unlock(&rv->cache_lock);
 #endif
 #endif
@@ -655,6 +656,7 @@ RVOP(sfencevma, {
 #if RV32_HAS(T2C)
         /* Selectively clear only jit_cache entries matching the VA page */
         jit_cache_clear_page(rv->jit_cache, va, rv->csr_satp);
+        inline_cache_clear_page(rv->inline_cache, va, rv->csr_satp);
         pthread_mutex_unlock(&rv->cache_lock);
 #endif
 #endif
@@ -690,6 +692,7 @@ RVOP(fencei, {
     cache_invalidate_satp(rv->block_cache, rv->csr_satp);
 #if RV32_HAS(T2C)
     jit_cache_clear(rv->jit_cache);
+    inline_cache_clear(rv->inline_cache);
     pthread_mutex_unlock(&rv->cache_lock);
 #endif
 #endif


### PR DESCRIPTION
This implements inline cache optimization for T2C-compiled code:
- Add inline_cache struct with (key, entry) pairs
- Fast path: check inline cache before seqlock-based jit_cache lookup
- Slow path: full jit_cache lookup + update inline cache on hit
- Skip ISB on ARM64 for inline cache hits (already executed this target)
- Clear inline cache on SFENCE.VMA, FENCE.I, and block eviction

Benchmark: 44% faster on ARM64 (ISB avoidance), ~4% on x86_64.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add inline caching for T2C indirect jumps to speed up hot paths by bypassing jit_cache and skipping ARM64 ISB on hits. This reduces indirect jump overhead and lowers contention.

- **New Features**
  - Per-instance inline_cache storing (key, entry) pairs for indirect call sites.
  - Fast path: check inline_cache first; direct call on hit.
  - Slow path: seqlock jit_cache lookup; populate inline_cache on success; ISB only on ARM64 misses.
  - Invalidation on SFENCE.VMA (full/page), FENCE.I, and block eviction.
  - Initialization and cleanup wired into rv_create/rv_delete and code_cache_flush.

- **Performance**
  - 44% faster on ARM64 (ISB avoidance on hits).
  - ~4% faster on x86_64.

<sup>Written for commit df9727acb346f487fb6c504b0b05508a2201c5f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

