### PR TITLE
Fix wasm CI cache-lock race under make -j

### DIFF
--- a/.github/workflows/deploy-wasm.yml
+++ b/.github/workflows/deploy-wasm.yml
@@ -62,14 +62,44 @@ jobs:
         run: |
             git clone https://github.com/emscripten-core/emsdk -b 3.1.51
             cd emsdk
-            ./emsdk install latest
-            ./emsdk activate latest
+            # Pin to the same version as the emsdk tag. `install latest`
+            # would otherwise drift; newer Emscripten releases tightened the
+            # port-cache lock and broke `make -j` builds here.
+            ./emsdk install 3.1.51
+            ./emsdk activate 3.1.51
             source ./emsdk_env.sh
-            echo "$PATH" >> $GITHUB_PATH
+            # Propagate emsdk env to subsequent steps (each `run:` is a fresh
+            # shell). One dir per line per GitHub Actions docs; non-PATH vars
+            # (EM_CONFIG, EMSDK_NODE) ensure emcc finds its .emscripten config
+            # and bundled node without relying on relative-path auto-discovery.
+            {
+              echo "EMSDK=$EMSDK"
+              echo "EM_CONFIG=$EM_CONFIG"
+              echo "EMSDK_NODE=$EMSDK_NODE"
+              echo "EMSDK_PYTHON=$EMSDK_PYTHON"
+            } >> $GITHUB_ENV
+            {
+              echo "$EMSDK"
+              echo "$EMSDK/upstream/emscripten"
+            } >> $GITHUB_PATH
         shell: bash
       - name: fetch artifact
         run: |
               make artifact ENABLE_SYSTEM=1
+      # Populate the SDL2 / SDL2_mixer port cache serially. Without this,
+      # concurrent first-time port generation under `make -j` trips
+      # emscripten's nested-lock assertion on libSDL2.a.
+      - name: warm emscripten port cache
+        if: ${{ steps.changed-files.outputs.any_modified == 'true' ||
+            github.event_name == 'workflow_dispatch' ||
+            (github.event_name == 'repository_dispatch' && github.event.action == 'deploy_system_wasm') }}
+        run: |
+            echo 'int main(void){return 0;}' > /tmp/warmup.c
+            # Link (not just compile) so sysroot libraries that materialize at
+            # link time (e.g. libmimalloc) are populated too.
+            emcc -sSTRICT=0 -sUSE_SDL=2 -sUSE_SDL_MIXER=2 \
+                 -sSDL2_MIXER_FORMATS=wav,mid -sMALLOC=mimalloc -pthread \
+                 -O2 /tmp/warmup.c -o /tmp/warmup.js
       # Note: wasm_defconfig sets CONFIG_BUILD_WASM=y which auto-selects CC=emcc
       - name: build with emcc and move application files to /tmp
         if: ${{ steps.changed-files.outputs.any_modified == 'true' ||
@@ -186,10 +216,26 @@ jobs:
         run: |
             git clone https://github.com/emscripten-core/emsdk -b 3.1.51
             cd emsdk
-            ./emsdk install latest
-            ./emsdk activate latest
+            # Pin to the same version as the emsdk tag. `install latest`
+            # would otherwise drift; newer Emscripten releases tightened the
+            # port-cache lock and broke `make -j` builds here.
+            ./emsdk install 3.1.51
+            ./emsdk activate 3.1.51
             source ./emsdk_env.sh
-            echo "$PATH" >> $GITHUB_PATH
+            # Propagate emsdk env to subsequent steps (each `run:` is a fresh
+            # shell). One dir per line per GitHub Actions docs; non-PATH vars
+            # (EM_CONFIG, EMSDK_NODE) ensure emcc finds its .emscripten config
+            # and bundled node without relying on relative-path auto-discovery.
+            {
+              echo "EMSDK=$EMSDK"
+              echo "EM_CONFIG=$EM_CONFIG"
+              echo "EMSDK_NODE=$EMSDK_NODE"
+              echo "EMSDK_PYTHON=$EMSDK_PYTHON"
+            } >> $GITHUB_ENV
+            {
+              echo "$EMSDK"
+              echo "$EMSDK/upstream/emscripten"
+            } >> $GITHUB_PATH
         shell: bash
       - name: fetch artifact
         run: |
@@ -197,6 +243,20 @@ jobs:
               # get from rv32emu-prebuilt
               .ci/fetch.sh -o build/shareware_doom_iwad.zip "https://raw.githubusercontent.com/sysprog21/rv32emu-prebuilt/doom-artifact/shareware_doom_iwad.zip"
               unzip -o -d build/ build/shareware_doom_iwad.zip
+      # Populate the SDL2 / SDL2_mixer port cache serially. Without this,
+      # concurrent first-time port generation under `make -j` trips
+      # emscripten's nested-lock assertion on libSDL2.a.
+      - name: warm emscripten port cache
+        if: ${{ steps.changed-files.outputs.any_modified == 'true' ||
+            github.event_name == 'workflow_dispatch' ||
+            (github.event_name == 'repository_dispatch' && github.event.action == 'deploy_user_wasm') }}
+        run: |
+            echo 'int main(void){return 0;}' > /tmp/warmup.c
+            # Link (not just compile) so sysroot libraries that materialize at
+            # link time (e.g. libmimalloc) are populated too.
+            emcc -sSTRICT=0 -sUSE_SDL=2 -sUSE_SDL_MIXER=2 \
+                 -sSDL2_MIXER_FORMATS=wav,mid -sMALLOC=mimalloc -pthread \
+                 -O2 /tmp/warmup.c -o /tmp/warmup.js
       # Note: wasm_defconfig sets CONFIG_BUILD_WASM=y which auto-selects CC=emcc
       - name: build with emcc and move application files to /tmp
         if: ${{ steps.changed-files.outputs.any_modified == 'true' ||

--- a/mk/http.mk
+++ b/mk/http.mk
@@ -10,8 +10,16 @@ _MK_HTTP_INCLUDED := 1
 CURL := $(shell command -v curl 2>/dev/null)
 WGET := $(shell command -v wget 2>/dev/null)
 
+# Detect curl --retry-all-errors support (curl 7.71+)
+CURL_HAS_RETRY_ALL_ERRORS := $(if $(CURL),$(shell $(CURL) --help all 2>&1 | grep -q -- '--retry-all-errors' && echo 1))
+
 # Detect wget --show-progress support (GNU wget extension)
 WGET_HAS_PROGRESS := $(if $(WGET),$(shell $(WGET) --help 2>&1 | grep -q show-progress && echo 1))
+
+# Detect wget --retry-on-http-error support (wget 1.20+, Dec 2018).
+# RHEL/CentOS 8 ships wget 1.19; without this guard a curl-less host
+# there would die with "unrecognized option".
+WGET_HAS_RETRY_ON_HTTP_ERROR := $(if $(WGET),$(shell $(WGET) --help 2>&1 | grep -q -- '--retry-on-http-error' && echo 1))
 
 # Select HTTP tool and define unified commands
 # Note: GH_TOKEN environment variable enables authenticated GitHub API requests
@@ -23,16 +31,21 @@ ifdef CURL
     # $(1): URL
     HTTP_GET = curl -fsSL $(if $(GH_TOKEN),-H "Authorization: Bearer $(GH_TOKEN)") $(1) 2>/dev/null
     # Download file with progress bar and retry
+    # --retry-all-errors (curl 7.71+) extends --retry to transient HTTP 5xx
+    # (502/503/504); without it a single GitHub Releases CDN hiccup fails
+    # the build instead of being absorbed by the retry loop.
     # $(1): URL, $(2): output file
-    HTTP_DOWNLOAD = curl -fSL --retry 3 --retry-delay 2 --progress-bar $(1) -o $(2)
+    HTTP_DOWNLOAD = curl -fSL --retry 5 --retry-delay 2 $(if $(CURL_HAS_RETRY_ALL_ERRORS),--retry-all-errors) --progress-bar $(1) -o $(2)
     # Download file silently with retry
     # $(1): URL, $(2): output file
-    HTTP_DOWNLOAD_QUIET = curl -fsSL --retry 3 --retry-delay 2 $(1) -o $(2)
+    HTTP_DOWNLOAD_QUIET = curl -fsSL --retry 5 --retry-delay 2 $(if $(CURL_HAS_RETRY_ALL_ERRORS),--retry-all-errors) $(1) -o $(2)
 else ifdef WGET
     HTTP_TOOL := wget
     HTTP_GET = wget -q $(if $(GH_TOKEN),--header="Authorization: Bearer $(GH_TOKEN)") -O- $(1) 2>/dev/null
-    HTTP_DOWNLOAD = wget -q $(if $(WGET_HAS_PROGRESS),--show-progress) --tries=3 --waitretry=2 $(1) -O $(2)
-    HTTP_DOWNLOAD_QUIET = wget -q --tries=3 --waitretry=2 $(1) -O $(2)
+    # --retry-on-http-error covers transient 5xx that --tries alone ignores;
+    # gated on wget 1.20+ so older wget (e.g. RHEL 8) still works.
+    HTTP_DOWNLOAD = wget -q $(if $(WGET_HAS_PROGRESS),--show-progress) --tries=5 --waitretry=2 $(if $(WGET_HAS_RETRY_ON_HTTP_ERROR),--retry-on-http-error=500,502,503,504) $(1) -O $(2)
+    HTTP_DOWNLOAD_QUIET = wget -q --tries=5 --waitretry=2 $(if $(WGET_HAS_RETRY_ON_HTTP_ERROR),--retry-on-http-error=500,502,503,504) $(1) -O $(2)
 else
     HTTP_TOOL :=
 endif


### PR DESCRIPTION
deploy-wasm workflow ran 'make ENABLE_SYSTEM=1 -j' against emscripten cache that was missing libSDL2[-mt].a. Parallel emcc invocations all raced to materialize the same port, and one top-level emcc held cache lock while spawning child compilations that re-entered ports.add_cflags -> shared.cache.lock and tripped emscripten's nested-lock assertion:

  AssertionError: attempt to lock the cache while a parent process is
  holding the lock (sysroot/lib/wasm32-emscripten/libSDL2.a)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky deploy-wasm builds by removing an Emscripten port cache lock race under `make -j` and hardening HTTP downloads without breaking older runners. Pins `emsdk` to 3.1.51 and pre-warms SDL2 ports so parallel builds no longer hit nested-lock assertions.

- **Bug Fixes**
  - Pin `emsdk` install/activate to 3.1.51; export `EMSDK`, `EM_CONFIG`, `EMSDK_NODE`, `EMSDK_PYTHON`; add `$EMSDK` and `$EMSDK/upstream/emscripten` to `PATH` for consistent `emcc`.
  - Pre-warm SDL2/SDL_mixer and sysroot libs by linking a tiny program (`-sUSE_SDL=2 -sUSE_SDL_MIXER=2 -sSDL2_MIXER_FORMATS=wav,mid -sMALLOC=mimalloc -pthread`); run in system and user jobs only on artifact rebuilds or manual/dispatch.
  - Harden `mk/http.mk` downloads: increase retries to 5; add curl `--retry-all-errors` and wget `--retry-on-http-error=500,502,503,504`.
  - Feature-detect those flags for curl/wget at make time; clean fallback on older toolchains.

<sup>Written for commit 4c940abd6079e7364943fcce69054f5fca719a07. Summary will update on new commits. <a href="https://cubic.dev/pr/sysprog21/rv32emu/pull/737?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

