### PR TITLE
Fix FCVT illegal instruction handling

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -997,7 +997,6 @@ static inline bool op_system(rv_insn_t *ir, const uint32_t insn)
     /* decode I-type */
     decode_itype(ir, insn);
 
-
     /* dispatch from funct3 field */
     switch (decode_funct3(insn)) {
     case 0:
@@ -1113,12 +1112,10 @@ static inline bool op_misc_mem(rv_insn_t *ir, const uint32_t insn)
     case 0b001:
         ir->opcode = rv_insn_fencei;
         return true;
-#endif       /* RV32_HAS(Zifencei) */
-    default: /* illegal instruction */
+#endif /* RV32_HAS(Zifencei) */
+    default:
         return false;
     }
-
-    return false;
 }
 
 #if RV32_HAS(EXT_A)
@@ -1306,6 +1303,8 @@ static inline bool op_op_fp(rv_insn_t *ir, const uint32_t insn)
         case 0b00001: /* FCVT.WU.S */
             ir->opcode = rv_insn_fcvtwus;
             break;
+        default: /* illegal instruction */
+            return false;
         }
         break;
     case 0b0010100:
@@ -1614,7 +1613,7 @@ static inline bool op_cmisc_alu(rv_insn_t *ir, const uint32_t insn)
         ir->imm = c_decode_caddi_imm(insn);
         ir->opcode = rv_insn_candi;
         break;
-    case 3:; /* Arithmistic */
+    case 3: /* Arithmetic */
         ir->rs1 = c_decode_rs1c(insn) | 0x08;
         ir->rs2 = c_decode_rs2c(insn) | 0x08;
         ir->rd = ir->rs1;
@@ -1637,12 +1636,8 @@ static inline bool op_cmisc_alu(rv_insn_t *ir, const uint32_t insn)
         case 5: /* ADDW */
             assert(!"RV64/128C instructions");
             break;
-        case 6: /* Reserved */
-        case 7: /* Reserved */
+        default: /* Reserved (cases 6, 7) */
             assert(!"Instruction reserved");
-            break;
-        default:
-            __UNREACHABLE;
             break;
         }
         break;
@@ -1827,9 +1822,6 @@ static inline bool op_ccr(rv_insn_t *ir, const uint32_t insn)
             /* Hint */
             ir->opcode = rv_insn_cnop;
         }
-        break;
-    default:
-        __UNREACHABLE;
         break;
     }
     return true;


### PR DESCRIPTION
- Add missing default case in op_op_fp() for FCVT.W.S/FCVT.WU.S to properly reject illegal instruction encodings (rs2 != 0 or 1)
- Remove unreachable code after exhaustive switch statements:
  - op_misc_mem(): return after switch with default case
  - op_cmisc_alu(): default after all 8 cases (0-7) handled
  - op_ccr(): default after both cases (0, 1) of single-bit dispatch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes illegal-instruction handling for FCVT.W.S/FCVT.WU.S and removes unreachable code in several switch statements. This rejects invalid encodings and simplifies control flow.

- **Bug Fixes**
  - op_op_fp: add default case to reject FCVT.W.S/FCVT.WU.S when rs2 is not 0 or 1.

- **Refactors**
  - Remove unreachable code after exhaustive switches in op_misc_mem, op_cmisc_alu, and op_ccr.

<sup>Written for commit 82205cbb16fcfc77b269d68d988382f1fa2971fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

