### PR TITLE
Fix JIT jump table overflow in block chaining

### DIFF
--- a/src/emulate.c
+++ b/src/emulate.c
@@ -2290,24 +2290,25 @@ void rv_step(void *arg)
             && runtime_profiler(rv, block)
 #endif
         ) {
-            jit_translate(rv, block);
+            if (jit_translate(rv, block)) {
 #if defined(__aarch64__)
-            /* Ensure instruction cache coherency before executing JIT code */
-            __asm__ volatile("isb" ::: "memory");
+                /* Ensure icache coherency before executing JIT */
+                __asm__ volatile("isb" ::: "memory");
 #endif
-            ((exec_block_func_t) state->buf)(
-                rv, (uintptr_t) (state->buf + block->offset));
-            rv->csr_cycle += block->cycle_cost;
+                ((exec_block_func_t) state->buf)(
+                    rv, (uintptr_t) (state->buf + block->offset));
+                rv->csr_cycle += block->cycle_cost;
 #if RV32_HAS(SYSTEM)
-            /* Handle trap if one occurred during JIT block execution */
-            if (rv->is_trapped) {
-                trap_handler(rv);
+                /* Handle trap if one occurred during JIT block execution */
+                if (rv->is_trapped) {
+                    trap_handler(rv);
+                    prev = NULL;
+                    continue;
+                }
+#endif
                 prev = NULL;
                 continue;
             }
-#endif
-            prev = NULL;
-            continue;
         }
         set_reset(&pc_set);
         has_loops = false;

--- a/src/jit.c
+++ b/src/jit.c
@@ -68,6 +68,13 @@
 #define MAX_BLOCKS 8192
 #define IN_JUMP_THRESHOLD 256
 
+/* Worst-case jump targets per instruction.  SYSTEM_MMIO load paths emit
+ * emit_jump_target_offset x4 (LOC_0, LOC_1, TRAP, NORMAL) plus emit_exit
+ * which itself records a jump target, totaling 5.  Branch epilogues also
+ * reach 5 (2x emit_jmp + 2x emit_exit + 1x emit_jump_target_offset).
+ */
+#define JUMPS_PER_INSN 5
+
 /* Check if branch history table entry should trigger JIT translation */
 static inline bool bht_should_translate(const branch_history_table_t *bt,
                                         int idx
@@ -2952,7 +2959,16 @@ static void translate_chained_block(struct jit_state *state,
     if (state->n_blocks == MAX_BLOCKS)
         return;
 
-    assert(set_add(&state->set, RV_HASH_KEY(block)));
+    /* Check whether the remaining jump slots can accommodate this block.
+     * Each instruction emits up to JUMPS_PER_INSN jump targets (SYSTEM_MMIO
+     * load paths are the worst case) plus up to 2 for a page-terminated
+     * block epilogue (emit_jmp + emit_exit).
+     */
+    if (state->n_jumps + block->n_insn * JUMPS_PER_INSN + 2 >= MAX_JUMPS)
+        return;
+
+    bool added UNUSED = set_add(&state->set, RV_HASH_KEY(block));
+    assert(added);
     offset_map_insert(state, block);
     translate(state, rv, block);
     if (unlikely(should_flush))
@@ -2998,7 +3014,7 @@ static void translate_chained_block(struct jit_state *state,
     }
 }
 
-void jit_translate(riscv_t *rv, block_t *block)
+bool jit_translate(riscv_t *rv, block_t *block)
 {
     struct jit_state *state = rv->jit_state;
     if (set_has(&state->set, RV_HASH_KEY(block))) {
@@ -3011,7 +3027,7 @@ void jit_translate(riscv_t *rv, block_t *block)
             ) {
                 block->offset = state->offset_map[i].offset;
                 block->hot = true;
-                return;
+                return true;
             }
         }
         assert(NULL);
@@ -3036,6 +3052,19 @@ restart:
         code_cache_flush(state, rv);
         goto restart;
     }
+
+    /* If the root block was not translated (e.g. jump budget exhausted on
+     * the very first call to translate_chained_block), bail out without
+     * marking the block hot.  Otherwise resolve_jumps and cache maintenance
+     * would operate on an empty / stale code region.
+     */
+    if (!set_has(&state->set, RV_HASH_KEY(block))) {
+#if defined(__APPLE__) && defined(__aarch64__)
+        jit_exit_write_mode();
+#endif
+        return false;
+    }
+
     resolve_jumps(state);
 #if defined(__aarch64__)
     /* Cache maintenance after patching branch immediates.
@@ -3057,6 +3086,7 @@ restart:
     __asm__ volatile("isb" ::: "memory");
 #endif
     block->hot = true;
+    return true;
 }
 
 struct jit_state *jit_state_init(size_t size)

--- a/src/jit.h
+++ b/src/jit.h
@@ -67,7 +67,7 @@ struct host_reg {
 
 struct jit_state *jit_state_init(size_t size);
 void jit_state_exit(struct jit_state *state);
-void jit_translate(riscv_t *rv, block_t *block);
+bool jit_translate(riscv_t *rv, block_t *block);
 typedef void (*exec_block_func_t)(riscv_t *rv, uintptr_t);
 
 /* JIT misaligned memory access handler.


### PR DESCRIPTION
translate_chained_block() recursively chains translated blocks, each emitting jump targets into a fixed-size jumps[MAX_JUMPS] array. Deep chains (triggered by newer Linux kernel images with longer hot paths) overflow the array, hitting assert(n_jumps < MAX_JUMPS).

This adds a budget guard that checks remaining jump slots before translating each block: n_insn * JUMPS_PER_INSN + 2 accounts for the worst-case per-instruction emissions (5: SYSTEM_MMIO load or branch epilogue) plus the page-terminated block epilogue (2: emit_jmp + emit_exit).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents JIT jump table overflow during deep block chaining by adding a jump budget check. Fixes crashes (assert n_jumps < MAX_JUMPS) seen with newer Linux kernel hot paths.

- Bug Fixes
  - Add jump-slot budget check in translate_chained_block: n_insn * JUMPS_PER_INSN + 2 against MAX_JUMPS.
  - Define JUMPS_PER_INSN = 5 based on worst-case SYSTEM_MMIO loads and branch epilogues.
  - Bail out cleanly if the root block isn’t translated to avoid resolve_jumps and cache maintenance on stale/empty code.

- Migration
  - jit_translate now returns bool. Update callers to check the result and only execute the block when true.

<sup>Written for commit 8092c66edef8b97886ebf835094ba37f1cdda62d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

