### PR TITLE
Fix memory leak

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -396,6 +396,22 @@ void cache_free(cache_t *cache)
         }
     }
 #endif
+    /* Free all live cache entries */
+    cache_entry_t *entry, *safe;
+#ifdef __HAVE_TYPEOF
+    list_for_each_entry_safe (entry, safe, &cache->list, list)
+#else
+    list_for_each_entry_safe (entry, safe, &cache->list, list, cache_entry_t)
+#endif
+        free(entry);
+    /* Free all ghost (evicted history) cache entries */
+#ifdef __HAVE_TYPEOF
+    list_for_each_entry_safe (entry, safe, &cache->ghost_list, list)
+#else
+    list_for_each_entry_safe (entry, safe, &cache->ghost_list, list,
+                              cache_entry_t)
+#endif
+        free(entry);
     free(cache->map.ht_list_head);
     free(cache);
 }

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -1983,7 +1983,7 @@ static block_t *block_find_or_translate(riscv_t *rv)
     for (rv_insn_t *ir = replaced_blk->ir_head, *next_ir; ir != NULL;
          ir = next_ir) {
         next_ir = ir->next;
-
+        free(ir->branch_table);
         if (ir->fuse)
             mpool_free(rv->fuse_mp, ir->fuse);
 

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -1063,12 +1063,20 @@ void rv_set_fromhost_addr(riscv_t *rv, uint32_t addr)
 }
 #endif
 
+#if RV32_HAS(JIT)
+static void free_block_branch_tables(void *block)
+{
+    assert(block);
+    block_t *blk = (block_t *) block;
+    for (rv_insn_t *ir = blk->ir_head; ir; ir = ir->next)
+        free(ir->branch_table);
+}
+#endif
+
 void rv_delete(riscv_t *rv)
 {
     assert(rv);
-#if !RV32_HAS(JIT) || (RV32_HAS(SYSTEM_MMIO))
     vm_attr_t *attr = PRIV(rv);
-#endif
 #if !RV32_HAS(JIT)
     map_delete(attr->fd_map);
     memory_delete(attr->mem);
@@ -1099,11 +1107,15 @@ void rv_delete(riscv_t *rv)
     /* Dispose LLVM engines for all remaining blocks before freeing cache */
     clear_cache_hot(rv->block_cache, t2c_dispose_block_engine);
 #endif
+    /* Free branch tables for all remaining blocks before freeing cache */
+    clear_cache_hot(rv->block_cache, free_block_branch_tables);
     jit_state_exit(rv->jit_state);
     cache_free(rv->block_cache);
     mpool_destroy(rv->block_ir_mp);
     mpool_destroy(rv->block_mp);
     mpool_destroy(rv->fuse_mp);
+    map_delete(attr->fd_map);
+    memory_delete(attr->mem);
 #endif
 #if RV32_HAS(SYSTEM_MMIO)
     u8250_delete(attr->uart);

--- a/src/t2c.c
+++ b/src/t2c.c
@@ -380,6 +380,11 @@ static void t2c_trace_ebb(LLVMBuilderRef *builder,
             LLVMBuildRetVoid(*builder);
         }
     }
+
+    if (tk && tk != *builder)
+        LLVMDisposeBuilder(tk);
+    if (utk && utk != *builder)
+        LLVMDisposeBuilder(utk);
 }
 
 void t2c_compile(riscv_t *rv, block_t *block, pthread_mutex_t *cache_lock)

--- a/src/t2c.c
+++ b/src/t2c.c
@@ -532,9 +532,11 @@ void t2c_compile(riscv_t *rv, block_t *block, pthread_mutex_t *cache_lock)
 #else
     LLVMCodeModel code_model = LLVMCodeModelLarge;
 #endif
-    LLVMTargetMachineRef tm = LLVMCreateTargetMachine(
-        target, triple, LLVMGetHostCPUName(), LLVMGetHostCPUFeatures(),
-        LLVMCodeGenLevelNone, LLVMRelocPIC, code_model);
+    char *cpu_name = LLVMGetHostCPUName();
+    char *cpu_features = LLVMGetHostCPUFeatures();
+    LLVMTargetMachineRef tm =
+        LLVMCreateTargetMachine(target, triple, cpu_name, cpu_features,
+                                LLVMCodeGenLevelNone, LLVMRelocPIC, code_model);
     LLVMPassBuilderOptionsRef pb_option = LLVMCreatePassBuilderOptions();
     /* Run LLVM optimization passes on the generated IR.
      *
@@ -589,6 +591,8 @@ void t2c_compile(riscv_t *rv, block_t *block, pthread_mutex_t *cache_lock)
     LLVMDisposePassBuilderOptions(pb_option);
     LLVMDisposeTargetMachine(tm);
     LLVMDisposeMessage(triple);
+    LLVMDisposeMessage(cpu_name);
+    LLVMDisposeMessage(cpu_features);
 
     /* Reacquire lock to update shared state.
      * All block field writes must happen under lock to avoid data races.

--- a/src/t2c.c
+++ b/src/t2c.c
@@ -610,6 +610,7 @@ void t2c_compile(riscv_t *rv, block_t *block, pthread_mutex_t *cache_lock)
             /* Free IRs that main thread skipped during deferred eviction */
             for (rv_insn_t *ir = block->ir_head, *next_ir; ir; ir = next_ir) {
                 next_ir = ir->next;
+                free(ir->branch_table);
                 if (ir->fuse)
                     mpool_free(rv->fuse_mp, ir->fuse);
                 mpool_free(rv->block_ir_mp, ir);
@@ -631,6 +632,7 @@ void t2c_compile(riscv_t *rv, block_t *block, pthread_mutex_t *cache_lock)
         /* Free IRs that main thread skipped during deferred eviction */
         for (rv_insn_t *ir = block->ir_head, *next_ir; ir; ir = next_ir) {
             next_ir = ir->next;
+            free(ir->branch_table);
             if (ir->fuse)
                 mpool_free(rv->fuse_mp, ir->fuse);
             mpool_free(rv->block_ir_mp, ir);


### PR DESCRIPTION
This PR fixes several ASan-reported memory leaks:

- Dispose tk/utk builders returned from instruction handlers in t2c_trace_ebb().
- Dispose messages returned by LLVMGetHostCPUName() / LLVMGetHostCPUFeatures().
- Free branch_tables for all cached blocks before teardown.
- Free fd_map and mem in rv_delete().
- Free all live cache entries in cache_free().

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ASan-reported memory leaks in the JIT and teardown for a clean shutdown and lower memory use. Disposes temporary LLVM builders/messages and frees branch tables on eviction/teardown, plus fd_map/mem and cache entries.

- **Bug Fixes**
  - t2c: dispose tk/utk builders; dispose LLVMGetHostCPUName/Features messages.
  - eviction/teardown: free ir->branch_table when replacing/evicting blocks and for all remaining blocks before freeing the cache; delete fd_map and mem in rv_delete().
  - cache: free all live and ghost cache entries in cache_free().

<sup>Written for commit 2138efe3ec8e0f7888610a820cd0db5e26fddd60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

