### PR TITLE
Integrate embench-iot as benchmark suite

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -29,6 +29,7 @@ jobs:
             mk/kconfig.mk
             mk/toolchain.mk
             tools/detect-env.py
+            tests/embench-iot/**
             tests/ansibench/**
             tests/rv8-bench/**
             tests/doom/**
@@ -59,7 +60,7 @@ jobs:
         run: |
           sudo apt-get update -q=2
           sudo apt-get upgrade -q=2
-          sudo apt-get install -q=2 gcc-multilib g++-multilib
+          sudo apt-get install -q=2 gcc-multilib g++-multilib scons
           .ci/riscv-toolchain-install.sh
           echo "$PWD/toolchain/bin" >> $GITHUB_PATH
       - name: Build binaries

--- a/.gitmodules
+++ b/.gitmodules
@@ -36,5 +36,5 @@
 	shallow = true
 [submodule "tests/embench-iot"]
 	path = tests/embench-iot
-	url = https://github.com/sysprog21/embench-iot.git
+	url = https://github.com/sysprog21/embench-iot
 	shallow = true

--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,7 @@
 	path = src/dtc
 	url = https://github.com/dgibson/dtc
 	shallow = true
+[submodule "tests/embench-iot"]
+	path = tests/embench-iot
+	url = https://github.com/sysprog21/embench-iot.git
+	shallow = true

--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,7 @@
 	path = src/dtc
 	url = https://github.com/dgibson/dtc
 	shallow = true
+[submodule "tests/embench-iot"]
+	path = tests/embench-iot
+	url = https://github.com/yc199911/embench-iot.git
+	shallow = true

--- a/mk/artifact.mk
+++ b/mk/artifact.mk
@@ -13,6 +13,7 @@ BIN_DIR := $(abspath $(OUT))
 
 TEST_SUITES += \
 	ansibench \
+	embench-iot \
 	rv8-bench
 
 # "ieee754" needs F extension


### PR DESCRIPTION
embench-iot provides 19 benchmarks designed for embedded systems, offering more representative coverage than the existing dhrystone. This complements the current benchmark infrastructure and enables more thorough performance evaluation of rv32emu.

- Add embench-iot as a git submodule under tests/embench-iot
- Add rv32emu board support (boardsupport.c/h) in the fork
- Add wrapper Makefile to bridge rv32emu build system with scons
- Register embench-iot in TEST_SUITES in mk/artifact.mk
- Add scons to CI install dependencies
- Update CI to detect changes under tests/embench-iot

Note: This integration requires sysprog21 to create an official fork of embench-iot (similar to sysprog21/ansibench) and update the submodule URL accordingly before merging.

Close #28

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates `embench-iot` as a new benchmark suite for rv32emu, adding 19 embedded-focused tests to improve coverage beyond Dhrystone. Hooks the suite into the build, CI, and artifact pipeline for repeatable runs.

- **New Features**
  - Add `tests/embench-iot` submodule pointing to `sysprog21/embench-iot`.
  - Add rv32emu board support and a wrapper Makefile in the fork to build via `scons`.
  - Register the suite in `TEST_SUITES` in `mk/artifact.mk`.
  - CI: install `scons` and watch `tests/embench-iot/**` for changes.
  - Normalize submodule URL (drop .git suffix) to match GitHub format.

<sup>Written for commit fadf9a930b32b9b8a6d4b62080c94fea0a95ef14. Summary will update on new commits. <a href="https://cubic.dev/pr/sysprog21/rv32emu/pull/724?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

