### PR TITLE
Trap reserved vfrdiv.vf encoding as illegal-instruction

### DIFF
--- a/src/decode_v.c
+++ b/src/decode_v.c
@@ -1416,10 +1416,8 @@ static inline bool op_100001(rv_insn_t *ir, const uint32_t insn)
         decode_vvtype(ir, insn);
         ir->opcode = rv_insn_vsadd_vv;
         break;
-    case 1:
-        decode_vvtype(ir, insn);
-        ir->opcode = rv_insn_vfrdiv_vf;
-        break;
+    case 1: /* reserved per V 1.0 spec */
+        return false;
     case 2:
         decode_vvtype(ir, insn);
         ir->opcode = rv_insn_vdiv_vv;


### PR DESCRIPTION
The reserved encoding (funct6=0x21, funct3=1, OPFVV) was decoded
as vfrdiv.vf in op_100001 case 1, executing the FP divide kernel
instead of trapping. Per riscv-opcodes, vfrdiv.vf is defined only
at funct3=5 (OPFVF). Return false in case 1.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix incorrect decode of reserved `vfrdiv.vf` encoding: OPFVV with funct6=0x21, funct3=1 now returns false to trigger an illegal-instruction trap. Per RISC-V V 1.0, `vfrdiv.vf` is only valid in OPFVF with funct3=5.

<sup>Written for commit 8656e045458e646813807af15df53bb839ad37f4. Summary will update on new commits. <a href="https://cubic.dev/pr/sysprog21/rv32emu/pull/743?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

