### PR TITLE
Fix T2C crash on Apple Silicon

### DIFF
--- a/src/t2c_template.c
+++ b/src/t2c_template.c
@@ -866,7 +866,12 @@ T2C_OP(fence, { __UNREACHABLE; })
 T2C_OP(ecall, {
     T2C_LLVM_GEN_STORE_IMM32(*builder, ir->pc,
                              t2c_gen_PC_addr(start, builder, ir));
-    t2c_gen_call_io_func(start, builder, param_types, 8);
+    /* Use offsetof() to compute proper byte offset for on_ecall.
+     * This works correctly regardless of SYSTEM mode (which adds MMU ptrs).
+     */
+    t2c_gen_call_io_func(
+        start, builder, param_types,
+        offsetof(riscv_t, io) + offsetof(riscv_io_t, on_ecall));
     T2C_STORE_TIMER(*builder, start, insn_counter);
     LLVMBuildRetVoid(*builder);
 })
@@ -874,7 +879,12 @@ T2C_OP(ecall, {
 T2C_OP(ebreak, {
     T2C_LLVM_GEN_STORE_IMM32(*builder, ir->pc,
                              t2c_gen_PC_addr(start, builder, ir));
-    t2c_gen_call_io_func(start, builder, param_types, 9);
+    /* Use offsetof() to compute proper byte offset for on_ebreak.
+     * This works correctly regardless of SYSTEM mode (which adds MMU ptrs).
+     */
+    t2c_gen_call_io_func(
+        start, builder, param_types,
+        offsetof(riscv_t, io) + offsetof(riscv_io_t, on_ebreak));
     T2C_STORE_TIMER(*builder, start, insn_counter);
     LLVMBuildRetVoid(*builder);
 })
@@ -1289,7 +1299,12 @@ T2C_OP(cmv, {
 T2C_OP(cebreak, {
     T2C_LLVM_GEN_STORE_IMM32(*builder, ir->pc,
                              t2c_gen_PC_addr(start, builder, ir));
-    t2c_gen_call_io_func(start, builder, param_types, 9);
+    /* Use offsetof() to compute proper byte offset for on_ebreak.
+     * This works correctly regardless of SYSTEM mode (which adds MMU ptrs).
+     */
+    t2c_gen_call_io_func(
+        start, builder, param_types,
+        offsetof(riscv_t, io) + offsetof(riscv_io_t, on_ebreak));
     T2C_STORE_TIMER(*builder, start, insn_counter);
     LLVMBuildRetVoid(*builder);
 })
@@ -1514,10 +1529,13 @@ T2C_OP(fuse6, {
                    addr_a7);
     /* Store PC and call ecall handler.
      * ECALL is at ir->pc + 4 (second instruction in fused pair).
+     * Use offsetof() to compute proper byte offset for on_ecall.
      */
     T2C_LLVM_GEN_STORE_IMM32(*builder, ir->pc + 4,
                              t2c_gen_PC_addr(start, builder, ir));
-    t2c_gen_call_io_func(start, builder, param_types, 8);
+    t2c_gen_call_io_func(
+        start, builder, param_types,
+        offsetof(riscv_t, io) + offsetof(riscv_io_t, on_ecall));
     T2C_STORE_TIMER(*builder, start, insn_counter);
     LLVMBuildRetVoid(*builder);
 })


### PR DESCRIPTION
The LLVM MCJIT backend was crashing with SIGBUS when running DOOM on ARM64 macOS. Root causes and fixes:
1. LLVM struct layout mismatch: The LLVM IR struct definition for riscv_internal had fields in wrong order (io at position 2), not matching the actual C struct layout. Fixed by reordering to match: halt, X[32], PC, timer, data, io.
2. GEP-based io function offset: t2c_gen_call_io_func used GEP with incorrect struct indices. Replaced with manual pointer arithmetic (PtrToInt -> Add -> IntToPtr) using byte offsets from offsetof(). This is robust regardless of SYSTEM mode configuration.
3. Hard-coded ecall/ebreak indices: Call sites used magic numbers that were incorrect. Changed to use offsetof(riscv_t, io) + offsetof(riscv_io_t, on_ecall/on_ebreak) for correctness across all build configurations.
4. Code model on Apple Silicon: LLVMCodeModelLarge generates movz/movk sequences that are problematic on ARM64. Use LLVMCodeModelSmall for Apple Silicon, Large for other platforms.
5. MCJIT initialization: Changed from LLVMCreateExecutionEngineForModule to LLVMCreateMCJITCompilerForModule with explicit options to ensure code model setting is respected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a SIGBUS crash on Apple Silicon by aligning LLVM IR with the C struct, correcting io handler address calculation, and using the Small code model on ARM64 macOS. Also switches MCJIT initialization to respect these settings.

- **Bug Fixes**
  - Match riscv_internal struct order in LLVM IR: halt, X[32], PC, timer, data, io.
  - Load io function pointers via byte offsets (offsetof) with PtrToInt/Add/IntToPtr; remove incorrect GEP usage.
  - Replace magic indices for ecall/ebreak with offsetof(riscv_t, io) + offsetof(riscv_io_t, on_ecall/on_ebreak).
  - Use LLVMCodeModelSmall on Apple Silicon; Large elsewhere, with PIC relocation.
  - Create the engine with LLVMCreateMCJITCompilerForModule and explicit options so the code model is applied.

<sup>Written for commit 7109507375bb5c399d748eb25f0fd0a49567ac60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

