### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![GitHub Actions](https://github.com/sysprog21/rv32emu/actions/workflows/main.yml/badge.svg)
 ```
                        /--===============------\
-      ______     __    | |⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺|     |
+      ______     __    | |⎺⎺⎺⎺⎺⎺⎺⎺⎺|     |
      |  _ \ \   / /    | |               |     |
      | |_) \ \ / /     | |   Emulator!   |     |
      |  _ < \ V /      | |               |     |


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix the ASCII art banner in README by shortening the overline so the box aligns correctly and doesn’t wrap in some renderers.

<sup>Written for commit fbeb91b5a29195ee8e9c6c010ef688048d878733. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

