### PR TITLE
Prepopulate sdl2/mimalloc before warm-cache emcc

### DIFF
--- a/.github/workflows/deploy-wasm.yml
+++ b/.github/workflows/deploy-wasm.yml
@@ -101,12 +101,20 @@ jobs:
               make artifact ENABLE_SYSTEM=1
       # Populate the SDL2 / SDL2_mixer port cache serially. Without this,
       # concurrent first-time port generation under `make -j` trips
-      # emscripten's nested-lock assertion on libSDL2.a.
+      # emscripten's nested-lock assertion on libSDL2.a. The link-time
+      # warmup alone is not enough on emsdk 3.1.51: building sdl2_mixer
+      # spawns one emcc -c subprocess per .c file with -sUSE_SDL=2, each
+      # of which tries to build the sdl2 port while the parent emcc still
+      # holds the cache lock and has exported EM_CACHE_IS_LOCKED=1 into
+      # the subprocess environment, tripping cache.py's assertion. Run
+      # embuilder up front to put sdl2 (and the -pthread/-mt variants) in
+      # the cache so those subprocess port lookups are hits.
       - name: warm emscripten port cache
         if: ${{ steps.changed-files.outputs.any_modified == 'true' ||
             github.event_name == 'workflow_dispatch' ||
             (github.event_name == 'repository_dispatch' && github.event.action == 'deploy_system_wasm') }}
         run: |
+            embuilder build sdl2 sdl2-mt libmimalloc libmimalloc-mt
             echo 'int main(void){return 0;}' > /tmp/warmup.c
             # Link (not just compile) so sysroot libraries that materialize at
             # link time (e.g. libmimalloc) are populated too.
@@ -271,12 +279,17 @@ jobs:
               unzip -o -d build/ build/shareware_doom_iwad.zip
       # Populate the SDL2 / SDL2_mixer port cache serially. Without this,
       # concurrent first-time port generation under `make -j` trips
-      # emscripten's nested-lock assertion on libSDL2.a.
+      # emscripten's nested-lock assertion on libSDL2.a. See the matching
+      # comment on the system-deploy warmup step for the root-cause
+      # explanation; embuilder seeds the sdl2 / sdl2-mt / mimalloc cache
+      # entries so per-file sdl2_mixer compile subprocesses don't try to
+      # re-acquire the cache lock the parent emcc already holds.
       - name: warm emscripten port cache
         if: ${{ steps.changed-files.outputs.any_modified == 'true' ||
             github.event_name == 'workflow_dispatch' ||
             (github.event_name == 'repository_dispatch' && github.event.action == 'deploy_user_wasm') }}
         run: |
+            embuilder build sdl2 sdl2-mt libmimalloc libmimalloc-mt
             echo 'int main(void){return 0;}' > /tmp/warmup.c
             # Link (not just compile) so sysroot libraries that materialize at
             # link time (e.g. libmimalloc) are populated too.


### PR DESCRIPTION
## Summary
- The deploy-wasm warm-cache step still hits `AssertionError: attempt to lock the cache while a parent process is holding the lock (libSDL2.a)` on emsdk 3.1.51 (see run 26168404799).
- Root cause: building the sdl2_mixer port spawns one `emcc -c` subprocess per source file with `-sUSE_SDL=2` baked in. Each subprocess inherits `EM_CACHE_IS_LOCKED=1` from the parent emcc that is still holding the cache lock, then tries to materialize the sdl2 port to satisfy `-sUSE_SDL=2` and trips `cache.acquire_cache_lock`'s assertion in cache.py. b2aa4cd serialized `make -j` against the cache but the nested race inside a single emcc invocation survives.
- Fix: run `embuilder build sdl2 sdl2-mt libmimalloc libmimalloc-mt` ahead of the existing warmup so the per-file sdl2_mixer compile subprocesses resolve sdl2 as cache hits and never re-enter `acquire_cache_lock`. Comments in both warm-cache steps now record the root cause for future readers.

## Test plan
- [ ] After merge, run `gh workflow run deploy-wasm.yml --ref master` and confirm both `wasm-system-deploy` and `wasm-user-deploy` reach the push step.
- [ ] Verify `sysprog21/rv32emu-demo:main` picks up new `system/` and `user/` commits.
- [ ] Hit https://sysprog21.github.io/rv32emu-demo/ and `/system` and confirm the c51bccf unified layout and demo behavior are live.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-seed `sdl2`, `sdl2-mt`, `libmimalloc`, and `libmimalloc-mt` with `embuilder` before the warm-cache `emcc` step to stop the nested cache lock assertion on `emsdk 3.1.51`. This keeps `SDL2_mixer` per-file compiles as cache hits and stabilizes both system and user WASM deploys.

- **Bug Fixes**
  - Run `embuilder build sdl2 sdl2-mt libmimalloc libmimalloc-mt` in both warmup steps.
  - Prevent `AssertionError: attempt to lock the cache while a parent process is holding the lock (libSDL2.a)` from `emcc -c` subprocesses inheriting `EM_CACHE_IS_LOCKED=1`.

<sup>Written for commit 0e1b453aeda74af63bdddda71e1011adb84a2a43. Summary will update on new commits. <a href="https://cubic.dev/pr/sysprog21/rv32emu/pull/741?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

