### PR TITLE
Skip empty emsdk env vars in wasm deploy

### DIFF
--- a/.github/workflows/deploy-wasm.yml
+++ b/.github/workflows/deploy-wasm.yml
@@ -72,12 +72,16 @@ jobs:
             # shell). One dir per line per GitHub Actions docs; non-PATH vars
             # (EM_CONFIG, EMSDK_NODE) ensure emcc finds its .emscripten config
             # and bundled node without relying on relative-path auto-discovery.
-            {
-              echo "EMSDK=$EMSDK"
-              echo "EM_CONFIG=$EM_CONFIG"
-              echo "EMSDK_NODE=$EMSDK_NODE"
-              echo "EMSDK_PYTHON=$EMSDK_PYTHON"
-            } >> $GITHUB_ENV
+            #
+            # Only propagate values that are set and non-empty: emsdk
+            # 3.1.51's emsdk_env.sh does not export EM_CONFIG / EMSDK_PYTHON.
+            # Writing them empty to $GITHUB_ENV would override emcc's
+            # $HOME/.emscripten fallback with "", which emcc resolves to '.'
+            # and reports as "config file not found".
+            for var in EMSDK EM_CONFIG EMSDK_NODE EMSDK_PYTHON; do
+              val="${!var}"
+              [ -n "$val" ] && printf '%s=%s\n' "$var" "$val" >> "$GITHUB_ENV"
+            done
             {
               echo "$EMSDK"
               echo "$EMSDK/upstream/emscripten"
@@ -235,12 +239,16 @@ jobs:
             # shell). One dir per line per GitHub Actions docs; non-PATH vars
             # (EM_CONFIG, EMSDK_NODE) ensure emcc finds its .emscripten config
             # and bundled node without relying on relative-path auto-discovery.
-            {
-              echo "EMSDK=$EMSDK"
-              echo "EM_CONFIG=$EM_CONFIG"
-              echo "EMSDK_NODE=$EMSDK_NODE"
-              echo "EMSDK_PYTHON=$EMSDK_PYTHON"
-            } >> $GITHUB_ENV
+            #
+            # Only propagate values that are set and non-empty: emsdk
+            # 3.1.51's emsdk_env.sh does not export EM_CONFIG / EMSDK_PYTHON.
+            # Writing them empty to $GITHUB_ENV would override emcc's
+            # $HOME/.emscripten fallback with "", which emcc resolves to '.'
+            # and reports as "config file not found".
+            for var in EMSDK EM_CONFIG EMSDK_NODE EMSDK_PYTHON; do
+              val="${!var}"
+              [ -n "$val" ] && printf '%s=%s\n' "$var" "$val" >> "$GITHUB_ENV"
+            done
             {
               echo "$EMSDK"
               echo "$EMSDK/upstream/emscripten"


### PR DESCRIPTION
emsdk 3.1.51's emsdk_env.sh does not export EM_CONFIG or EMSDK_PYTHON, so the unconditional GITHUB_ENV propagation in the install-emcc step forwarded them as the literal empty string. The next step then ran with EM_CONFIG="", which overrode emcc's $HOME/.emscripten fallback and triggered:

  emcc: warning: config file not found: .
  emcc: error: BINARYEN_ROOT not set in config (), and `wasm-opt`
    not found in PATH

Loop over the four candidate vars and only write entries whose value is set and non-empty so emcc keeps the default-config behavior. Use printf instead of echo to stay robust against shell-dependent handling of backslashes and -n-looking payloads. Apply identically to wasm-system-deploy and wasm-user-deploy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent broken wasm deploys by skipping empty `emsdk` env vars when exporting to `GITHUB_ENV`. Keeps `emcc` default config and avoids "BINARYEN_ROOT not set / wasm-opt not found" errors.

- **Bug Fixes**
  - Only write `EMSDK`, `EM_CONFIG`, `EMSDK_NODE`, `EMSDK_PYTHON` to `GITHUB_ENV` if set and non-empty.
  - Use `printf` instead of `echo` to avoid shell quirks.
  - Apply to both `wasm-system-deploy` and `wasm-user-deploy` jobs.

<sup>Written for commit d959553004c97597f45396272c736972ba7cbffc. Summary will update on new commits. <a href="https://cubic.dev/pr/sysprog21/rv32emu/pull/740?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

