### PR TITLE
Refine branch history table

### DIFF
--- a/src/decode.h
+++ b/src/decode.h
@@ -379,6 +379,38 @@ typedef struct {
 #endif
 } branch_history_table_t;
 
+#if RV32_HAS(JIT)
+/* Find index with maximum times count in branch history table.
+ * Used by JIT to identify the most frequently taken indirect jump target.
+ */
+static inline int bht_find_max_idx(const branch_history_table_t *bt)
+{
+    int max_idx = 0;
+    for (int i = 0; i < HISTORY_SIZE; i++) {
+        if (!bt->times[i])
+            break;
+        if (bt->times[max_idx] < bt->times[i])
+            max_idx = i;
+    }
+    return max_idx;
+}
+
+/* Find index with minimum times count for LFU replacement.
+ * Returns first empty slot if available, otherwise the least frequently used.
+ */
+static inline int bht_find_min_idx(const branch_history_table_t *bt)
+{
+    int min_idx = 0;
+    for (int i = 0; i < HISTORY_SIZE; i++) {
+        if (!bt->times[i])
+            return i; /* empty slot found */
+        if (bt->times[min_idx] > bt->times[i])
+            min_idx = i;
+    }
+    return min_idx;
+}
+#endif
+
 typedef struct rv_insn {
     union {
         int32_t imm;

--- a/src/rv32_template.c
+++ b/src/rv32_template.c
@@ -152,17 +152,8 @@ RVOP(jal, {
                     }                                                        \
                 }                                                            \
             }                                                                \
-            /* update branch history table */                                \
-            int min_idx = 0;                                                 \
-            for (int i = 0; i < HISTORY_SIZE; i++) {                         \
-                if (!ir->branch_table->times[i]) {                           \
-                    min_idx = i;                                             \
-                    break;                                                   \
-                } else if (ir->branch_table->times[min_idx] >                \
-                           ir->branch_table->times[i]) {                     \
-                    min_idx = i;                                             \
-                }                                                            \
-            }                                                                \
+            /* update branch history table using LFU replacement */          \
+            int min_idx = bht_find_min_idx(ir->branch_table);                \
             ir->branch_table->times[min_idx] = 1;                            \
             ir->branch_table->PC[min_idx] = PC;                              \
             IIF(RV32_HAS(SYSTEM))(                                           \


### PR DESCRIPTION
This extracts duplicated BHT logic into reusable inline helpers:
- bht_find_max_idx(): find most frequent indirect jump target
- bht_find_min_idx(): find LFU replacement slot
- bht_should_translate(): check JIT translation threshold

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored branch history table logic into small inline helpers to remove duplication and make JIT translation decisions consistent.

- **Refactors**
  - Added bht_find_max_idx to pick the most frequent indirect jump target.
  - Added bht_find_min_idx for LFU replacement (returns first empty slot).
  - Added bht_should_translate to centralize threshold and SATP checks; used in parse_branch_history_table and translate_chained_block.
  - Updated rv32_template to use bht_find_min_idx when recording branch targets.

<sup>Written for commit 5fe0bcb8a7ff28c6fbae74127a8fbc4e1b50b0ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

