### PR TITLE
Fix grammatical errors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Build with a larger `INITRD_SIZE` (e.g., 64 MiB) to run SDL-oriented application
 ```shell
 $ make system ENABLE_SYSTEM=1 ENABLE_SDL=1 INITRD_SIZE=64
 ```
-Once login the guestOS, run `doom-riscv` or `quake` or `smolnes`. To terminate SDL-oriented applications, use the built-in exit utility, ctrl-c or the SDL window close button(X).
+Once log into the guestOS, run `doom-riscv` or `quake` or `smolnes`. To terminate SDL-oriented applications, use the built-in exit utility, ctrl-c or the SDL window close button(X).
 
 #### Virtio Block Device (optional)
 Generate ext4 image file for virtio block device in Unix-like system:

--- a/README.md
+++ b/README.md
@@ -471,10 +471,10 @@ Thus, the target system should have the Emscripten version 3.1.51 installed.
 
 Moreover, `rv32emu` leverages the tail call optimization (TCO) and we have tested the WebAssembly
 execution in Chrome with at least MAJOR 112, Firefox with at least MAJOR 121 and Safari with at least version 18.2
-since they supports tail call feature. Please check your browser version and update if necessary, or install a compatible
+since they support tail call feature. Please check your browser version and update if necessary, or install a compatible
 browser before proceeding.
 
-Source your Emscripten SDK environment before make. For macOS and Linux user:
+Source your Emscripten SDK environment before make. For macOS and Linux users:
 ```shell
 $ source ~/emsdk/emsdk_env.sh
 ```


### PR DESCRIPTION
Update the documentation to address several grammatical inconsistencies
and improve readability.

Changes include:
- Replace "login" with "log into" in the system emulation section, as
  the context requires a verb phrase rather than a noun.
- Correct subject-verb agreement in the WebAssembly section regarding
  browser support.
- Fix pluralization in the environment setup instructions for macOS
  and Linux users.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix grammatical errors in README to improve clarity and accuracy. Replaced “login” with “log into” in system emulation, corrected subject-verb agreement in the WebAssembly browser support note, and pluralized “user” to “users” in the Emscripten setup instructions.

<sup>Written for commit 1227d35ee4cd152313b5e866c48911e92bc0eb8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

