### PR TITLE
CI: Increase timeout-minutes on macOS platform

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -553,7 +553,7 @@ jobs:
   macOS-arm64:
     needs: [detect-code-related-file-changes]
     if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
-    timeout-minutes: 60
+    timeout-minutes: 80
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Recently, regression test on macOS platform triggers the 60 timeout-minutes, see [1], [2]. Also, newly added guestOS tests like reboot test(#638), gzip images test(#755) and virtio-net test (#748) increase the test time certainly and due to github action run2run test time variance, adding 20 more minutes timeout budget for the macOS platform.

[1] https://github.com/sysprog21/rv32emu/actions/runs/33958066355/job/101284903885?pr=748
[2] https://github.com/sysprog21/rv32emu/actions/runs/33958788627/job/101286909550?pr=755

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increases the `macOS-arm64` CI job timeout from 60 to 80 minutes so regression and new guestOS tests (reboot, gzip images, virtio-net) no longer hit the limit.

<sup>Written for commit a93c05a64a320d653dc0f256be382b268177efd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/rv32emu/pull/762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

