### PR TITLE
Fix T2C crash from unterminated LLVM basic blocks

### DIFF
--- a/src/t2c.c
+++ b/src/t2c.c
@@ -363,6 +363,22 @@ static void t2c_trace_ebb(LLVMBuilderRef *builder,
                 }
             }
         }
+
+        /* Ensure the basic block has a terminator. When a block ends with a
+         * non-branching instruction (e.g., addi, lw, sw) whose branch_taken
+         * and branch_untaken are both NULL, or whose target block cannot be
+         * resolved from the cache, no terminator is emitted above. This
+         * produces malformed LLVM IR that crashes LLVMRunPasses.
+         *
+         * Store the next PC (block->pc_end) and return to the interpreter.
+         */
+        LLVMBasicBlockRef bb = LLVMGetInsertBlock(*builder);
+        if (!LLVMGetBasicBlockTerminator(bb)) {
+            T2C_LLVM_GEN_STORE_IMM32(*builder, block->pc_end,
+                                     t2c_gen_PC_addr(start, builder, NULL));
+            T2C_STORE_TIMER(*builder, start, insn_counter);
+            LLVMBuildRetVoid(*builder);
+        }
     }
 }
 


### PR DESCRIPTION
When t2c_trace_ebb() compiles a block whose last instruction is a non-branching, non-terminal instruction (e.g., addi, lw, sw) with no branch_taken/branch_untaken pointers, no LLVM terminator was emitted. This produced malformed IR that crashed LLVMRunPasses during the LowerExpectIntrinsicPass.

This occurs when a block ends at a page boundary or instruction limit before block chaining is established, or when a linked block has been evicted from the cache.

This adds a safety check at the end of t2c_trace_ebb() using LLVMGetBasicBlockTerminator() to detect unterminated blocks. When found, store block->pc_end to rv->PC, flush the cycle counter, and emit ret void to return control to the interpreter.

Close #718

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash during LLVMRunPasses (LowerExpectIntrinsicPass) by ensuring every compiled basic block is properly terminated. If a block ends without a branch or a resolvable target, we now return to the interpreter safely.

- Bug Fixes
  - Detect unterminated LLVM basic blocks with LLVMGetBasicBlockTerminator.
  - When missing: write block->pc_end to rv->PC, flush the cycle counter, and emit ret void.
  - Prevents malformed IR when a block ends at a page boundary, hits the instruction limit, or its linked block was evicted.

<sup>Written for commit 9b56311b7605c927d08783e5c350dc5dd7f4fde3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

