### PR TITLE
Stabilizes the WASM deploy workflow and fixes missing Linux image artifacts after a clean build

### DIFF
--- a/.github/workflows/deploy-wasm.yml
+++ b/.github/workflows/deploy-wasm.yml
@@ -84,6 +84,15 @@ jobs:
             } >> $GITHUB_PATH
         shell: bash
       - name: fetch artifact
+        if: ${{ steps.changed-files.outputs.any_modified == 'true' ||
+            github.event_name == 'workflow_dispatch' ||
+            (github.event_name == 'repository_dispatch' && github.event.action == 'deploy_system_wasm') }}
+        # GH_TOKEN authenticates the parse-time fetch-releases-tag call in
+        # mk/artifact.mk so the GitHub API request escapes the 60 req/hr
+        # anonymous (IP-shared) limit and stops flaking when several
+        # merges land back-to-back.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
               make artifact ENABLE_SYSTEM=1
       # Populate the SDL2 / SDL2_mixer port cache serially. Without this,
@@ -238,6 +247,15 @@ jobs:
             } >> $GITHUB_PATH
         shell: bash
       - name: fetch artifact
+        if: ${{ steps.changed-files.outputs.any_modified == 'true' ||
+            github.event_name == 'workflow_dispatch' ||
+            (github.event_name == 'repository_dispatch' && github.event.action == 'deploy_user_wasm') }}
+        # GH_TOKEN authenticates the parse-time fetch-releases-tag call in
+        # mk/artifact.mk so the GitHub API request escapes the 60 req/hr
+        # anonymous (IP-shared) limit and stops flaking when several
+        # merges land back-to-back.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
               make artifact
               # get from rv32emu-prebuilt

--- a/mk/artifact.mk
+++ b/mk/artifact.mk
@@ -317,6 +317,20 @@ ifeq ($(call has, PREBUILT), 1)
 	$(call fetch-checksum-files,$(ACTIVE_CHECKSUMS),$(ACTIVE_TAG))
 endif
 
+# File-level entry points for the Linux image payload produced by `artifact`.
+# Web/system targets depend on these paths directly, so they need explicit
+# rules that can re-materialize the files after `make clean`.
+#
+# Guarded to PREBUILT=1: the PREBUILT=0 && SYSTEM=1 branch of `artifact:`
+# moves these files to /tmp to be repackaged as a tarball, so a `test -f`
+# sentinel would always fail there (issue identified by cubic).
+ifeq ($(call has, PREBUILT), 1)
+$(OUT)/linux-image/Image \
+$(OUT)/linux-image/rootfs.cpio \
+$(OUT)/linux-image/simplefs.ko: artifact
+	$(Q)test -f $@
+endif
+
 scimark2: | $(BIN_DIR)/linux-x86-softfp $(BIN_DIR)/riscv32
 ifeq ($(call has, PREBUILT), 0)
 ifeq ($(call has, SYSTEM), 0)

--- a/mk/wasm.mk
+++ b/mk/wasm.mk
@@ -266,7 +266,9 @@ start_web_deps := check-demo-dir-exist $(BIN) $(XTERM_DATA)
 ifeq ($(CONFIG_SYSTEM),y)
 # rootfs.web.cpio is the upstream rootfs.cpio with an /etc/init.d/S99automount
 # overlay so the guest auto-mounts /dev/vda at /mnt during boot.
-start_web_deps += $(BUILD_DTB) $(BUILD_DTB2C) $(OUT)/linux-image/rootfs.web.cpio
+start_web_deps += $(BUILD_DTB) $(BUILD_DTB2C) \
+                  $(OUT)/linux-image/Image \
+                  $(OUT)/linux-image/rootfs.web.cpio
 else
 # User mode also stages large game data alongside the WASM bundle so the
 # WEB_FILES copy step succeeds. These targets pull from DOOM_DATA/QUAKE_DATA


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stabilizes the WASM deploy workflow and fixes missing Linux image outputs after a clean build. Authenticates artifact fetches and makes kernel/rootfs files explicit so `start_web` works after `make clean`.

- **Bug Fixes**
  - CI: Gate the “fetch artifact” step with the same predicate as install/build and pass `GH_TOKEN` to the parse-time API call; applies to both system and user deploy jobs.
  - Build: Add file rules for `$(OUT)/linux-image/Image`, `rootfs.cpio`, `simplefs.ko` that depend on `artifact` (guarded to `PREBUILT=1`), and include `Image` in `start_web_deps` when `CONFIG_SYSTEM=y` to prevent “No rule to make target” after `make clean`.

<sup>Written for commit ccbc109a173556d552350c64bd44bf8fd34d95f6. Summary will update on new commits. <a href="https://cubic.dev/pr/sysprog21/rv32emu/pull/739?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

