### PR TITLE
Support LLVM 18-21 for T2C

### DIFF
--- a/src/t2c.c
+++ b/src/t2c.c
@@ -9,7 +9,27 @@
 #include <llvm-c/ExecutionEngine.h>
 #include <llvm-c/Target.h>
 #include <llvm-c/Transforms/PassBuilder.h>
+#include <llvm/Config/llvm-config.h>
 #include <stdlib.h>
+
+/* LLVM version compatibility check.
+ * T2C requires LLVM 18-21 for the following APIs:
+ * - LLVMRunPasses (new pass manager, added in LLVM 13)
+ * - LLVMGetInlineAsm with 9 arguments (CanThrow param added in LLVM 13)
+ * - LLVMBuildAtomicRMW (stable across 18-21)
+ * - LLVMCreateTargetMachine (stable across 18-21)
+ *
+ * Note: LLVM 22+ may deprecate MCJIT in favor of ORC JIT.
+ * When upgrading beyond LLVM 21, review:
+ * - MCJIT deprecation status
+ * - Any LLVMGetInlineAsm signature changes
+ * - Code model defaults for JIT on aarch64
+ */
+#if LLVM_VERSION_MAJOR < 18
+#error "T2C requires LLVM 18 or later. Found LLVM " LLVM_VERSION_STRING
+#elif LLVM_VERSION_MAJOR > 21
+#warning "LLVM version > 21 detected. T2C is tested with LLVM 18-21."
+#endif
 
 #include "jit.h"
 #include "mpool.h"


### PR DESCRIPTION
- Add LLVM version detection macros to mk/toolchain.mk using 'define' for reusability: llvm-config-path, llvm-homebrew-config, detect-llvm-config, llvm-version, llvm-check-libs, llvm-cflags, llvm-libfiles
- Support LLVM 18, 19, 20, and 21 (previously only LLVM 18)
- Add compile-time version check in t2c.c with clear error/warning
- Document MCJIT deprecation status: LLVM 22+ may deprecate MCJIT in favor of ORC JIT; when upgrading, review MCJIT status and LLVMGetInlineAsm signature changes
- Allow user override via LLVM_CONFIG= make variable

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand T2C LLVM support to versions 18–21 and add reusable detection + compile-time checks to make builds simpler and more reliable. Homebrew installs are handled, and users can override the LLVM binary via LLVM_CONFIG.

- **New Features**
  - Added LLVM detection helpers in mk/toolchain.mk (detect-llvm-config, llvm-version, llvm-check-libs, llvm-cflags, llvm-libfiles, detect-homebrew-llvm-prefix).
  - Makefile now uses these helpers, sets flags from llvm-config, and adds Homebrew lib path when needed. Clear warnings if libs or llvm-config are missing.
  - t2c.c enforces LLVM 18–21 at compile time (error if <18, warning if >21). Notes MCJIT deprecation risk for LLVM 22+.

- **Refactors**
  - Moved LLVM detection logic out of the Makefile into mk/toolchain.mk for reuse and readability.
  - Skip the JIT arch check when cross-compiling with emcc. Simplified T2C_OPT_LEVEL default handling.

<sup>Written for commit b26939d1a0a4aecb303182ef356efcf75c22a4c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

