### PR TITLE
Fix LLVM builder leaks in T2C's cbeqz/cbnez/fuse12

### DIFF
--- a/src/t2c_template.c
+++ b/src/t2c_template.c
@@ -1209,23 +1209,27 @@ T2C_OP(cbeqz, {
     LLVMBasicBlockRef taken = LLVMAppendBasicBlock(start, "taken");
     LLVMBuilderRef builder2 = LLVMCreateBuilder();
     LLVMPositionBuilderAtEnd(builder2, taken);
-    if (ir->branch_taken)
+    if (ir->branch_taken &&
+        t2c_check_valid_blk(rv, block, ir->branch_taken->pc)) {
         *taken_builder = builder2;
-    else {
+    } else {
         T2C_LLVM_GEN_STORE_IMM32(builder2, ir->pc + ir->imm, addr_PC);
         T2C_STORE_TIMER(builder2, start, insn_counter);
         LLVMBuildRetVoid(builder2);
+        LLVMDisposeBuilder(builder2);
     }
 
     LLVMBasicBlockRef untaken = LLVMAppendBasicBlock(start, "untaken");
     LLVMBuilderRef builder3 = LLVMCreateBuilder();
     LLVMPositionBuilderAtEnd(builder3, untaken);
-    if (ir->branch_untaken)
+    if (ir->branch_untaken &&
+        t2c_check_valid_blk(rv, block, ir->branch_untaken->pc)) {
         *untaken_builder = builder3;
-    else {
+    } else {
         T2C_LLVM_GEN_STORE_IMM32(builder3, ir->pc + 2, addr_PC);
         T2C_STORE_TIMER(builder3, start, insn_counter);
         LLVMBuildRetVoid(builder3);
+        LLVMDisposeBuilder(builder3);
     }
     LLVMBuildCondBr(*builder, cmp, taken, untaken);
 })
@@ -1237,23 +1241,27 @@ T2C_OP(cbnez, {
     LLVMBasicBlockRef taken = LLVMAppendBasicBlock(start, "taken");
     LLVMBuilderRef builder2 = LLVMCreateBuilder();
     LLVMPositionBuilderAtEnd(builder2, taken);
-    if (ir->branch_taken)
+    if (ir->branch_taken &&
+        t2c_check_valid_blk(rv, block, ir->branch_taken->pc)) {
         *taken_builder = builder2;
-    else {
+    } else {
         T2C_LLVM_GEN_STORE_IMM32(builder2, ir->pc + ir->imm, addr_PC);
         T2C_STORE_TIMER(builder2, start, insn_counter);
         LLVMBuildRetVoid(builder2);
+        LLVMDisposeBuilder(builder2);
     }
 
     LLVMBasicBlockRef untaken = LLVMAppendBasicBlock(start, "untaken");
     LLVMBuilderRef builder3 = LLVMCreateBuilder();
     LLVMPositionBuilderAtEnd(builder3, untaken);
-    if (ir->branch_untaken)
+    if (ir->branch_untaken &&
+        t2c_check_valid_blk(rv, block, ir->branch_untaken->pc)) {
         *untaken_builder = builder3;
-    else {
+    } else {
         T2C_LLVM_GEN_STORE_IMM32(builder3, ir->pc + 2, addr_PC);
         T2C_STORE_TIMER(builder3, start, insn_counter);
         LLVMBuildRetVoid(builder3);
+        LLVMDisposeBuilder(builder3);
     }
     LLVMBuildCondBr(*builder, cmp, taken, untaken);
 })
@@ -1683,6 +1691,7 @@ T2C_OP(fuse12, {
         T2C_LLVM_GEN_STORE_IMM32(builder2, ir->pc + 4 + ir->imm2, addr_PC);
         T2C_STORE_TIMER(builder2, start, insn_counter);
         LLVMBuildRetVoid(builder2);
+        LLVMDisposeBuilder(builder2);
     }
     LLVMBasicBlockRef untaken = LLVMAppendBasicBlock(start, "untaken");
     LLVMBuilderRef builder3 = LLVMCreateBuilder();
@@ -1695,6 +1704,7 @@ T2C_OP(fuse12, {
         T2C_LLVM_GEN_STORE_IMM32(builder3, ir->pc + 8, addr_PC);
         T2C_STORE_TIMER(builder3, start, insn_counter);
         LLVMBuildRetVoid(builder3);
+        LLVMDisposeBuilder(builder3);
     }
     LLVMBuildCondBr(*builder, cmp, taken, untaken);
 })


### PR DESCRIPTION
The else branches in cbeqz, cbnez, and fuse12 handlers create LLVMBuilderRef objects that are used to emit RetVoid but never disposed, leaking heap-allocated LLVM objects per T2C compilation.

This adds LLVMDisposeBuilder() in each else branch, matching the pattern already used by the BRANCH_FUNC macro. Also add t2c_check_valid_blk() guard to cbeqz/cbnez branch conditions to prevent chaining to evicted or invalid blocks, aligning with BRANCH_FUNC and fuse12.

Close #722

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LLVMBuilderRef leaks in T2C’s cbeqz/cbnez/fuse12 and adds a guard to avoid chaining to invalid blocks. This reduces per-compile heap growth and aligns behavior with BRANCH_FUNC.

- **Bug Fixes**
  - Dispose LLVM builders after emitting RetVoid in else paths for cbeqz, cbnez, and fuse12 (LLVMDisposeBuilder).
  - Gate branch_taken/untaken in cbeqz/cbnez with t2c_check_valid_blk to prevent chaining to evicted/invalid blocks, matching BRANCH_FUNC.

<sup>Written for commit 7cd4602e90f1bec5b00c99a6dfb750b24d532692. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

