### PR TITLE
Use portable $(python) preprocessor for Kconfig

### DIFF
--- a/configs/Kconfig
+++ b/configs/Kconfig
@@ -4,23 +4,31 @@
 
 mainmenu "rv32emu Configuration"
 
-# Environment Detection (read-only, set by tools/detect-env.py)
+# Environment Detection (read-only)
+#
+# Boolean checks use the portable $(python,...) preprocessor function
+# with run() for shell-free subprocess execution.
+#
+# See: https://github.com/sysprog21/Kconfiglib/pull/47
 
 menu "Toolchain Detection"
 
 config COMPILER_TYPE
     string
-    default "$(shell,tools/detect-env.py --compiler 2>/dev/null || echo Unknown)"
+    default "Emscripten" if CC_IS_EMCC
+    default "Clang" if CC_IS_CLANG
+    default "GCC" if CC_IS_GCC
+    default "Unknown"
 
 config HAVE_EMCC
     bool
-    default $(shell,tools/detect-env.py --have-emcc 2>/dev/null)
+    default $(python,assert run(sys.executable, 'tools/detect-env.py', '--have-emcc'))
 
 config CC_IS_CLANG
-    def_bool $(shell,tools/detect-env.py --is-clang 2>/dev/null)
+    def_bool $(python,assert run(sys.executable, 'tools/detect-env.py', '--is-clang'))
 
 config CC_IS_GCC
-    def_bool $(shell,tools/detect-env.py --is-gcc 2>/dev/null)
+    def_bool $(python,assert run(sys.executable, 'tools/detect-env.py', '--is-gcc'))
 
 comment "Emscripten detected - WebAssembly build available"
     depends on HAVE_EMCC
@@ -76,20 +84,20 @@ endmenu
 config HAVE_SDL2
     bool
     default n if CC_IS_EMCC
-    default $(shell,tools/detect-env.py --have-sdl2 2>/dev/null)
+    default $(python,assert shutil.which('sdl2-config') or run('pkg-config', '--exists', 'sdl2'))
 
 config HAVE_SDL2_MIXER
     bool
     default n if CC_IS_EMCC
-    default $(shell,tools/detect-env.py --have-sdl2-mixer 2>/dev/null)
+    default $(python,assert run('pkg-config', '--exists', 'SDL2_mixer'))
 
 config HAVE_LLVM18
     bool
-    default $(shell,tools/detect-env.py --have-llvm18 2>/dev/null)
+    default $(python,assert run(sys.executable, 'tools/detect-env.py', '--have-llvm18'))
 
 config HAVE_RISCV_TOOLCHAIN
     bool
-    default $(shell,tools/detect-env.py --have-riscv-toolchain 2>/dev/null)
+    default $(python,assert run(sys.executable, 'tools/detect-env.py', '--have-riscv-toolchain'))
 
 # RISC-V ISA Extensions
 

--- a/tools/detect-env.py
+++ b/tools/detect-env.py
@@ -3,21 +3,22 @@
 Environment Detection Script for rv32emu Build System
 
 Detects compilers, libraries, and toolchains for Kconfig integration.
-Called by Kconfig with $(shell,...) to populate configuration options.
+Boolean checks use exit codes (0 = true, 1 = false) for portable
+$(python,...) preprocessor integration.
 
 Usage:
     python3 detect-env.py [OPTIONS]
 
 Options:
     --compiler           Print detected compiler type (GCC/Clang/Emscripten)
-    --is-emcc           Check if compiler is Emscripten (prints y/n)
-    --is-clang          Check if compiler is Clang (prints y/n)
-    --is-gcc            Check if compiler is GCC (prints y/n)
-    --have-emcc         Check if Emscripten (emcc) is available (prints y/n)
-    --have-sdl2         Check if SDL2 is available (prints y/n)
-    --have-sdl2-mixer   Check if SDL2_mixer is available (prints y/n)
-    --have-llvm18       Check if LLVM 18 is available (prints y/n)
-    --have-riscv-toolchain  Check if RISC-V toolchain exists (prints y/n)
+    --is-emcc           Check if compiler is Emscripten (exit 0/1)
+    --is-clang          Check if compiler is Clang (exit 0/1)
+    --is-gcc            Check if compiler is GCC (exit 0/1)
+    --have-emcc         Check if Emscripten (emcc) is available (exit 0/1)
+    --have-sdl2         Check if SDL2 is available (exit 0/1)
+    --have-sdl2-mixer   Check if SDL2_mixer is available (exit 0/1)
+    --have-llvm18       Check if LLVM 18 is available (exit 0/1)
+    --have-riscv-toolchain  Check if RISC-V toolchain exists (exit 0/1)
     --summary           Print full environment summary
 """
 
@@ -55,13 +56,13 @@ def get_compiler_path():
 
 
 def get_compiler_version(compiler):
-    """Get compiler version string."""
-    ret, stdout, _ = run_cmd(
+    """Get compiler version string (stdout + stderr for emcc compat)."""
+    ret, stdout, stderr = run_cmd(
         [compiler, "--version"]
-        if not " " in compiler
+        if " " not in compiler
         else shlex.split(compiler) + ["--version"]
     )
-    return stdout if ret == 0 else ""
+    return (stdout + stderr) if ret == 0 else ""
 
 
 def detect_compiler_type(version_output):
@@ -186,35 +187,50 @@ def print_summary():
     print(f"RISC-V Toolchain: {'yes' if have_riscv_toolchain() else 'no'}")
 
 
+def bool_exit(result):
+    """Signal boolean result via exit code for $(python,...) integration.
+
+    Kconfig's $(python,assert run(sys.executable, 'tools/detect-env.py', ...))
+    checks the exit code: 0 maps to 'y', non-zero maps to 'n'.
+    """
+    sys.exit(0 if result else 1)
+
+
+def _compiler_type():
+    """Detect compiler type (lazy, avoids probing when not needed)."""
+    compiler = get_compiler_path()
+    version = get_compiler_version(compiler)
+    return detect_compiler_type(version)
+
+
 def main():
     if len(sys.argv) < 2:
         print_summary()
         return
 
-    compiler = get_compiler_path()
-    version = get_compiler_version(compiler)
-    comp_type = detect_compiler_type(version)
-
     arg = sys.argv[1]
 
+    # Compiler-type queries (probe CC lazily)
     if arg == "--compiler":
-        print(comp_type)
+        # String output for $(shell,...) -- not convertible to $(python,...)
+        print(_compiler_type())
     elif arg == "--is-emcc":
-        print("y" if comp_type == "Emscripten" else "n")
+        bool_exit(_compiler_type() == "Emscripten")
     elif arg == "--is-clang":
-        print("y" if comp_type == "Clang" else "n")
+        bool_exit(_compiler_type() == "Clang")
     elif arg == "--is-gcc":
-        print("y" if comp_type == "GCC" else "n")
+        bool_exit(_compiler_type() == "GCC")
+    # Library/toolchain availability (no compiler probing needed)
     elif arg == "--have-emcc":
-        print("y" if have_emcc() else "n")
+        bool_exit(have_emcc())
     elif arg == "--have-sdl2":
-        print("y" if have_sdl2() else "n")
+        bool_exit(have_sdl2())
     elif arg == "--have-sdl2-mixer":
-        print("y" if have_sdl2_mixer() else "n")
+        bool_exit(have_sdl2_mixer())
     elif arg == "--have-llvm18":
-        print("y" if have_llvm18() else "n")
+        bool_exit(have_llvm18())
     elif arg == "--have-riscv-toolchain":
-        print("y" if have_riscv_toolchain() else "n")
+        bool_exit(have_riscv_toolchain())
     elif arg == "--summary":
         print_summary()
     else:


### PR DESCRIPTION
This replaces `$(shell,...)` call with portable `$(python,...)` preprocessor function from Kconfiglib for boolean environment detection. $(python) built-in evaluates Python code in-process and returns "y"/"n" without spawning a shell, eliminating POSIX shell dependencies (2>/dev/null, || echo) and improving Windows portability.

Simple checks (SDL2, SDL2_mixer) are inlined directly using the run()/shutil.which() helpers available in the $(python,...) namespace. Complex checks (compiler type, LLVM 18, RISC-V toolchain) delegate to detect-env.py via run(sys.executable, ...) with exit-code signaling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Kconfig detection to the portable $(python,...) preprocessor to remove POSIX shell dependencies and improve Windows support. Simple checks run in-process; complex checks call detect-env.py and signal results via exit codes.

- **Refactors**
  - Replace $(shell,...) with $(python,assert ...) for boolean symbols (emcc, clang/gcc, SDL2, SDL2_mixer, LLVM 18, RISC-V toolchain).
  - Inline SDL2/SDL2_mixer checks using shutil.which/pkg-config; avoid spawning a shell.
  - Derive COMPILER_TYPE from CC_IS_EMCC/CLANG/GCC with Kconfig defaults; fallback to "Unknown".
  - Delegate complex checks to tools/detect-env.py via run(sys.executable, ...); exit 0/1 drives y/n.
  - Update detect-env.py: exit-code booleans, lazy compiler probing, and capture stderr in --version for emcc.

<sup>Written for commit 2a635b4d8e50379f1a5985fcaf3b3e3f28100347. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

