### PR TITLE
Fix vwmaccsu.vx mislabeled as vwmaccus.vx

### DIFF
--- a/src/decode_v.c
+++ b/src/decode_v.c
@@ -2277,7 +2277,7 @@ static inline bool op_111111(rv_insn_t *ir, const uint32_t insn)
         break;
     case 6:
         decode_vxtype(ir, insn);
-        ir->opcode = rv_insn_vwmaccus_vx;
+        ir->opcode = rv_insn_vwmaccsu_vx;
         break;
     default: /* illegal instruction */
         return false;


### PR DESCRIPTION
In op_111111 case 6, funct6=0x3f, funct3=6 was emitting
rv_insn_vwmaccus_vx, routing vwmaccsu.vx (signed vector ×
unsigned scalar) to the vwmaccus_vx executor (unsigned vector ×
signed scalar). Per riscv-opcodes, funct6=0x3f, funct3=6 is
vwmaccsu.vx; the correct executor already exists at
rv32_v_template.c:6406. Map case 6 to rv_insn_vwmaccsu_vx.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the vector decoder to route vwmaccsu.vx to the correct executor. op_111111 case 6 (funct6=0x3f, funct3=6) now emits rv_insn_vwmaccsu_vx instead of rv_insn_vwmaccus_vx, restoring signed-vector × unsigned-scalar semantics.

<sup>Written for commit 2b8cb481d690cdfc1ab76406aa51c33042b869eb. Summary will update on new commits. <a href="https://cubic.dev/pr/sysprog21/rv32emu/pull/744?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

