### PR TITLE
Run simplefs virtio block validation on macOS

### DIFF
--- a/.ci/boot-linux-prepare.sh
+++ b/.ci/boot-linux-prepare.sh
@@ -8,12 +8,8 @@ check_platform
 
 VBLK_IMGS=(
     build/disk_ext4.img
+    build/disk_simplefs.img
 )
-# FIXME: mkfs.simplefs is not compilable on macOS, thus running the
-# simplefs cases on Linux runner for now
-if [[ "${OS_TYPE}" == "Linux" ]]; then
-    VBLK_IMGS+=(build/disk_simplefs.img)
-fi
 
 which dd > /dev/null 2>&1 || {
     echo "Error: dd not found"
@@ -34,7 +30,7 @@ ACTION=$1
 case "$ACTION" in
     setup)
         # Clone simplefs to use mkfs.simplefs util and create simplefs disk image
-        git clone https://github.com/sysprog21/simplefs.git -b rel2025.0 --depth 1
+        git clone https://github.com/sysprog21/simplefs.git -b rel2026.0 --depth 1
 
         # Setup disk images
         for disk_img in "${VBLK_IMGS[@]}"; do
@@ -54,17 +50,23 @@ case "$ACTION" in
                     ;;
                 Darwin)
                     # Setup a /dev/ block device with ext4 fs to test guestOS access to hostOS /dev/ block device
-                    dd if=/dev/zero of=${disk_img} bs=4M count=32
-                    $(brew --prefix e2fsprogs)/sbin/mkfs.ext4 ${disk_img}
-                    # Write simplefs.ko BEFORE hdiutil attach (hdiutil locks the image file)
-                    DEBUGFS_CMD="$(brew --prefix e2fsprogs)/sbin/debugfs"
-                    if [ ! -x "${DEBUGFS_CMD}" ]; then
-                        echo "Error: debugfs not found at ${DEBUGFS_CMD}"
-                        exit 1
+                    if [[ "${disk_img}" =~ ext4 ]]; then
+                        dd if=/dev/zero of=${disk_img} bs=4M count=32
+                        $(brew --prefix e2fsprogs)/sbin/mkfs.ext4 ${disk_img}
+                        # Write simplefs.ko BEFORE hdiutil attach (hdiutil locks the image file)
+                        DEBUGFS_CMD="$(brew --prefix e2fsprogs)/sbin/debugfs"
+                        if [ ! -x "${DEBUGFS_CMD}" ]; then
+                            echo "Error: debugfs not found at ${DEBUGFS_CMD}"
+                            exit 1
+                        fi
+                        "${DEBUGFS_CMD}" -w -R \
+                            "write build/linux-image/simplefs.ko simplefs.ko" "${disk_img}" \
+                            || exit 1
+                    else
+                        mkdir -p simplefs/build
+                        make IMAGE=${disk_img} ${disk_img} -C simplefs
+                        mv simplefs/${disk_img} ./build
                     fi
-                    "${DEBUGFS_CMD}" -w -R \
-                        "write build/linux-image/simplefs.ko simplefs.ko" "${disk_img}" \
-                        || exit 1
                     BLK_DEV=$(hdiutil attach -nomount ${disk_img})
                     ;;
             esac
@@ -108,6 +110,7 @@ case "$ACTION" in
                 ;;
             Darwin)
                 hdiutil detach ${BLK_DEV_EXT4}
+                hdiutil detach ${BLK_DEV_SIMPLEFS}
                 ;;
         esac
 

--- a/.ci/boot-linux.sh
+++ b/.ci/boot-linux.sh
@@ -60,12 +60,8 @@ HOST_UTC_YEAR=$(LC_ALL=C date -u +%Y)
 ENABLE_VBLK=1
 VBLK_IMGS=(
     build/disk_ext4.img
+    build/disk_simplefs.img
 )
-# FIXME: mkfs.simplefs is not compilable on macOS, thus running the
-# simplefs cases on Linux runner for now
-if [[ "${OS_TYPE}" == "Linux" ]]; then
-    VBLK_IMGS+=(build/disk_simplefs.img)
-fi
 SIMPLEFS_KO_SRC="${VBLK_IMGS[0]}"
 
 # If any disk image is not found in the VBLK_IMGS, skip the VBLK tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -622,7 +622,7 @@ jobs:
                                    . \${TMP_FILE}; \
                                    .ci/boot-linux.sh; \
                                    EXIT_CODE=\$?; \
-                                   sudo env TMP_FILE=\${TMP_FILE} BLK_DEV_EXT4=\${BLK_DEV_EXT4} .ci/boot-linux-prepare.sh cleanup; \
+                                   sudo env TMP_FILE=\${TMP_FILE} BLK_DEV_EXT4=\${BLK_DEV_EXT4} BLK_DEV_SIMPLEFS=\${BLK_DEV_SIMPLEFS} .ci/boot-linux-prepare.sh cleanup; \
                                    exit \${EXIT_CODE};" >> "$GITHUB_ENV"
      - name: Symlink gcc-15 due to the default /usr/local/bin/gcc links to system's clang
        run: |

--- a/mk/external.mk
+++ b/mk/external.mk
@@ -155,7 +155,7 @@ LINUX_DATA_SKIP_DIR_LEVEL := 1
 LINUX_DATA_SHA_CMD := $(SHA256SUM)
 
 # simplefs kernel module
-SIMPLEFS_VERSION := rel2025.0
+SIMPLEFS_VERSION := rel2026.0
 SIMPLEFS_DATA_DEST := /tmp
 SIMPLEFS_DATA := $(SIMPLEFS_DATA_DEST)/simplefs
 SIMPLEFS_DATA_URL := git clone https://github.com/sysprog21/simplefs $(SIMPLEFS_DATA) -b $(SIMPLEFS_VERSION) --depth=1
@@ -164,7 +164,7 @@ SIMPLEFS_DATA_URL := git clone https://github.com/sysprog21/simplefs $(SIMPLEFS_
 #	xargs -0 sha1sum | \
 #	LC_ALL=C sort | \
 #	sha1sum
-SIMPLEFS_DATA_SHA := 863936f72e0781b240c5ec4574510c57f0394b99
+SIMPLEFS_DATA_SHA := f04a3044bc64195ae59cea064c4bf330132de269
 SIMPLEFS_DATA_SHA_CMD := $(SHA1SUM)
 
 # Download Rules Template


### PR DESCRIPTION
simplefs rel2026.0 reworks mkfs.simplefs to build the disk image via the native macOS disk utility, lifting the earlier Linux-only restriction. Enable the simplefs image on macOS and drop the Linux-only guards.

Bump simplefs to rel2026.0 in mk/external.mk as well, so the kernel module built from source matches the mkfs that creates the image.

Close #750

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable `simplefs` virtio-block validation on macOS by generating the `simplefs` disk with the native macOS disk utility and removing Linux-only guards. Bumps `simplefs` to `rel2026.0` so the kernel module matches the image builder. Closes #750.

- **New Features**
  - Run `simplefs` VBLK tests on macOS; always include `build/disk_simplefs.img`.
  - On macOS: build ext4 via `e2fsprogs`, create `simplefs` image via `mkfs.simplefs` (macOS disk utility), attach/detach with `hdiutil`, and pass `BLK_DEV_SIMPLEFS` for cleanup.

- **Dependencies**
  - Update `SIMPLEFS_VERSION` to `rel2026.0` and refresh SHA in `mk/external.mk`; CI clones `rel2026.0`.

<sup>Written for commit a2a77ceb012b6d54b3520e17e8e859fc61ee9845. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/rv32emu/pull/758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

