### PR TITLE
CI: Parallelize workflows and extract .ci scripts

### DIFF
--- a/.ci/apt-install.sh
+++ b/.ci/apt-install.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Install apt packages on a CI runner, tolerating out-of-sync mirrors.
+#
+# GitHub's Ubuntu images regularly hit mirrors whose Release files lag behind
+# the package indexes, which makes "apt-get update" exit non-zero even though
+# every package the job needs is available. Failing the whole job on that is
+# noise, so the update is advisory and only the install decides the exit code.
+#
+# Usage:
+#   .ci/apt-install.sh <package>...
+
+set -u -o pipefail
+
+# Options are passed to this one invocation rather than dropped into
+# /etc/apt/apt.conf.d. A persistent file also governs every later apt run,
+# including the "apt-get update" inside install-llvm.sh, which runs under set -e
+# and would then abort on any repository error.
+APT_OPTS=(
+    -o APT::Update::Error-Mode=any
+    -o Acquire::IndexTargets::deb::DEP-11::DefaultEnabled=false
+    -o Acquire::IndexTargets::deb::DEP-11-icons::DefaultEnabled=false
+    -o Acquire::IndexTargets::deb::DEP-11-icons-hidpi::DefaultEnabled=false
+    -o Acquire::Retries=3
+)
+
+sudo apt-get update -q=2 "${APT_OPTS[@]}" \
+    || echo "WARNING: apt-get update failed, continuing with cached indexes"
+
+if [ "$#" -eq 0 ]; then
+    exit 0
+fi
+
+sudo apt-get install -y -q=2 "$@"

--- a/.ci/boot-linux-prepare.sh
+++ b/.ci/boot-linux-prepare.sh
@@ -4,6 +4,17 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "${SCRIPT_DIR}/common.sh"
 
+# Strict mode matters more here than in the other boot scripts: this one runs as
+# root and creates, formats and attaches block devices. Without it a failed
+# mkfs.ext4 fell through to losetup, chown and mount on a garbage image, and the
+# real error surfaced much later as an unexplained boot timeout.
+#
+# The sibling scripts (boot-linux.sh, virtio-blk.sh, reboot.sh, rtc.sh)
+# deliberately do not do this: they sum up $? from expect runs that are expected
+# to fail, and errexit would abort on the first failing case instead of
+# reporting all of them.
+set -e -u -o pipefail
+
 check_platform
 
 VBLK_IMGS=(
@@ -11,32 +22,55 @@ VBLK_IMGS=(
     build/disk_simplefs.img
 )
 
-which dd > /dev/null 2>&1 || {
-    echo "Error: dd not found"
-    exit 1
-}
-which mkfs.ext4 > /dev/null 2>&1 || which $(brew --prefix e2fsprogs)/sbin/mkfs.ext4 > /dev/null 2>&1 \
-    || {
-        echo "Error: mkfs.ext4 not found"
+# Tools only the setup path needs. Checked there rather than here: teardown
+# must stay runnable when setup failed precisely because a tool was missing,
+# otherwise the devices setup did attach are never released.
+check_setup_tools()
+{
+    which dd > /dev/null 2>&1 || {
+        echo "Error: dd not found"
         exit 1
     }
-# Optional tooling used later in the test suite
-if ! command -v debugfs > /dev/null 2>&1 && ! command -v 7z > /dev/null 2>&1; then
-    print_warning "Neither debugfs nor 7z is available; virtio-blk verification will be skipped."
-fi
+    which mkfs.ext4 > /dev/null 2>&1 \
+        || which "$(brew --prefix e2fsprogs 2> /dev/null)/sbin/mkfs.ext4" > /dev/null 2>&1 \
+        || {
+            echo "Error: mkfs.ext4 not found"
+            exit 1
+        }
 
-ACTION=$1
+    # Optional tooling used later in the test suite
+    if ! command -v debugfs > /dev/null 2>&1 && ! command -v 7z > /dev/null 2>&1; then
+        print_warning "Neither debugfs nor 7z is available; virtio-blk verification will be skipped."
+    fi
+}
+
+# Default rather than $1: under set -u a missing argument would abort here with
+# "unbound variable" and never reach the usage message below.
+ACTION=${1:-}
+
+# Both actions read and write TMP_FILE, which the caller passes through
+# "sudo env". Under set -u a missing one aborts with a bare "unbound variable"
+# from whichever line happens to touch it first.
+if [ -z "${TMP_FILE:-}" ] && [ "${ACTION}" != "" ]; then
+    echo "Error: TMP_FILE must be set (see .ci/boot-linux-test.sh)" >&2
+    exit 2
+fi
 
 case "$ACTION" in
     setup)
-        # Clone simplefs to use mkfs.simplefs util and create simplefs disk image
+        check_setup_tools
+
+        # Clone simplefs to use mkfs.simplefs util and create simplefs disk
+        # image
         git clone https://github.com/sysprog21/simplefs -b rel2026.0 --depth 1
 
         # Setup disk images
         for disk_img in "${VBLK_IMGS[@]}"; do
             case "${OS_TYPE}" in
                 Linux)
-                    # Setup a /dev/ block device with ext4 fs to test guestOS access to hostOS /dev/ block device
+
+                    # Setup a /dev/ block device with ext4 fs to test guestOS
+                    # access to hostOS /dev/ block device
                     if [[ "${disk_img}" =~ ext4 ]]; then
                         dd if=/dev/zero of=${disk_img} bs=4M count=32
                         mkfs.ext4 ${disk_img}
@@ -49,11 +83,15 @@ case "$ACTION" in
                     losetup ${BLK_DEV} ${disk_img}
                     ;;
                 Darwin)
-                    # Setup a /dev/ block device with ext4 fs to test guestOS access to hostOS /dev/ block device
+
+                    # Setup a /dev/ block device with ext4 fs to test guestOS
+                    # access to hostOS /dev/ block device
                     if [[ "${disk_img}" =~ ext4 ]]; then
                         dd if=/dev/zero of=${disk_img} bs=4M count=32
                         $(brew --prefix e2fsprogs)/sbin/mkfs.ext4 ${disk_img}
-                        # Write simplefs.ko BEFORE hdiutil attach (hdiutil locks the image file)
+
+                        # Write simplefs.ko BEFORE hdiutil attach (hdiutil locks
+                        # the image file)
                         DEBUGFS_CMD="$(brew --prefix e2fsprogs)/sbin/debugfs"
                         if [ ! -x "${DEBUGFS_CMD}" ]; then
                             echo "Error: debugfs not found at ${DEBUGFS_CMD}"
@@ -71,17 +109,22 @@ case "$ACTION" in
                     ;;
             esac
 
-            # On Linux, ${disk_img} will be created by root and owned by root:root.
-            # Even if "others" have read and write (rw) permissions, accessing the file for certain operations may
-            # still require elevated privileges (e.g., setuid).
-            # To simplify this, we change the ownership to a non-root user.
-            # Use this with caution—changing ownership to runner:runner is specific to the GitHub CI environment.
+            # On Linux, ${disk_img} will be created by root and owned by
+            # root:root. Even if "others" have read and write (rw) permissions,
+            # accessing the file for certain operations may still require
+            # elevated privileges (e.g., setuid). To simplify this, we change
+            # the ownership to a non-root user. Use this with caution—changing
+            # ownership to runner:runner is specific to the GitHub CI
+            # environment.
             chown runner: ${disk_img}
-            # Add other's rw permission to the disk image and device, so non-superuser can rw them
+
+            # Add other's rw permission to the disk image and device, so
+            # non-superuser can rw them
             chmod o+r,o+w ${disk_img}
             chmod o+r,o+w ${BLK_DEV}
 
-            # Export ${BLK_DEV} to a tmp file. Then, source to "$GITHUB_ENV" in job step.
+            # Export ${BLK_DEV} to a tmp file. Then, source to "$GITHUB_ENV" in
+            # job step.
             if [[ "${disk_img}" =~ ext4 ]]; then
                 echo "export BLK_DEV_EXT4=${BLK_DEV}" >> "${TMP_FILE}"
             else
@@ -89,7 +132,8 @@ case "$ACTION" in
             fi
         done
 
-        # Put simplefs.ko into ext4 fs (Linux only; Darwin handled above before hdiutil attach)
+        # Put simplefs.ko into ext4 fs (Linux only; Darwin handled above before
+        # hdiutil attach)
         if [ "${OS_TYPE}" = "Linux" ]; then
             mkdir -p mnt
             mount "${VBLK_IMGS[0]}" mnt
@@ -102,25 +146,27 @@ case "$ACTION" in
         # Remove simplefs repo
         rm -rf simplefs
 
-        # Detach the /dev/loopx(Linux) or /dev/diskx(Darwin)
-        case "${OS_TYPE}" in
-            Linux)
-                losetup -d ${BLK_DEV_EXT4}
-                losetup -d ${BLK_DEV_SIMPLEFS}
-                ;;
-            Darwin)
-                hdiutil detach ${BLK_DEV_EXT4}
-                hdiutil detach ${BLK_DEV_SIMPLEFS}
-                ;;
-        esac
+        # Detach the /dev/loopx(Linux) or /dev/diskx(Darwin).
+        #
+        # Cleanup also runs when setup died partway through, so a device may
+        # never have been attached. Skip the empty ones and keep going past a
+        # failed detach: leaking one loop device is better than aborting before
+        # the other one and the disk images are released.
+        for blk_dev in "${BLK_DEV_EXT4:-}" "${BLK_DEV_SIMPLEFS:-}"; do
+            [ -n "${blk_dev}" ] || continue
+            case "${OS_TYPE}" in
+                Linux) losetup -d "${blk_dev}" || true ;;
+                Darwin) hdiutil detach "${blk_dev}" || true ;;
+            esac
+        done
 
         # delete disk images
         for disk_img in "${VBLK_IMGS[@]}"; do
             rm -f ${disk_img}
         done
 
-        # delete tmp file
-        rm "${TMP_FILE}"
+        # delete tmp file; -f because setup may have died before creating it
+        rm -f "${TMP_FILE}"
         ;;
     *)
         printf "Usage: %s {setup|cleanup}\n" "$0"

--- a/.ci/boot-linux-prepare.sh
+++ b/.ci/boot-linux-prepare.sh
@@ -30,7 +30,7 @@ ACTION=$1
 case "$ACTION" in
     setup)
         # Clone simplefs to use mkfs.simplefs util and create simplefs disk image
-        git clone https://github.com/sysprog21/simplefs.git -b rel2026.0 --depth 1
+        git clone https://github.com/sysprog21/simplefs -b rel2026.0 --depth 1
 
         # Setup disk images
         for disk_img in "${VBLK_IMGS[@]}"; do

--- a/.ci/boot-linux-test.sh
+++ b/.ci/boot-linux-test.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Boot the Linux guest with the virtio-blk backing devices attached.
+#
+# boot-linux-prepare.sh must run as root: it creates the disk images and
+# attaches them to a loop (Linux) or disk (Darwin) device, reporting the
+# resulting device names back through TMP_FILE. Teardown detaches those devices,
+# so it has to run even when the boot itself fails, otherwise the runner leaks
+# loop devices into the next step.
+
+set -u -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMP_FILE=$(mktemp "${RUNNER_TEMP:-/tmp}/rv32emu-boot.XXXXXX")
+
+cleanup()
+{
+    # Setup records each device in TMP_FILE as it attaches it, so a setup that
+    # died partway has already leaked one. Re-read the file here rather than
+    # trusting the environment, which only carries what was sourced below.
+    if [ -s "${TMP_FILE}" ]; then
+        . "${TMP_FILE}"
+    fi
+
+    sudo env TMP_FILE="${TMP_FILE}" \
+        BLK_DEV_EXT4="${BLK_DEV_EXT4:-}" \
+        BLK_DEV_SIMPLEFS="${BLK_DEV_SIMPLEFS:-}" \
+        "${SCRIPT_DIR}/boot-linux-prepare.sh" cleanup
+}
+trap cleanup EXIT
+
+sudo env TMP_FILE="${TMP_FILE}" "${SCRIPT_DIR}/boot-linux-prepare.sh" setup || exit 1
+. "${TMP_FILE}"
+"${SCRIPT_DIR}/boot-linux.sh"

--- a/.ci/brew-install.sh
+++ b/.ci/brew-install.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Install the macOS build dependencies.
+#
+# The Cellar is restored from the actions cache before this runs, but the cache
+# does not carry the /opt/homebrew/bin symlinks, and "brew install" on a formula
+# it already sees in the Cellar reports "already installed" without relinking.
+# So the link step below is not redundant on a cache hit: it is the only thing
+# that puts these tools back on PATH.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+set -e -u -o pipefail
+
+LLVM_VERSION=$(cat "${SCRIPT_DIR}/llvm-version")
+
+brew install make dtc expect sdl2 bc e2fsprogs p7zip "llvm@${LLVM_VERSION}" dcfldd
+
+# SDL_mixer only gates the audio tests, so a bottle outage should not take the
+# whole job down with it.
+brew install sdl2_mixer \
+    || echo "WARNING: sdl2_mixer unavailable, continuing without SDL_MIXER support"
+
+# Relink every formula the later build steps invoke by name. Failures are
+# tolerated (a keg-only formula refuses to link, and is reached through "brew
+# --prefix" instead), so the verification below is what actually decides.
+for formula in make dtc expect sdl2 bc p7zip dcfldd; do
+    brew link --overwrite "${formula}" > /dev/null 2>&1 || true
+done
+
+MISSING=
+for tool in dtc expect bc; do
+    command -v "${tool}" > /dev/null || MISSING="${MISSING} ${tool}"
+done
+if [ -n "${MISSING}" ]; then
+    echo "ERROR: not found in PATH after install:${MISSING}" >&2
+    exit 1
+fi

--- a/.ci/build-opt-levels.sh
+++ b/.ci/build-opt-levels.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Build the emulator at the boundary optimization levels.
+#
+# -O0 catches code that only compiles once the optimizer folds it away, -O2 is
+# what everyone actually ships, and -Ofast turns on the relaxed floating-point
+# and aliasing rules that the softfloat and JIT paths must still survive.
+#
+# Usage:
+#   .ci/build-opt-levels.sh <defconfig> [OPT_LEVEL...]
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${SCRIPT_DIR}/common.sh"
+
+set -e -u -o pipefail
+
+if [ "$#" -lt 1 ]; then
+    echo "Usage: $0 <defconfig> [OPT_LEVEL...]" >&2
+    exit 2
+fi
+
+DEFCONFIG=$1
+shift
+
+OPT_LEVELS=("$@")
+if [ "${#OPT_LEVELS[@]}" -eq 0 ]; then
+    OPT_LEVELS=(-O0 -O2 -Ofast)
+fi
+
+for opt_level in "${OPT_LEVELS[@]}"; do
+    echo "Building ${DEFCONFIG} with OPT_LEVEL=${opt_level}"
+
+    # cleanconfig, not distclean: it drops the objects and the configuration,
+    # which is all a flag change needs, while leaving the prebuilt artifacts the
+    # job setup just downloaded in place.
+    if ! (make cleanconfig && make "${DEFCONFIG}" && make OPT_LEVEL="${opt_level}" ${PARALLEL}); then
+        print_error "${DEFCONFIG} build failed with OPT_LEVEL=${opt_level}"
+        exit 1
+    fi
+done

--- a/.ci/check-format.sh
+++ b/.ci/check-format.sh
@@ -4,6 +4,10 @@
 
 set -u -o pipefail
 
+# Track the same clang-format .ci/install-formatters.sh installs; hardcoding a
+# version here makes the check silently skip itself after an LLVM bump.
+CLANG_FORMAT=clang-format-$(cat "$(dirname "${BASH_SOURCE[0]}")/llvm-version")
+
 # Use git ls-files to exclude submodules and untracked files
 C_SOURCES=()
 while IFS= read -r file; do
@@ -11,12 +15,12 @@ while IFS= read -r file; do
 done < <(git ls-files -- '*.c' '*.cxx' '*.cpp' '*.h' '*.hpp')
 
 if [ ${#C_SOURCES[@]} -gt 0 ]; then
-    if command -v clang-format-20 > /dev/null 2>&1; then
+    if command -v "${CLANG_FORMAT}" > /dev/null 2>&1; then
         echo "Checking C/C++ files..."
-        clang-format-20 -n --Werror "${C_SOURCES[@]}"
+        "${CLANG_FORMAT}" -n --Werror "${C_SOURCES[@]}"
         C_FORMAT_EXIT=$?
     else
-        echo "Skipping C/C++ format check: clang-format-20 not found" >&2
+        echo "Skipping C/C++ format check: ${CLANG_FORMAT} not found" >&2
         C_FORMAT_EXIT=0
     fi
 else

--- a/.ci/check-newline.sh
+++ b/.ci/check-newline.sh
@@ -4,7 +4,9 @@ set -e -u -o pipefail
 
 ret=0
 show=0
-# Reference: https://medium.com/@alexey.inkin/how-to-force-newline-at-end-of-files-and-why-you-should-do-it-fdf76d1d090e
+
+# Reference:
+# https://medium.com/@alexey.inkin/how-to-force-newline-at-end-of-files-and-why-you-should-do-it-fdf76d1d090e
 while IFS= read -rd '' f; do
     if file --mime-encoding "$f" | grep -qv binary; then
         tail -c1 < "$f" | read -r _ || show=1

--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -1,4 +1,6 @@
-# Bash strict mode (enabled only when executed directly, not sourced)
+# shellcheck shell=bash
+# Sourced, not executed: no shebang on purpose. Bash strict mode (enabled only
+# when executed directly, not sourced)
 if ! (return 0 2> /dev/null); then
     set -euo pipefail
 fi
@@ -156,13 +158,13 @@ download_with_headers()
             for header in "$@"; do
                 headers+=(-H "$header")
             done
-            curl -fS --retry 5 --retry-delay 2 --retry-max-time 60 -sL "${headers[@]}" "$url"
+            curl -fS --retry 5 --retry-delay 2 --retry-max-time 60 -sL ${headers[@]+"${headers[@]}"} "$url"
             ;;
         wget)
             for header in "$@"; do
                 headers+=(--header="$header")
             done
-            wget -qO- "${headers[@]}" "$url"
+            wget -qO- ${headers[@]+"${headers[@]}"} "$url"
             ;;
     esac
 }
@@ -252,7 +254,8 @@ fetch_latest_release()
 
     # Use C-style loop (Bash builtin) instead of 'seq' for portability
     for ((attempt = 1; attempt <= max_retries; attempt++)); do
-        # Fetch releases with optional authentication
+
+        # Fetch releases with optional authentication.
         # Capture stdout only; let stderr pass through to console for debugging
         if [ -n "${GH_TOKEN:-}" ]; then
             api_response=$(download_with_headers "$api_url" "Authorization: Bearer ${GH_TOKEN}") || download_status=$?
@@ -290,9 +293,8 @@ fetch_latest_release()
     return 1
 }
 
-# Fetch and build artifact with automatic release tag resolution
-# Usage: fetch_artifact <artifact_type> [make_options...]
-# Arguments:
+# Fetch and build artifact with automatic release tag resolution Usage:
+# fetch_artifact <artifact_type> [make_options...] Arguments:
 #   artifact_type: One of "ELF", "Linux-Image", or "sail"
 #   make_options: Additional options to pass to make (e.g., ENABLE_SYSTEM=1)
 # Environment:
@@ -318,7 +320,11 @@ fetch_artifact()
     # Use C-style loop (Bash builtin) instead of 'seq' for portability
     for ((attempt = 1; attempt <= max_retries; attempt++)); do
         echo "Fetching $artifact_type artifact (release: $release_tag, attempt $attempt/$max_retries)..." >&2
-        if make LATEST_RELEASE="$release_tag" "${make_opts[@]}" artifact; then
+        # ${a[@]+"${a[@]}"} rather than "${a[@]}": macOS ships bash 3.2, where
+        # expanding an empty array under `set -u` is a fatal "unbound variable"
+        # rather than the empty expansion bash 4.4+ gives. Callers that pass no
+        # make options (fetch_artifact ELF) would otherwise abort here.
+        if make LATEST_RELEASE="$release_tag" ${make_opts[@]+"${make_opts[@]}"} artifact; then
             return 0
         fi
 
@@ -332,8 +338,8 @@ fetch_artifact()
     return 1
 }
 
-# Common test configuration variables
-# Allow timeout override for JIT tests (JIT compilation adds significant overhead)
+# Common test configuration variables Allow timeout override for JIT tests (JIT
+# compilation adds significant overhead)
 TIMEOUT=${BOOT_TIMEOUT:-50}
 
 # Color codes for test output (bold variants)

--- a/.ci/emsdk-warm-cache.sh
+++ b/.ci/emsdk-warm-cache.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Populate the Emscripten port cache before any parallel build touches it.
+#
+# On a cold cache, "make -j" trips emscripten's nested-lock assertion: building
+# sdl2_mixer spawns one "emcc -c" per source file with -sUSE_SDL=2, and each
+# child tries to build the sdl2 port while the parent emcc still holds the cache
+# lock and has exported EM_CACHE_IS_LOCKED=1 into its environment. Seeding the
+# entries serially turns those child lookups into hits.
+
+set -e -u -o pipefail
+
+embuilder build sdl2 sdl2-mt libmimalloc libmimalloc-mt
+
+# Link rather than just compile: some sysroot libraries (libmimalloc among them)
+# only materialize at link time.
+WARMUP=$(mktemp -d)
+trap 'rm -rf "${WARMUP}"' EXIT
+echo 'int main(void) { return 0; }' > "${WARMUP}/warmup.c"
+emcc -sSTRICT=0 -sUSE_SDL=2 -sUSE_SDL_MIXER=2 \
+    -sSDL2_MIXER_FORMATS=wav,mid -sMALLOC=mimalloc -pthread \
+    -O2 "${WARMUP}/warmup.c" -o "${WARMUP}/warmup.js"

--- a/.ci/fetch-artifacts.sh
+++ b/.ci/fetch-artifacts.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+# Download the prebuilt artifacts a job needs, in one place so the various CI
+# jobs stop each spelling out their own slightly different sequence.
+#
+# Usage:
+#   .ci/fetch-artifacts.sh <elf|linux-image|sail|doom>...
+#
+# Environment:
+#   GH_TOKEN: raises the GitHub API rate limit used to resolve release tags.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${SCRIPT_DIR}/common.sh"
+
+set -e -u -o pipefail
+
+if [ "$#" -eq 0 ]; then
+    echo "Usage: $0 <elf|linux-image|sail|doom>..." >&2
+    exit 2
+fi
+
+# The build system keeps its configuration in the repository root, not under
+# build/. Clear it before fetching so each request below is driven purely by the
+# flags it passes, and not by whatever mode a previous job left enabled.
+rm -f .config build/.config
+
+DOOM_IWAD_URL="https://raw.githubusercontent.com/sysprog21/rv32emu-prebuilt/doom-artifact/shareware_doom_iwad.zip"
+
+for artifact in "$@"; do
+    case "${artifact}" in
+        elf)
+            fetch_artifact ELF
+            ;;
+        linux-image)
+            fetch_artifact Linux-Image ENABLE_SYSTEM=1
+
+            # ENABLE_SYSTEM=1 leaves a system configuration behind; drop it so
+            # the next request, and the job's first build, start clean.
+            rm -f .config build/.config
+            ;;
+        sail)
+            fetch_artifact sail ENABLE_ARCH_TEST=1
+            rm -f .config build/.config
+            ;;
+        doom)
+            "${SCRIPT_DIR}/fetch.sh" -o build/shareware_doom_iwad.zip "${DOOM_IWAD_URL}"
+            unzip -o -d build/ build/shareware_doom_iwad.zip
+
+            # This download sidesteps mk/external.mk, and with it the checksum
+            # the build would otherwise apply, while the archive comes from a
+            # mutable branch. Verify against the same constant so there is one
+            # source of truth for what the payload should be.
+            expected=$(sed -n 's/^DOOM_DATA_SHA := //p' mk/external.mk)
+            if [ -z "${expected}" ]; then
+                print_error "DOOM_DATA_SHA not found in mk/external.mk"
+                exit 1
+            fi
+            if command -v sha1sum > /dev/null 2>&1; then
+                actual=$(sha1sum build/DOOM1.WAD | cut -d' ' -f1)
+            else
+                actual=$(shasum build/DOOM1.WAD | cut -d' ' -f1)
+            fi
+            if [ "${actual}" != "${expected}" ]; then
+                print_error "DOOM1.WAD checksum mismatch: got ${actual}, want ${expected}"
+                exit 1
+            fi
+            ;;
+        *)
+            print_error "Unknown artifact: ${artifact}"
+            exit 2
+            ;;
+    esac
+done

--- a/.ci/fetch.sh
+++ b/.ci/fetch.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# Reliable download wrapper with retry logic and timeout handling
-# Prefers curl over wget for better error handling and features
+# Reliable download wrapper with retry logic and timeout handling.
+# Prefers curl over wget for better error handling and features.
 
 set -euo pipefail
 
@@ -143,16 +143,17 @@ download()
             print_error "curl binary not found in PATH"
             return 1
         fi
+
         # curl options:
-        # -f: Fail silently on HTTP errors
-        # -L: Follow redirects
-        # -S: Show error even with -s
-        # -s: Silent mode (if quiet)
-        # --retry: Number of retries
-        # --retry-delay: Wait time between retries
-        # --connect-timeout: Connection timeout
-        # --max-time: Total operation timeout
-        # -o: Output file
+        #   -f               Fail silently on HTTP errors
+        #   -L               Follow redirects
+        #   -S               Show error even with -s
+        #   -s               Silent mode (if quiet)
+        #   --retry          Number of retries
+        #   --retry-delay    Wait time between retries
+        #   --connect-timeout Connection timeout
+        #   --max-time       Total operation timeout
+        #   -o               Output file
         local curl_opts=(
             -f
             -L
@@ -177,13 +178,14 @@ download()
             print_error "wget binary not found in PATH"
             return 1
         fi
+
         # wget options:
-        # --retry-connrefused: Retry on connection refused
-        # --waitretry: Wait between retries
-        # --read-timeout: Read timeout
-        # --timeout: Connection timeout
-        # --tries: Number of attempts
-        # -O: Output file
+        #   --retry-connrefused  Retry on connection refused
+        #   --waitretry          Wait between retries
+        #   --read-timeout       Read timeout
+        #   --timeout            Connection timeout
+        #   --tries              Number of attempts
+        #   -O                   Output file
         local wget_opts=(
             --retry-connrefused
             --waitretry="$WAIT_RETRY"

--- a/.ci/gdbstub-test.sh
+++ b/.ci/gdbstub-test.sh
@@ -31,6 +31,7 @@ fi
 
 OPTS=
 tmpfile=/tmp/rv32emu-gdbstub.$PID
+
 # Use main() function addresses that are identical across platforms:
 # - 0x100e0: main entry (addi sp,sp,-16)
 # - 0x100e8: jal run_puzzle (call to puzzle solver)
@@ -39,7 +40,7 @@ breakpoints=(0x100e0 0x100e8 0x100f0)
 bkpt_count=${#breakpoints[@]}
 OPTS+="-ex 'file build/riscv32/puzzle' "
 OPTS+="-ex 'target remote :1234' "
-for t in ${breakpoints[@]}; do
+for t in "${breakpoints[@]}"; do
     OPTS+="-ex 'break *$t' "
 done
 for ((i = 1; i <= $bkpt_count; i++)); do

--- a/.ci/install-formatters.sh
+++ b/.ci/install-formatters.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Install the formatters that .ci/check-format.sh shells out to.
+#
+# clang-format is pulled from apt.llvm.org through install-llvm.sh so the
+# signing key is fingerprint-checked rather than trusted blind, and so the
+# version tracks .ci/llvm-version instead of drifting on its own.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+set -e -u -o pipefail
+
+LLVM_VERSION=$(cat "${SCRIPT_DIR}/llvm-version")
+DTSFMT_VERSION=v0.8.0
+
+"${SCRIPT_DIR}/apt-install.sh" curl wget lsb-release gnupg
+sudo "${SCRIPT_DIR}/install-llvm.sh" "${LLVM_VERSION}"
+sudo apt-get install -y -q=2 "clang-format-${LLVM_VERSION}" shfmt python3-pip
+
+pip3 install --break-system-packages black==25.1.0
+
+# Fetch the release binary directly rather than piping the vendor's installer
+# into a shell: that installer is unversioned, so the formatter it lands could
+# change under a rerun and start reporting different diffs than the run that
+# passed. Linux x86_64 is the only host this job runs on.
+DTSFMT_URL="https://github.com/mskelton/dtsfmt/releases/download/${DTSFMT_VERSION}/dtsfmt-x86_64-unknown-linux-musl.tar.gz"
+curl -fsSL --retry 3 "${DTSFMT_URL}" | sudo tar -xz -C /usr/local/bin dtsfmt
+dtsfmt --version

--- a/.ci/install-llvm.sh
+++ b/.ci/install-llvm.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-#
 # Install LLVM <major> from apt.llvm.org with GPG fingerprint pinning.
 #
 # Replaces the pattern of fetching upstream's llvm.sh and sudo-executing it
-# without verification, which is a supply-chain risk: a hostile mirror or
-# DNS hijack could ship anything to the runner and run it as root.
+# without verification, which is a supply-chain risk: a hostile mirror or DNS
+# hijack could ship anything to the runner and run it as root.
 #
 # What this script does (mirrors the relevant parts of llvm.sh):
 #   1. Download the apt.llvm.org signing key.
@@ -20,8 +19,8 @@
 # Example:
 #   sudo .ci/install-llvm.sh 20
 #
-# Afterwards the caller is expected to `apt-get install` the specific
-# llvm-<N>* / clang-<N> / lld-<N> packages it needs.
+# Afterwards the caller is expected to `apt-get install` the specific llvm-<N>*
+# / clang-<N> / lld-<N> packages it needs.
 
 set -euo pipefail
 
@@ -41,9 +40,9 @@ if [ "$(id -u)" -ne 0 ]; then
     exit 2
 fi
 
-# Pinned fingerprint for the apt.llvm.org signing key.
-# Published by the LLVM project; rotating this requires a deliberate edit.
-# Verify against https://apt.llvm.org/llvm-snapshot.gpg.key (no spaces).
+# Pinned fingerprint for the apt.llvm.org signing key. Published by the LLVM
+# project; rotating this requires a deliberate edit. Verify against
+# https://apt.llvm.org/llvm-snapshot.gpg.key (no spaces).
 LLVM_APT_FINGERPRINT='6084F3CF814B57C1CF12EFD515CF4D18AF4F7421'
 
 KEY_URL='https://apt.llvm.org/llvm-snapshot.gpg.key'
@@ -60,8 +59,8 @@ else
     exit 1
 fi
 
-# Convert the ASCII-armored key to a dearmored keyring so apt can use it,
-# and extract the fingerprint for verification.
+# Convert the ASCII-armored key to a dearmored keyring so apt can use it, and
+# extract the fingerprint for verification.
 gpg --dearmor < "${WORK_DIR}/llvm.key" > "${WORK_DIR}/llvm.gpg"
 
 ACTUAL_FINGERPRINT=$(gpg --with-colons --import-options show-only --import \
@@ -82,12 +81,12 @@ if [ "${ACTUAL_FINGERPRINT}" != "${LLVM_APT_FINGERPRINT}" ]; then
 fi
 echo "Fingerprint OK: ${ACTUAL_FINGERPRINT}"
 
-# Install the verified key under /usr/share/keyrings and bind it to the
-# LLVM repo only via `signed-by=`. Putting it in /etc/apt/trusted.gpg.d
-# would let this key validate ANY apt source claiming to be signed by
-# the same fingerprint (e.g. a hostile mirror serving spoofed packages
-# under an unrelated suite); scoping the trust to llvm-${VER}.list makes
-# that misuse impossible without a second apt source explicitly opting in.
+# Install the verified key under /usr/share/keyrings and bind it to the LLVM
+# repo only via `signed-by=`. Putting it in /etc/apt/trusted.gpg.d would let
+# this key validate ANY apt source claiming to be signed by the same fingerprint
+# (e.g. a hostile mirror serving spoofed packages under an unrelated suite);
+# scoping the trust to llvm-${VER}.list makes that misuse impossible without a
+# second apt source explicitly opting in.
 install -d -m 0755 /usr/share/keyrings
 KEYRING=/usr/share/keyrings/apt.llvm.org.gpg
 install -m 0644 "${WORK_DIR}/llvm.gpg" "${KEYRING}"

--- a/.ci/publish-prebuilt.sh
+++ b/.ci/publish-prebuilt.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Publish build outputs as a release on the rv32emu-prebuilt repository.
+#
+# The tag encodes the date and the source commit, which is what the artifact
+# fetchers in mk/artifact.mk match against.
+#
+# Usage:
+#   .ci/publish-prebuilt.sh <tag-suffix> <file>...
+#
+# Files are taken relative to the current directory, so the caller can stay in
+# whatever staging directory it built the tarball in.
+#
+# Environment:
+#   GH_TOKEN: token with write access to sysprog21/rv32emu-prebuilt.
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+set -e -u -o pipefail
+
+if [ "$#" -lt 2 ]; then
+    echo "Usage: $0 <tag-suffix> <file>..." >&2
+    exit 2
+fi
+
+PREBUILT_REPO=sysprog21/rv32emu-prebuilt
+SUFFIX=$1
+shift
+
+RELEASE_TAG="$(date +'%Y.%m.%d')-$(git -C "${REPO_DIR}" rev-parse --short HEAD)-${SUFFIX}"
+
+# Create as a draft, then publish once every asset is up. A plain release is
+# visible to the artifact fetchers the moment it exists, so publishing first
+# leaves a window where they resolve this tag and then fail to download, or take
+# an incomplete set.
+gh release create --draft --latest=false "${RELEASE_TAG}" \
+    --repo "${PREBUILT_REPO}" \
+    --title "${RELEASE_TAG}"
+gh release upload "${RELEASE_TAG}" "$@" --repo "${PREBUILT_REPO}"
+
+# --latest=false again on publish: the flag set at creation does not survive the
+# draft transition, and these are dated prebuilt drops, not the release a
+# visitor to the repository should land on.
+gh release edit "${RELEASE_TAG}" --draft=false --latest=false --repo "${PREBUILT_REPO}"

--- a/.ci/requirements.txt
+++ b/.ci/requirements.txt
@@ -18,7 +18,10 @@ pytest==9.0.3
 python-dateutil==2.9.0.post0
 pytz==2025.1
 PyYAML==6.0.2
-riscof @ git+https://github.com/riscv/riscof.git@d38859f85fe407bcacddd2efcd355ada4683aee4
+# Commit pin, not a tag, because upstream stopped tagging at 1.25.3 (Jan 2023)
+# and this commit is 16 commits past it. Converting this to the newest tag would
+# roll riscof back by a year and a half; retag upstream first if you want one.
+riscof @ git+https://github.com/riscv/riscof@d38859f85fe407bcacddd2efcd355ada4683aee4
 # riscv-config installed separately in riscv-tests.sh (--no-deps) due to pyyaml==5.2 conflict
 riscv-isac==0.18.0
 ruamel.yaml==0.18.10

--- a/.ci/riscv-tests.sh
+++ b/.ci/riscv-tests.sh
@@ -6,11 +6,22 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 set -e -u -o pipefail
 
-# Install RISCOF
-# Note: riscv-config 3.18.3 pins pyyaml==5.2, but PyYAML 5.x fails to build on
-# Python 3.12 (Cython compatibility). Since requirements.txt is a full freeze
-# of all transitive dependencies, use --no-deps to bypass resolver conflicts.
-# riscof also depends on riscv-config, so --no-deps prevents re-triggering.
+# The Sail reference model comes from the prebuilt releases; resolve the tag
+# here so callers do not each have to remember to export it.
+# Assign before exporting: "export VAR=$(cmd)" takes its exit status from
+# export, so set -e cannot see the command substitution fail and the script
+# would carry on with an empty tag.
+if [ -z "${LATEST_RELEASE:-}" ]; then
+    LATEST_RELEASE=$(fetch_latest_release sail)
+fi
+export LATEST_RELEASE
+
+# Install RISCOF.
+# Note: riscv-config 3.18.3 pins pyyaml==5.2, but PyYAML 5.x
+# fails to build on Python 3.12 (Cython compatibility). Since requirements.txt
+# is a full freeze of all transitive dependencies, use --no-deps to bypass
+# resolver conflicts. riscof also depends on riscv-config, so --no-deps prevents
+# re-triggering.
 pip3 install --no-deps riscv-config==3.18.3
 pip3 install --no-deps -r .ci/requirements.txt
 # Smoke test: verify riscv-config works with PyYAML 6.x
@@ -23,7 +34,9 @@ python3 -c "import riscv_config; print('riscv-config import OK')"
 DBGEN_PATH=$(python3 -c "import riscof; import os; print(os.path.join(os.path.dirname(riscof.__file__), 'dbgen.py'))")
 if grep -q 'if key not in list:' "$DBGEN_PATH" 2> /dev/null; then
     echo "Patching RISCOF dbgen.py: fixing 'list' -> 'flist' bug"
-    # Use portable sed in-place: create temp file, then move (works on both Linux and macOS)
+
+    # Use portable sed in-place: create temp file, then move (works on both
+    # Linux and macOS)
     sed 's/if key not in list:/if key not in flist:/' "$DBGEN_PATH" > "${DBGEN_PATH}.tmp" \
         && mv "${DBGEN_PATH}.tmp" "$DBGEN_PATH"
 fi
@@ -33,7 +46,9 @@ set -x
 export PATH=$(pwd)/toolchain/bin:$PATH
 
 make distclean
-# Generate config with all RISC-V extensions (including B-extension: Zba/Zbb/Zbc/Zbs)
+
+# Generate config with all RISC-V extensions (including B-extension:
+# Zba/Zbb/Zbc/Zbs)
 make defconfig
 make ENABLE_ARCH_TEST=1 ENABLE_EXT_M=1 ENABLE_EXT_A=1 ENABLE_EXT_F=1 ENABLE_EXT_C=1 \
     ENABLE_Zicsr=1 ENABLE_Zifencei=1 \
@@ -57,7 +72,8 @@ esac
 cp "build/rv32emu-prebuilt-sail-${HOST_PLATFORM}" tests/arch-test-target/sail_cSim/riscv_sim_RV32
 chmod +x tests/arch-test-target/sail_cSim/riscv_sim_RV32
 
-# Run architecture tests in parallel (each uses device-specific work directory and config)
+# Run architecture tests in parallel (each uses device-specific work directory
+# and config)
 arch_test_pids=()
 arch_test_devices=("IMAFCZicsrZifencei" "FCZicsr" "IMZbaZbbZbcZbs")
 
@@ -85,9 +101,9 @@ make defconfig
 make ENABLE_ARCH_TEST=1 ENABLE_RV32E=1 $PARALLEL
 make ENABLE_ARCH_TEST=1 arch-test RISCV_DEVICE=E SKIP_PREREQ=1 $PARALLEL || exit 1
 
-# Rebuild with JIT
-# Do not run the architecture test with "Zicsr" extension. It ignores
-# the hardware misalignment (hw_data_misaligned_support) option.
+# Rebuild with JIT.
+# Do not run the architecture test with "Zicsr" extension. It
+# ignores the hardware misalignment (hw_data_misaligned_support) option.
 make distclean
 make jit_defconfig
 make ENABLE_ARCH_TEST=1 ENABLE_T2C=0 \

--- a/.ci/scan-build.sh
+++ b/.ci/scan-build.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Run the Clang static analyzer over an interpreter and a JIT build.
+#
+# --status-bugs makes scan-build exit non-zero on any report, which is what
+# turns this into a gate rather than a report nobody reads.
+#
+# Usage:
+#   .ci/scan-build.sh [defconfig...]     (default: defconfig jit_defconfig)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+set -e -u -o pipefail
+
+LLVM_VERSION=$(cat "${SCRIPT_DIR}/llvm-version")
+
+# The analyzer never runs the emulator, so it does not need a real prebuilt
+# release; mk/artifact.mk only wants the variable to be non-empty.
+export LATEST_RELEASE="${LATEST_RELEASE:-dummy}"
+
+DEFCONFIGS=("$@")
+if [ "${#DEFCONFIGS[@]}" -eq 0 ]; then
+    DEFCONFIGS=(defconfig jit_defconfig)
+fi
+
+for defconfig in "${DEFCONFIGS[@]}"; do
+    case "${defconfig}" in
+        jit_defconfig) jit=1 ;;
+        *) jit=0 ;;
+    esac
+
+    echo "Running scan-build over ${defconfig}"
+    make distclean
+    make "${defconfig}"
+    "scan-build-${LLVM_VERSION}" -v -o ~/scan-build \
+        --status-bugs \
+        --use-cc="clang-${LLVM_VERSION}" \
+        --force-analyze-debug-code \
+        --show-description \
+        -analyzer-config stable-report-filename=true \
+        -enable-checker valist,nullability \
+        make ENABLE_EXT_F=0 ENABLE_SDL=0 "ENABLE_JIT=${jit}"
+done

--- a/.ci/test-ext-disable.sh
+++ b/.ci/test-ext-disable.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# Build and run "make check" with one optional feature turned off at a time, in
+# both interpreter and JIT mode.
+#
+# Every feature here is independently switchable, so a CI that only ever builds
+# the default configuration hides compile errors behind whichever #ifdef nobody
+# flipped. Walking the whole matrix is what catches those.
+#
+# Usage:
+#   .ci/test-ext-disable.sh [GROUP...]
+#
+# GROUP is one of the names below; with no argument every group runs. Naming
+# groups lets the CI matrix spread the run over several runners.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${SCRIPT_DIR}/common.sh"
+
+set -e -u -o pipefail
+
+CORE_FEATURES=(
+    ENABLE_EXT_M ENABLE_EXT_A ENABLE_EXT_F ENABLE_EXT_C
+    ENABLE_Zicsr ENABLE_Zifencei
+)
+
+# Bit manipulation plus the two performance features, which share this group
+# only because the split is about balancing runners, not about taxonomy.
+BITMANIP_PERF_FEATURES=(
+    ENABLE_Zba ENABLE_Zbb ENABLE_Zbc ENABLE_Zbs
+    ENABLE_MOP_FUSION ENABLE_BLOCK_CHAINING
+)
+
+# Not "GROUPS": bash reserves that name for the caller's group IDs.
+FEATURE_GROUPS=("$@")
+if [ "${#FEATURE_GROUPS[@]}" -eq 0 ]; then
+    FEATURE_GROUPS=(core bitmanip-perf)
+fi
+
+FEATURES=()
+for group in "${FEATURE_GROUPS[@]}"; do
+    case "${group}" in
+        core) FEATURES+=("${CORE_FEATURES[@]}") ;;
+        bitmanip-perf) FEATURES+=("${BITMANIP_PERF_FEATURES[@]}") ;;
+        *)
+            print_error "Unknown feature group: ${group} (expected: core, bitmanip-perf)"
+            exit 2
+            ;;
+    esac
+done
+
+# cleanconfig rather than distclean: the prebuilt artifacts under build/ are
+# expensive to re-fetch and a configuration change does not invalidate them.
+for feature in "${FEATURES[@]}"; do
+    for defconfig in defconfig jit_defconfig; do
+        echo "Testing ${feature}=0 (${defconfig})"
+        if ! (make cleanconfig && make "${defconfig}" && make "${feature}"=0 check ${PARALLEL}); then
+            print_error "${defconfig} check failed with ${feature}=0"
+            exit 1
+        fi
+    done
+done

--- a/.ci/virtio-blk.sh
+++ b/.ci/virtio-blk.sh
@@ -62,10 +62,12 @@ for disk_img in "${VBLK_IMGS[@]}"; do
         TEST_OPTIONS+=("${TEST_OPTION}")
         EXPECT_CMDS+=("${EXPECT_CMD}")
 
-        # multiple blocks, Read-only, one disk image, one loop device (/dev/loopx(Linux) or /dev/diskx(Darwin))
-        # FIXME: On macOS, block devices (/dev/diskX) require pread() fallback instead of mmap().
-        # Combined with JIT compilation (especially gcc), this results in significantly slower
-        # I/O performance that exceeds the boot timeout. Skip multi-device tests on macOS.
+        # multiple blocks, Read-only, one disk image, one loop device
+        # (/dev/loopx(Linux) or /dev/diskx(Darwin)) FIXME: On macOS, block
+        # devices (/dev/diskX) require pread() fallback instead of mmap().
+        # Combined with JIT compilation (especially gcc), this results in
+        # significantly slower I/O performance that exceeds the boot timeout.
+        # Skip multi-device tests on macOS.
         if [[ "${OS_TYPE}" == "Darwin" ]]; then
             print_warning "Skipping multi-device readonly test on macOS (block device pread fallback too slow)"
         elif [[ ${disk_img} =~ simplefs ]]; then
@@ -173,10 +175,12 @@ for disk_img in "${VBLK_IMGS[@]}"; do
             EXPECT_CMDS+=("${EXPECT_CMD}")
         fi
 
-        # multiple blocks, Read-write, one disk image and one loop device (/dev/loopx(Linux) or /dev/diskx(Darwin))
-        # FIXME: On macOS, hdiutil locks the disk image file when attached as a block device.
-        # Opening both the original file and its attached block device for read-write access
-        # simultaneously causes pread() to block indefinitely. Skip this test on macOS.
+        # multiple blocks, Read-write, one disk image and one loop device
+        # (/dev/loopx(Linux) or /dev/diskx(Darwin)) FIXME: On macOS, hdiutil
+        # locks the disk image file when attached as a block device. Opening
+        # both the original file and its attached block device for read-write
+        # access simultaneously causes pread() to block indefinitely. Skip this
+        # test on macOS.
         if [[ "${OS_TYPE}" == "Darwin" ]]; then
             print_warning "Skipping combined disk image + block device read-write test on macOS (file locking conflict)"
         elif [[ ${disk_img} =~ simplefs ]]; then
@@ -231,13 +235,13 @@ for disk_img in "${VBLK_IMGS[@]}"; do
 
         # Allow one retry on transient JIT/T2C boot failures. Limit retries to
         # cases that do not persist guest writes into the backing image; a
-        # writable virtio-blk retry could otherwise pass by reusing emu.txt
-        # from an earlier failed attempt.
+        # writable virtio-blk retry could otherwise pass by reusing emu.txt from
+        # an earlier failed attempt.
         #
-        # BOOT_ATTEMPTS_DEFAULT is taken from the environment but validated:
-        # an empty, non-integer, or zero value would otherwise skip the
-        # for-loop entirely and leave ret=0, masking a real failure as a
-        # silent pass. Clamp anything invalid back to the 2-attempt default.
+        # BOOT_ATTEMPTS_DEFAULT is taken from the environment but validated: an
+        # empty, non-integer, or zero value would otherwise skip the for-loop
+        # entirely and leave ret=0, masking a real failure as a silent pass.
+        # Clamp anything invalid back to the 2-attempt default.
         BOOT_ATTEMPTS=1
         if [[ ! "${TEST_OPTIONS[$i]}" =~ vblk ]] || [[ "${TEST_OPTIONS[$i]}" =~ readonly ]]; then
             BOOT_ATTEMPTS_RAW=${BOOT_ATTEMPTS_DEFAULT:-2}
@@ -272,11 +276,15 @@ for disk_img in "${VBLK_IMGS[@]}"; do
 
         printf "\nBoot Linux Test: [ ${MESSAGES[$ret]}${COLOR_N} ]\n"
         if [[ "${TEST_OPTIONS[$i]}" =~ vblk ]]; then
-            # read-only test first, so the emu.txt definitely does not exist, skipping the check
+
+            # read-only test first, so the emu.txt definitely does not exist,
+            # skipping the check
             if [[ ! "${TEST_OPTIONS[$i]}" =~ readonly ]]; then
                 if [[ ${disk_img} =~ simplefs ]]; then
-                    # Does not verify the written file on hostOS since 7z does not recognize the format.
-                    # But, the written file is printed out and verified in EXPECT_CMD in guestOS
+
+                    # Does not verify the written file on hostOS since 7z does
+                    # not recognize the format. But, the written file is printed
+                    # out and verified in EXPECT_CMD in guestOS
                     :
                 else
                     7z l ${disk_img} | grep emu.txt > /dev/null 2>&1 || ret=4

--- a/.ci/wasm-build.sh
+++ b/.ci/wasm-build.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+# Build the WebAssembly demo and stage its files under /tmp for the deploy job.
+#
+# Usage:
+#   .ci/wasm-build.sh <system|user>
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${SCRIPT_DIR}/common.sh"
+
+set -e -u -o pipefail
+
+MODE=${1:-}
+
+# Note: wasm_defconfig sets CONFIG_BUILD_WASM=y, which auto-selects CC=emcc.
+make wasm_defconfig
+
+case "${MODE}" in
+    system)
+        STAGE=/tmp/rv32emu-system-demo
+        make ENABLE_SYSTEM=1 ENABLE_GOLDFISH_RTC=1 ${PARALLEL}
+        make assets/wasm/vendor/xterm.min.js assets/wasm/vendor/xterm.min.css
+
+        # Concatenate the S99automount overlay onto the upstream rootfs so the
+        # guest mounts /dev/vda at boot.
+        make build/linux-image/rootfs.web.cpio ENABLE_SYSTEM=1
+
+        mkdir -p "${STAGE}"
+        cp assets/wasm/html/system.html "${STAGE}/index.html"
+        cp assets/wasm/js/coi-serviceworker.min.js "${STAGE}/"
+        cp assets/wasm/vendor/xterm.min.js "${STAGE}/"
+        cp assets/wasm/vendor/xterm.min.css "${STAGE}/"
+        cp build/rv32emu.js "${STAGE}/"
+        cp build/rv32emu.wasm "${STAGE}/"
+        # Only emitted for pthread-enabled builds.
+        cp build/rv32emu.worker.js "${STAGE}/" || true
+        cp build/linux-image/Image "${STAGE}/"
+        cp build/linux-image/rootfs.web.cpio "${STAGE}/rootfs.cpio"
+        ;;
+    user)
+        STAGE=/tmp/rv32emu-demo
+        make ${PARALLEL}
+        make assets/wasm/vendor/xterm.min.js assets/wasm/vendor/xterm.min.css
+
+        # Ship the timidity instrument set twice: browsers with
+        # DecompressionStream take the gzip payload, older Safari and Firefox
+        # fall back to the plain tar.
+        tar -cf build/timidity.tar -C build/timidity .
+        gzip -9 -c build/timidity.tar > build/timidity.tar.gz
+
+        mkdir -p "${STAGE}"
+
+        # The landing page is committed at the demo repo root, the rest below
+        # /user.
+        cp assets/wasm/html/demo-index.html "${STAGE}/landing.html"
+        cp assets/wasm/html/user.html "${STAGE}/index.html"
+        cp assets/wasm/js/coi-serviceworker.min.js "${STAGE}/"
+        cp assets/wasm/vendor/xterm.min.js "${STAGE}/"
+        cp assets/wasm/vendor/xterm.min.css "${STAGE}/"
+        cp build/elf_list.js "${STAGE}/"
+        cp build/rv32emu.js "${STAGE}/"
+        cp build/rv32emu.wasm "${STAGE}/"
+        cp build/rv32emu.worker.js "${STAGE}/" || true
+        # Game data, fetched on demand by user.html.
+        cp build/DOOM1.WAD "${STAGE}/"
+        cp build/id1/pak0.pak "${STAGE}/"
+        cp build/timidity.tar "${STAGE}/"
+        cp build/timidity.tar.gz "${STAGE}/"
+        ;;
+    *)
+        echo "Usage: $0 <system|user>" >&2
+        exit 2
+        ;;
+esac
+
+ls -al "${STAGE}"

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -1,0 +1,182 @@
+name: Set up rv32emu build environment
+description: >
+  Install the packages, LLVM and RISC-V toolchain a build job needs, restoring
+  each of them from the actions cache when possible, and fetch the prebuilt
+  artifacts the job asks for.
+
+inputs:
+  compiler:
+    description: Compiler to select through rlalik/setup-cpp-compiler; empty to skip.
+    default: ''
+  cc:
+    description: >
+      Compiler command to export as CC, overriding whatever the compiler input
+      resolved to. Use it to pick a compiler off the LLVM bin directory this
+      action puts on PATH, which setup-cpp-compiler knows nothing about.
+    default: ''
+  llvm:
+    description: >
+      Install LLVM at the version pinned in .ci/llvm-version. Linux only: the
+      macOS dependency set always includes llvm@<version>, because the JIT needs
+      it and separating it there would save nothing. On macOS this input governs
+      only whether its bin directory goes on PATH.
+    default: 'true'
+  riscv-toolchain:
+    description: Install the RISC-V cross toolchain, needed by the gdbstub and architecture tests.
+    default: 'false'
+  artifacts:
+    description: Prebuilt artifacts to fetch, as accepted by .ci/fetch-artifacts.sh.
+    default: ''
+  cache-suffix:
+    description: >
+      Discriminator for the build/ cache key. Jobs that leave different object
+      files behind must not share a key, or whichever finishes first poisons
+      the others.
+    default: 'shared'
+
+outputs:
+  cc:
+    description: >
+      The compiler exported as CC, whether it came from the cc override or from
+      setup-cpp-compiler. Empty when no compiler was requested.
+    value: ${{ steps.export-cc.outputs.cc }}
+  llvm-version:
+    description: LLVM major version pinned in .ci/llvm-version.
+    value: ${{ steps.llvm-version.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Read LLVM version
+      id: llvm-version
+      shell: bash
+      run: echo "version=$(cat .ci/llvm-version)" >> "$GITHUB_OUTPUT"
+
+    - name: Install packages (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        .ci/apt-install.sh curl wget lsb-release software-properties-common \
+            gnupg libsdl2-dev libsdl2-mixer-dev device-tree-compiler expect \
+            bc p7zip-full e2fsprogs
+
+    # No Homebrew cache on purpose. The cache can only carry the Cellar, not
+    # the opt/ and bin/ symlinks, and "brew install" on a formula it already
+    # finds in the Cellar reports "already installed" without recreating
+    # them. A hit therefore leaves brew --prefix pointing at a path that does
+    # not exist, which is how the boot test lost mkfs.ext4. The equivalent
+    # cache on master keyed off main.yml, so it invalidated on nearly every
+    # change and hid this.
+    - name: Install packages (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: .ci/brew-install.sh
+
+    - name: Cache LLVM
+      if: runner.os == 'Linux' && inputs.llvm == 'true'
+      id: cache-llvm
+      uses: actions/cache@v6
+      with:
+        path: /usr/lib/llvm-${{ steps.llvm-version.outputs.version }}
+        key: ${{ runner.os }}-${{ runner.arch }}-llvm-${{ steps.llvm-version.outputs.version }}
+
+    - name: Install LLVM
+      if: runner.os == 'Linux' && inputs.llvm == 'true' && steps.cache-llvm.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        # Ubuntu Noble's base repos cap at llvm-18, so the pinned version comes
+        # from apt.llvm.org. install-llvm.sh verifies the signing key against a
+        # pinned fingerprint before touching apt sources.
+        VER='${{ steps.llvm-version.outputs.version }}'
+        sudo .ci/install-llvm.sh "${VER}"
+        sudo apt-get install -y -q=2 \
+            "llvm-${VER}" "llvm-${VER}-dev" "llvm-${VER}-runtime" \
+            "clang-${VER}" "lld-${VER}"
+
+    - name: Set up LLVM PATH
+      if: inputs.llvm == 'true'
+      shell: bash
+      run: |
+        if [ "${RUNNER_OS}" = "macOS" ]; then
+          echo "$(brew --prefix llvm@${{ steps.llvm-version.outputs.version }})/bin" >> "$GITHUB_PATH"
+        else
+          echo "/usr/lib/llvm-${{ steps.llvm-version.outputs.version }}/bin" >> "$GITHUB_PATH"
+        fi
+
+    - name: Cache RISC-V toolchain
+      if: inputs.riscv-toolchain == 'true'
+      id: cache-toolchain
+      uses: actions/cache@v6
+      with:
+        path: ${{ github.workspace }}/toolchain
+        key: ${{ runner.os }}-${{ runner.arch }}-riscv-toolchain-${{ hashFiles('.ci/riscv-toolchain-install.sh') }}
+
+    - name: Install RISC-V toolchain
+      if: inputs.riscv-toolchain == 'true' && steps.cache-toolchain.outputs.cache-hit != 'true'
+      shell: bash
+      run: .ci/riscv-toolchain-install.sh
+
+    - name: Set up RISC-V toolchain PATH
+      if: inputs.riscv-toolchain == 'true'
+      shell: bash
+      run: echo "${{ github.workspace }}/toolchain/bin" >> "$GITHUB_PATH"
+
+    - name: Set up Python
+      if: runner.os == 'macOS'
+      uses: actions/setup-python@v7
+      with:
+        python-version: '3.12'
+
+    - name: Install compiler
+      id: install-cc
+      if: inputs.compiler != ''
+      uses: rlalik/setup-cpp-compiler@v2
+      with:
+        compiler: ${{ inputs.compiler }}
+
+    # The default /usr/local/bin/gcc on the macOS image points at Apple clang,
+    # so the Homebrew GCC has to be reachable under its own name.
+    - name: Link Homebrew GCC
+      if: runner.os == 'macOS' && startsWith(inputs.compiler, 'gcc')
+      shell: bash
+      run: |
+        sudo ln -sf "/opt/homebrew/opt/gcc/bin/${{ inputs.compiler }}" \
+            "/usr/local/bin/${{ inputs.compiler }}"
+
+    - name: Export CC and parallel jobs
+      id: export-cc
+      shell: bash
+      run: |
+        echo "PARALLEL=-j$(getconf _NPROCESSORS_ONLN)" >> "$GITHUB_ENV"
+        SELECTED_CC='${{ inputs.cc }}'
+        [ -n "${SELECTED_CC}" ] || SELECTED_CC='${{ steps.install-cc.outputs.cc }}'
+        # Leave CC unset when no compiler was requested: the WebAssembly build
+        # selects emcc on its own and an empty CC would clobber that.
+        if [ -n "${SELECTED_CC}" ]; then
+          # Fail here rather than in the first make, where a missing compiler
+          # surfaces as an unrelated build error minutes later.
+          command -v "${SELECTED_CC}" > /dev/null \
+            || { echo "ERROR: compiler '${SELECTED_CC}' not found in PATH"; exit 1; }
+          echo "CC=${SELECTED_CC}" >> "$GITHUB_ENV"
+        fi
+        echo "cc=${SELECTED_CC}" >> "$GITHUB_OUTPUT"
+
+    - name: Cache build artifacts
+      if: inputs.artifacts != ''
+      uses: actions/cache@v6
+      with:
+        path: build/
+        key: rv32emu-artifacts-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cache-suffix }}-${{ hashFiles('mk/artifact.mk', 'mk/external.mk') }}
+        # The second fallback lets a cold job start from any sibling's build/.
+        # That is safe only because every job's first make is cleanconfig or
+        # distclean, which deletes the objects before anything links against
+        # them; what survives is the downloaded artifacts, which is the point.
+        # A new job that builds before cleaning would break that invariant.
+        restore-keys: |
+          rv32emu-artifacts-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cache-suffix }}-
+          rv32emu-artifacts-${{ runner.os }}-${{ runner.arch }}-
+
+    - name: Fetch artifacts
+      if: inputs.artifacts != ''
+      shell: bash
+      run: .ci/fetch-artifacts.sh ${{ inputs.artifacts }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,16 +6,23 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event.pull_request.head.sha || github.sha }}
   cancel-in-progress: true
 
+# github-action-benchmark authenticates with RV32EMU_BENCH_TOKEN for both the
+# gh-pages push and the PR comment, so GITHUB_TOKEN needs nothing beyond read.
+# This workflow runs on pull_request_target, where the default write-all token
+# would be in scope for fork-triggered runs.
+permissions:
+  contents: read
+
 jobs:
-  benchmark:
-    name: Performance regression check
+  # Resolved in its own job so the benchmark carries a single condition rather
+  # than repeating it on every step.
+  detect-file-changes:
     if: contains(toJSON(github.event.head_commit.message), 'Merge pull request ') == false
-    timeout-minutes: 30
     runs-on: ubuntu-24.04
+    outputs:
+      has_changed_files: ${{ steps.changed-files.outputs.any_changed }}
     steps:
-      - uses: actions/checkout@v6
-        with:
-          submodules: 'true'
+      - uses: actions/checkout@v7
 
       - name: Test changed files
         id: changed-files
@@ -35,9 +42,19 @@ jobs:
               mk/toolchain.mk
               tools/detect-env.py
 
+  benchmark:
+    name: Performance regression check
+    needs: [detect-file-changes]
+    if: needs.detect-file-changes.outputs.has_changed_files == 'true' || github.event_name == 'workflow_dispatch'
+    timeout-minutes: 30
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: 'true'
+
       - name: Cache benchmark artifacts
-        if: steps.changed-files.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch'
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: build/
           key: benchmark-artifacts-${{ runner.os }}-${{ hashFiles('mk/artifact.mk') }}
@@ -45,26 +62,20 @@ jobs:
             benchmark-artifacts-${{ runner.os }}-
 
       - name: Install dependencies
-        if: steps.changed-files.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch'
-        run: |
-            sudo pip3 install numpy --break-system-packages
-        shell: bash
+        run: sudo pip3 install numpy --break-system-packages
 
       - name: Build for benchmark
-        if: steps.changed-files.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch'
         # GH_TOKEN raises the anonymous-API rate limit (60 req/hr) so the
         # parse-time call to fetch-releases-tag stops flaking when the
         # cache misses and several PRs build back-to-back.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: make defconfig && make ENABLE_SDL=0 all artifact
+
       - name: Run benchmark
-        if: steps.changed-files.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch'
-        run: |
-          python3 tests/bench.py --json --quiet
+        run: python3 tests/bench.py --json --quiet
 
       - name: Store benchmark results
-        if: steps.changed-files.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch'
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: Benchmarks

--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -10,12 +10,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   detect-file-change:
     runs-on: ubuntu-24.04
+    outputs:
+      has_changed_files: ${{ steps.test-file-change.outputs.any_modified }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: 'true'
       - name: Test file change
@@ -36,32 +41,29 @@ jobs:
             tests/quake/**
             tests/scimark2/**
             tests/*.c
-      - name: Set alias
-        id: has_changed_files
-        run: |
-          if [[ ${{ steps.test-file-change.outputs.any_modified }} == true ]]; then
-            echo "has_changed_files=true" >> $GITHUB_OUTPUT
-          else
-            echo "has_changed_files=false" >> $GITHUB_OUTPUT
-          fi
-    outputs:
-      has_changed_files: ${{ steps.has_changed_files.outputs.has_changed_files }}
 
   build-artifact:
     needs: [detect-file-change]
     if: ${{ needs.detect-file-change.outputs.has_changed_files == 'true' || github.event_name == 'workflow_dispatch' }}
+    timeout-minutes: 60
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: 'true'
+      - name: Cache RISC-V toolchain
+        id: cache-toolchain
+        uses: actions/cache@v6
+        with:
+          path: ${{ github.workspace }}/toolchain
+          key: ${{ runner.os }}-${{ runner.arch }}-riscv-toolchain-${{ hashFiles('.ci/riscv-toolchain-install.sh') }}
       - name: Install dependencies
         run: |
-          sudo apt-get update -q=2
-          sudo apt-get upgrade -q=2
-          sudo apt-get install -q=2 gcc-multilib g++-multilib scons
-          .ci/riscv-toolchain-install.sh
+          .ci/apt-install.sh gcc-multilib g++-multilib scons
+          if [ "${{ steps.cache-toolchain.outputs.cache-hit }}" != "true" ]; then
+            .ci/riscv-toolchain-install.sh
+          fi
           echo "$PWD/toolchain/bin" >> $GITHUB_PATH
       - name: Build binaries
         run: |
@@ -72,20 +74,11 @@ jobs:
           mv build/sha1sum-riscv32 /tmp
           mv build/linux-x86-softfp build/riscv32 /tmp/rv32emu-prebuilt
       - name: Create tarball
-        run: |
-          cd /tmp
-          tar -zcvf rv32emu-prebuilt.tar.gz rv32emu-prebuilt
+        run: tar -zcf /tmp/rv32emu-prebuilt.tar.gz -C /tmp rv32emu-prebuilt
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.RV32EMU_PREBUILT_TOKEN }}
+        working-directory: /tmp
         run: |
-          RELEASE_TAG="$(date +'%Y.%m.%d')-$(git rev-parse --short HEAD)-ELF"
-          cd /tmp
-          gh release create --latest=false $RELEASE_TAG \
-            --repo sysprog21/rv32emu-prebuilt \
-            --title "$RELEASE_TAG"
-          gh release upload $RELEASE_TAG \
-            rv32emu-prebuilt.tar.gz \
-            sha1sum-linux-x86-softfp \
-            sha1sum-riscv32 \
-            --repo sysprog21/rv32emu-prebuilt
+          ${{ github.workspace }}/.ci/publish-prebuilt.sh ELF \
+            rv32emu-prebuilt.tar.gz sha1sum-linux-x86-softfp sha1sum-riscv32

--- a/.github/workflows/build-linux-artifacts.yml
+++ b/.github/workflows/build-linux-artifacts.yml
@@ -10,12 +10,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   detect-file-change:
     runs-on: ubuntu-24.04
+    outputs:
+      has_changed_linux_image_version: ${{ steps.has_changed_files.outputs.has_changed_linux_image_version }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: 'true'
       - name: Test file change of Linux image
@@ -49,42 +54,30 @@ jobs:
           else
             echo "has_changed_linux_image_version=false" >> $GITHUB_OUTPUT
           fi
-    outputs:
-      has_changed_linux_image_version: ${{ steps.has_changed_files.outputs.has_changed_linux_image_version }}
 
   build-linux-image-artifact:
     needs: [detect-file-change]
     if: ${{ needs.detect-file-change.outputs.has_changed_linux_image_version == 'true' || github.event_name == 'workflow_dispatch' }}
+    timeout-minutes: 120  # a full Buildroot run from scratch
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: 'true'
       - name: Install dependencies
-        run: |
-          sudo apt-get update -q=2
-          sudo apt-get upgrade -q=2
-          sudo apt-get install -q=2 build-essential git
+        run: .ci/apt-install.sh build-essential git
       - name: Build Linux image
         run: |
           make build-linux-image
           make system_defconfig
           make artifact ENABLE_PREBUILT=0
       - name: Create tarball
-        run: |
-          cd /tmp
-          tar -zcvf rv32emu-linux-image-prebuilt.tar.gz rv32emu-linux-image-prebuilt
+        run: tar -zcf /tmp/rv32emu-linux-image-prebuilt.tar.gz -C /tmp rv32emu-linux-image-prebuilt
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.RV32EMU_PREBUILT_TOKEN }}
+        working-directory: /tmp
         run: |
-          RELEASE_TAG="$(date +'%Y.%m.%d')-$(git rev-parse --short HEAD)-Linux-Image"
-          cd /tmp
-          gh release create --latest=false $RELEASE_TAG \
-            --repo sysprog21/rv32emu-prebuilt \
-            --title "$RELEASE_TAG"
-          gh release upload $RELEASE_TAG \
-            rv32emu-linux-image-prebuilt.tar.gz \
-            sha1sum-linux-image \
-            --repo sysprog21/rv32emu-prebuilt
+          ${{ github.workspace }}/.ci/publish-prebuilt.sh Linux-Image \
+            rv32emu-linux-image-prebuilt.tar.gz sha1sum-linux-image

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze (c-cpp)
+    timeout-minutes: 45
     runs-on: ubuntu-24.04
     permissions:
       security-events: write
@@ -28,14 +29,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         submodules: 'true'
 
     - name: Install dependencies
-      run: |
-        sudo apt-get update -q=2
-        sudo apt-get install -q=2 libsdl2-dev libsdl2-mixer-dev
+      run: .ci/apt-install.sh libsdl2-dev libsdl2-mixer-dev
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4
@@ -43,6 +42,9 @@ jobs:
         languages: c-cpp
         build-mode: manual
 
+    # No build cache here on purpose: CodeQL only sees the translation units
+    # that actually compile during this step, so restored objects would shrink
+    # the database instead of speeding it up.
     - name: Build
       run: |
         make defconfig

--- a/.github/workflows/deploy-wasm.yml
+++ b/.github/workflows/deploy-wasm.yml
@@ -7,8 +7,6 @@ on:
     types:
       - closed
   workflow_dispatch:
-    branches:
-      - master
   repository_dispatch:   # listening to rv32emu-prebuilt events
     types: [deploy_user_wasm, deploy_system_wasm]
 
@@ -16,23 +14,26 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false  # Don't cancel deployments
 
+permissions:
+  contents: read
+
 jobs:
-  wasm-system-deploy:
-    if: github.event.pull_request.merged == true ||
-        github.event_name == 'workflow_dispatch' ||
-        github.event_name == 'repository_dispatch' && github.event.action == 'deploy_system_wasm'
+  # Resolve both file sets once, so each deploy job carries a single condition
+  # instead of repeating it on every step.
+  # Only the merge path needs a file diff. On workflow_dispatch and
+  # repository_dispatch there is no base commit to diff against, and
+  # changed-files errors out; those events deploy unconditionally anyway.
+  detect-file-changes:
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-24.04
+    outputs:
+      system: ${{ steps.system.outputs.any_modified }}
+      user: ${{ steps.user.outputs.any_modified }}
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v6
-        with:
-          submodules: 'true'
-      - name: install-dependencies
-        run: |
-              sudo apt-get update -q=2
-              sudo apt-get install -q=2 curl device-tree-compiler
-      - name: Verify if the JS or HTML files has been modified
-        id: changed-files
+        uses: actions/checkout@v7
+      - name: Verify if the system emulation files have been modified
+        id: system
         uses: tj-actions/changed-files@v47
         with:
           files: |
@@ -44,6 +45,10 @@ jobs:
               mk/wasm.mk
               configs/wasm_defconfig
               tools/detect-env.py
+              # Helper scripts the deploy job runs
+              .ci/wasm-build.sh
+              .ci/fetch-artifacts.sh
+              .ci/emsdk-warm-cache.sh
               # rootfs overlay tooling (S99automount auto-mounts /dev/vda)
               tools/cpio-inject.py
               tools/rootfs-automount.sh
@@ -55,160 +60,8 @@ jobs:
               src/emulate.c
               src/rv32_template.c
               src/rv32_constopt.c
-      - name: install emcc
-        if: ${{ steps.changed-files.outputs.any_modified == 'true' ||
-            github.event_name == 'workflow_dispatch' ||
-            (github.event_name == 'repository_dispatch' && github.event.action == 'deploy_system_wasm') }}
-        run: |
-            git clone https://github.com/emscripten-core/emsdk -b 3.1.51
-            cd emsdk
-            # Pin to the same version as the emsdk tag. `install latest`
-            # would otherwise drift; newer Emscripten releases tightened the
-            # port-cache lock and broke `make -j` builds here.
-            ./emsdk install 3.1.51
-            ./emsdk activate 3.1.51
-            source ./emsdk_env.sh
-            # Propagate emsdk env to subsequent steps (each `run:` is a fresh
-            # shell). One dir per line per GitHub Actions docs; non-PATH vars
-            # (EM_CONFIG, EMSDK_NODE) ensure emcc finds its .emscripten config
-            # and bundled node without relying on relative-path auto-discovery.
-            #
-            # Only propagate values that are set and non-empty: emsdk
-            # 3.1.51's emsdk_env.sh does not export EM_CONFIG / EMSDK_PYTHON.
-            # Writing them empty to $GITHUB_ENV would override emcc's
-            # $HOME/.emscripten fallback with "", which emcc resolves to '.'
-            # and reports as "config file not found".
-            for var in EMSDK EM_CONFIG EMSDK_NODE EMSDK_PYTHON; do
-              val="${!var}"
-              [ -n "$val" ] && printf '%s=%s\n' "$var" "$val" >> "$GITHUB_ENV"
-            done
-            {
-              echo "$EMSDK"
-              echo "$EMSDK/upstream/emscripten"
-            } >> $GITHUB_PATH
-        shell: bash
-      - name: fetch artifact
-        if: ${{ steps.changed-files.outputs.any_modified == 'true' ||
-            github.event_name == 'workflow_dispatch' ||
-            (github.event_name == 'repository_dispatch' && github.event.action == 'deploy_system_wasm') }}
-        # GH_TOKEN authenticates the parse-time fetch-releases-tag call in
-        # mk/artifact.mk so the GitHub API request escapes the 60 req/hr
-        # anonymous (IP-shared) limit and stops flaking when several
-        # merges land back-to-back.
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-              make artifact ENABLE_SYSTEM=1
-      # Populate the SDL2 / SDL2_mixer port cache serially. Without this,
-      # concurrent first-time port generation under `make -j` trips
-      # emscripten's nested-lock assertion on libSDL2.a. The link-time
-      # warmup alone is not enough on emsdk 3.1.51: building sdl2_mixer
-      # spawns one emcc -c subprocess per .c file with -sUSE_SDL=2, each
-      # of which tries to build the sdl2 port while the parent emcc still
-      # holds the cache lock and has exported EM_CACHE_IS_LOCKED=1 into
-      # the subprocess environment, tripping cache.py's assertion. Run
-      # embuilder up front to put sdl2 (and the -pthread/-mt variants) in
-      # the cache so those subprocess port lookups are hits.
-      - name: warm emscripten port cache
-        if: ${{ steps.changed-files.outputs.any_modified == 'true' ||
-            github.event_name == 'workflow_dispatch' ||
-            (github.event_name == 'repository_dispatch' && github.event.action == 'deploy_system_wasm') }}
-        run: |
-            embuilder build sdl2 sdl2-mt libmimalloc libmimalloc-mt
-            echo 'int main(void){return 0;}' > /tmp/warmup.c
-            # Link (not just compile) so sysroot libraries that materialize at
-            # link time (e.g. libmimalloc) are populated too.
-            emcc -sSTRICT=0 -sUSE_SDL=2 -sUSE_SDL_MIXER=2 \
-                 -sSDL2_MIXER_FORMATS=wav,mid -sMALLOC=mimalloc -pthread \
-                 -O2 /tmp/warmup.c -o /tmp/warmup.js
-      # Note: wasm_defconfig sets CONFIG_BUILD_WASM=y which auto-selects CC=emcc
-      - name: build with emcc and move application files to /tmp
-        if: ${{ steps.changed-files.outputs.any_modified == 'true' ||
-            github.event_name == 'workflow_dispatch' ||
-            (github.event_name == 'repository_dispatch' && github.event.action == 'deploy_system_wasm') }}
-        run: |
-            make wasm_defconfig
-            make ENABLE_SYSTEM=1 ENABLE_GOLDFISH_RTC=1 -j
-            make assets/wasm/vendor/xterm.min.js assets/wasm/vendor/xterm.min.css
-            # Build the rootfs overlay (S99automount) and concatenate it with
-            # the upstream rootfs.cpio so the guest mounts /dev/vda at boot.
-            make build/linux-image/rootfs.web.cpio ENABLE_SYSTEM=1
-            mkdir /tmp/rv32emu-system-demo
-            cp assets/wasm/html/system.html /tmp/rv32emu-system-demo/index.html
-            cp assets/wasm/js/coi-serviceworker.min.js /tmp/rv32emu-system-demo/
-            cp assets/wasm/vendor/xterm.min.js /tmp/rv32emu-system-demo/
-            cp assets/wasm/vendor/xterm.min.css /tmp/rv32emu-system-demo/
-            cp build/rv32emu.js /tmp/rv32emu-system-demo/
-            cp build/rv32emu.wasm /tmp/rv32emu-system-demo/
-            cp build/rv32emu.worker.js /tmp/rv32emu-system-demo/ || true
-            cp build/linux-image/Image /tmp/rv32emu-system-demo/
-            # Ship the extended rootfs (with S99automount) as rootfs.cpio
-            cp build/linux-image/rootfs.web.cpio /tmp/rv32emu-system-demo/rootfs.cpio
-            ls -al /tmp/rv32emu-system-demo
-      - name: Check out the rv32emu-system-demo repo
-        if: ${{ steps.changed-files.outputs.any_modified == 'true' ||
-            github.event_name == 'workflow_dispatch' ||
-            (github.event_name == 'repository_dispatch' && github.event.action == 'deploy_system_wasm') }}
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
-          repository: sysprog21/rv32emu-demo
-      - name: Create local changes
-        if: ${{ steps.changed-files.outputs.any_modified == 'true' ||
-            github.event_name == 'workflow_dispatch' ||
-            (github.event_name == 'repository_dispatch' && github.event.action == 'deploy_system_wasm') }}
-        run: |
-            mkdir -p system
-            mv /tmp/rv32emu-system-demo/index.html ./system
-            mv /tmp/rv32emu-system-demo/coi-serviceworker.min.js ./system
-            mv /tmp/rv32emu-system-demo/xterm.min.js ./system
-            mv /tmp/rv32emu-system-demo/xterm.min.css ./system
-            mv /tmp/rv32emu-system-demo/rv32emu.js ./system
-            mv /tmp/rv32emu-system-demo/rv32emu.wasm ./system
-            mv /tmp/rv32emu-system-demo/rv32emu.worker.js ./system || true
-            mv /tmp/rv32emu-system-demo/Image ./system
-            mv /tmp/rv32emu-system-demo/rootfs.cpio ./system
-      - name: Commit files
-        id: commit
-        if: ${{ steps.changed-files.outputs.any_modified == 'true' ||
-            github.event_name == 'workflow_dispatch' ||
-            (github.event_name == 'repository_dispatch' && github.event.action == 'deploy_system_wasm') }}
-        run: |
-            git config --local user.email "github-actions[bot]@users.noreply.github.com"
-            git config --local user.name "github-actions[bot]"
-            git add system/
-            if git diff --cached --quiet; then
-              echo "committed=false" >> $GITHUB_OUTPUT
-            else
-              git commit -m "Add changes to system emulation"
-              echo "committed=true" >> $GITHUB_OUTPUT
-            fi
-      - name: Push changes
-        if: steps.commit.outputs.committed == 'true'
-        uses: ad-m/github-push-action@master
-        with:
-          repository: sysprog21/rv32emu-demo
-          github_token: ${{ secrets.RV32EMU_DEMO_TOKEN }}
-          branch: main
-  wasm-user-deploy:
-    needs: wasm-system-deploy # run jobs sequentially since two jobs operate on same repository: rv32emu-demo
-    if: |
-      !cancelled() && (
-        needs.wasm-system-deploy.result == 'success' ||
-        (needs.wasm-system-deploy.result == 'skipped' && github.event_name == 'repository_dispatch' && github.event.action == 'deploy_user_wasm')
-      )
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v6
-        with:
-          submodules: 'true'
-      - name: install-dependencies
-        run: |
-              sudo apt-get update -q=2
-              sudo apt-get install -q=2 curl device-tree-compiler
-      - name: Verify if the JS or HTML or ELF executable files has been modified
-        id: changed-files
+      - name: Verify if the user emulation files have been modified
+        id: user
         uses: tj-actions/changed-files@v47
         with:
           files: |
@@ -224,148 +77,136 @@ jobs:
               mk/wasm.mk
               configs/wasm_defconfig
               tools/detect-env.py
+              # Helper scripts the deploy job runs
+              .ci/wasm-build.sh
+              .ci/fetch-artifacts.sh
+              .ci/emsdk-warm-cache.sh
               # Files below may have a potential performance impact (reference from benchmark.yml)
               src/riscv.c
               src/decode.c
               src/emulate.c
               src/rv32_template.c
               src/rv32_constopt.c
-      - name: install emcc
-        if: ${{ steps.changed-files.outputs.any_modified == 'true' ||
-            github.event_name == 'workflow_dispatch' ||
-            (github.event_name == 'repository_dispatch' && github.event.action == 'deploy_user_wasm') }}
-        run: |
-            git clone https://github.com/emscripten-core/emsdk -b 3.1.51
-            cd emsdk
-            # Pin to the same version as the emsdk tag. `install latest`
-            # would otherwise drift; newer Emscripten releases tightened the
-            # port-cache lock and broke `make -j` builds here.
-            ./emsdk install 3.1.51
-            ./emsdk activate 3.1.51
-            source ./emsdk_env.sh
-            # Propagate emsdk env to subsequent steps (each `run:` is a fresh
-            # shell). One dir per line per GitHub Actions docs; non-PATH vars
-            # (EM_CONFIG, EMSDK_NODE) ensure emcc finds its .emscripten config
-            # and bundled node without relying on relative-path auto-discovery.
-            #
-            # Only propagate values that are set and non-empty: emsdk
-            # 3.1.51's emsdk_env.sh does not export EM_CONFIG / EMSDK_PYTHON.
-            # Writing them empty to $GITHUB_ENV would override emcc's
-            # $HOME/.emscripten fallback with "", which emcc resolves to '.'
-            # and reports as "config file not found".
-            for var in EMSDK EM_CONFIG EMSDK_NODE EMSDK_PYTHON; do
-              val="${!var}"
-              [ -n "$val" ] && printf '%s=%s\n' "$var" "$val" >> "$GITHUB_ENV"
-            done
-            {
-              echo "$EMSDK"
-              echo "$EMSDK/upstream/emscripten"
-            } >> $GITHUB_PATH
-        shell: bash
-      - name: fetch artifact
-        if: ${{ steps.changed-files.outputs.any_modified == 'true' ||
-            github.event_name == 'workflow_dispatch' ||
-            (github.event_name == 'repository_dispatch' && github.event.action == 'deploy_user_wasm') }}
-        # GH_TOKEN authenticates the parse-time fetch-releases-tag call in
-        # mk/artifact.mk so the GitHub API request escapes the 60 req/hr
-        # anonymous (IP-shared) limit and stops flaking when several
-        # merges land back-to-back.
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-              make artifact
-              # get from rv32emu-prebuilt
-              .ci/fetch.sh -o build/shareware_doom_iwad.zip "https://raw.githubusercontent.com/sysprog21/rv32emu-prebuilt/doom-artifact/shareware_doom_iwad.zip"
-              unzip -o -d build/ build/shareware_doom_iwad.zip
-      # Populate the SDL2 / SDL2_mixer port cache serially. Without this,
-      # concurrent first-time port generation under `make -j` trips
-      # emscripten's nested-lock assertion on libSDL2.a. See the matching
-      # comment on the system-deploy warmup step for the root-cause
-      # explanation; embuilder seeds the sdl2 / sdl2-mt / mimalloc cache
-      # entries so per-file sdl2_mixer compile subprocesses don't try to
-      # re-acquire the cache lock the parent emcc already holds.
-      - name: warm emscripten port cache
-        if: ${{ steps.changed-files.outputs.any_modified == 'true' ||
-            github.event_name == 'workflow_dispatch' ||
-            (github.event_name == 'repository_dispatch' && github.event.action == 'deploy_user_wasm') }}
-        run: |
-            embuilder build sdl2 sdl2-mt libmimalloc libmimalloc-mt
-            echo 'int main(void){return 0;}' > /tmp/warmup.c
-            # Link (not just compile) so sysroot libraries that materialize at
-            # link time (e.g. libmimalloc) are populated too.
-            emcc -sSTRICT=0 -sUSE_SDL=2 -sUSE_SDL_MIXER=2 \
-                 -sSDL2_MIXER_FORMATS=wav,mid -sMALLOC=mimalloc -pthread \
-                 -O2 /tmp/warmup.c -o /tmp/warmup.js
-      # Note: wasm_defconfig sets CONFIG_BUILD_WASM=y which auto-selects CC=emcc
-      - name: build with emcc and move application files to /tmp
-        if: ${{ steps.changed-files.outputs.any_modified == 'true' ||
-            github.event_name == 'workflow_dispatch' ||
-            (github.event_name == 'repository_dispatch' && github.event.action == 'deploy_user_wasm') }}
-        run: |
-            make wasm_defconfig
-            make -j
-            make assets/wasm/vendor/xterm.min.js assets/wasm/vendor/xterm.min.css
-            # Bundle the timidity instrument set once as tar and once as
-            # tar.gz. Browsers with DecompressionStream use the smaller gzip
-            # payload; older Safari/Firefox fall back to the plain tar.
-            tar -cf build/timidity.tar -C build/timidity .
-            gzip -9 -c build/timidity.tar > build/timidity.tar.gz
-            mkdir /tmp/rv32emu-demo
-            # Landing page goes to the repo root; user-mode assets to /user/
-            cp assets/wasm/html/demo-index.html /tmp/rv32emu-demo/landing.html
-            cp assets/wasm/html/user.html /tmp/rv32emu-demo/index.html
-            cp assets/wasm/js/coi-serviceworker.min.js /tmp/rv32emu-demo/
-            cp assets/wasm/vendor/xterm.min.js /tmp/rv32emu-demo/
-            cp assets/wasm/vendor/xterm.min.css /tmp/rv32emu-demo/
-            cp build/elf_list.js /tmp/rv32emu-demo/
-            cp build/rv32emu.js /tmp/rv32emu-demo/
-            cp build/rv32emu.wasm /tmp/rv32emu-demo/
-            cp build/rv32emu.worker.js /tmp/rv32emu-demo/ || true
-            # Large game-data assets fetched on demand by user.html
-            cp build/DOOM1.WAD /tmp/rv32emu-demo/
-            cp build/id1/pak0.pak /tmp/rv32emu-demo/
-            cp build/timidity.tar /tmp/rv32emu-demo/
-            cp build/timidity.tar.gz /tmp/rv32emu-demo/
-            ls -al /tmp/rv32emu-demo
+
+  wasm-system-deploy:
+    needs: [detect-file-changes]
+    # !cancelled() keeps this reachable when detect-file-changes is skipped (a
+    # dispatch event) or fails. Without a status function the default rule
+    # skips every dependent job, which would silently cancel a deploy that was
+    # asked for explicitly.
+    if: >
+      !cancelled() && (
+        (github.event.pull_request.merged == true && needs.detect-file-changes.outputs.system == 'true') ||
+        github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'repository_dispatch' && github.event.action == 'deploy_system_wasm')
+      )
+    timeout-minutes: 60
+    runs-on: ubuntu-24.04
+    # GH_TOKEN authenticates the parse-time fetch-releases-tag call in
+    # mk/artifact.mk so the GitHub API request escapes the 60 req/hr
+    # anonymous (IP-shared) limit and stops flaking when several merges land
+    # back-to-back.
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v7
+        with:
+          submodules: 'true'
+      - name: Install dependencies
+        run: .ci/apt-install.sh curl device-tree-compiler
+      # Pinned to the emsdk tag: newer Emscripten releases tightened the
+      # port-cache lock and broke "make -j" builds here.
+      - name: Set up emsdk
+        uses: mymindstorm/setup-emsdk@v16
+        with:
+          version: 3.1.51
+          actions-cache-folder: 'emsdk-cache'
+      - name: Fetch artifact
+        run: .ci/fetch-artifacts.sh linux-image
+      - name: Warm emscripten port cache
+        run: .ci/emsdk-warm-cache.sh
+      - name: Build system emulation demo
+        run: .ci/wasm-build.sh system
       - name: Check out the rv32emu-demo repo
-        if: ${{ steps.changed-files.outputs.any_modified == 'true' ||
-            github.event_name == 'workflow_dispatch' ||
-            (github.event_name == 'repository_dispatch' && github.event.action == 'deploy_user_wasm') }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
           repository: sysprog21/rv32emu-demo
       - name: Create local changes
-        if: ${{ steps.changed-files.outputs.any_modified == 'true' ||
-            github.event_name == 'workflow_dispatch' ||
-            (github.event_name == 'repository_dispatch' && github.event.action == 'deploy_user_wasm') }}
         run: |
-            # Migration: previous deploys placed user-mode assets at the repo
-            # root. Remove those stale files so the unified layout (landing
-            # page at /, user mode at /user/, system mode at /system/) is
-            # consistent. Use -f so the step is idempotent on subsequent runs.
+            mkdir -p system
+            mv /tmp/rv32emu-system-demo/* ./system/
+      - name: Commit files
+        id: commit
+        run: |
+            git config --local user.email "github-actions[bot]@users.noreply.github.com"
+            git config --local user.name "github-actions[bot]"
+            git add system/
+            if git diff --cached --quiet; then
+              echo "committed=false" >> $GITHUB_OUTPUT
+            else
+              git commit -m "Add changes to system emulation"
+              echo "committed=true" >> $GITHUB_OUTPUT
+            fi
+      - name: Push changes
+        if: steps.commit.outputs.committed == 'true'
+        uses: ad-m/github-push-action@v1.3.0
+        with:
+          repository: sysprog21/rv32emu-demo
+          github_token: ${{ secrets.RV32EMU_DEMO_TOKEN }}
+          branch: main
+
+  wasm-user-deploy:
+    # Sequential with the system job: both push to the same demo repository.
+    # "skipped" is not a failure here, a merge may touch only one of the two.
+    needs: [detect-file-changes, wasm-system-deploy]
+    if: >
+      !cancelled() && needs.wasm-system-deploy.result != 'failure' && (
+        (github.event.pull_request.merged == true && needs.detect-file-changes.outputs.user == 'true') ||
+        github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'repository_dispatch' && github.event.action == 'deploy_user_wasm')
+      )
+    timeout-minutes: 60
+    runs-on: ubuntu-24.04
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v7
+        with:
+          submodules: 'true'
+      - name: Install dependencies
+        run: .ci/apt-install.sh curl device-tree-compiler
+      - name: Set up emsdk
+        uses: mymindstorm/setup-emsdk@v16
+        with:
+          version: 3.1.51
+          actions-cache-folder: 'emsdk-cache'
+      - name: Fetch artifact
+        run: .ci/fetch-artifacts.sh elf doom
+      - name: Warm emscripten port cache
+        run: .ci/emsdk-warm-cache.sh
+      - name: Build user emulation demo
+        run: .ci/wasm-build.sh user
+      - name: Check out the rv32emu-demo repo
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
+          repository: sysprog21/rv32emu-demo
+      - name: Create local changes
+        run: |
+            # Migration: earlier deploys placed user-mode assets at the repo
+            # root. Drop the stale copies so the layout stays consistent
+            # (landing page at /, user mode at /user/, system at /system/).
             rm -f navigation.html coi-serviceworker.min.js xterm.min.js \
                   xterm.min.css elf_list.js rv32emu.js rv32emu.wasm \
                   rv32emu.worker.js
             mkdir -p user
             mv /tmp/rv32emu-demo/landing.html ./index.html
-            mv /tmp/rv32emu-demo/index.html ./user/
-            mv /tmp/rv32emu-demo/coi-serviceworker.min.js ./user/
-            mv /tmp/rv32emu-demo/xterm.min.js ./user/
-            mv /tmp/rv32emu-demo/xterm.min.css ./user/
-            mv /tmp/rv32emu-demo/elf_list.js ./user/
-            mv /tmp/rv32emu-demo/rv32emu.js ./user/
-            mv /tmp/rv32emu-demo/rv32emu.wasm ./user/
-            mv /tmp/rv32emu-demo/rv32emu.worker.js ./user/ || true
-            mv /tmp/rv32emu-demo/DOOM1.WAD ./user/
-            mv /tmp/rv32emu-demo/pak0.pak ./user/
-            mv /tmp/rv32emu-demo/timidity.tar ./user/
-            mv /tmp/rv32emu-demo/timidity.tar.gz ./user/
+            mv /tmp/rv32emu-demo/* ./user/
       - name: Commit files
         id: commit
-        if: ${{ steps.changed-files.outputs.any_modified == 'true' ||
-            github.event_name == 'workflow_dispatch' ||
-            (github.event_name == 'repository_dispatch' && github.event.action == 'deploy_user_wasm') }}
         run: |
             git config --local user.email "github-actions[bot]@users.noreply.github.com"
             git config --local user.name "github-actions[bot]"
@@ -378,7 +219,7 @@ jobs:
             fi
       - name: Push changes
         if: steps.commit.outputs.committed == 'true'
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@v1.3.0
         with:
           repository: sysprog21/rv32emu-demo
           github_token: ${{ secrets.RV32EMU_DEMO_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,20 +6,24 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   detect-code-related-file-changes:
     runs-on: ubuntu-24.04
     outputs:
-      has_code_related_changes: ${{ steps.set_has_code_related_changes.outputs.has_code_related_changes }}
+      has_code_related_changes: ${{ steps.changed-files.outputs.any_changed }}
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Test changed files
         id: changed-files
         uses: tj-actions/changed-files@v47
         with:
           files: |
               .ci/**
+              .github/actions/**
               .github/workflows/**
               build/**
               configs/**
@@ -31,23 +35,54 @@ jobs:
               .clang-format
               Dockerfile
               Makefile
-              # Build system configuration
-              mk/kconfig.mk
-              mk/toolchain.mk
-              tools/detect-env.py
-      - name: Set has_code_related_changes
-        id: set_has_code_related_changes
-        run: |
-          if [[ ${{ steps.changed-files.outputs.any_changed }} == true ]]; then
-            echo "has_code_related_changes=true" >> $GITHUB_OUTPUT
-          else
-            echo "has_code_related_changes=false" >> $GITHUB_OUTPUT
-          fi
 
-  host-x64:
+  # Emscripten output is platform independent, so it is built once on x64
+  # rather than in every host matrix leg.
+  wasm-build:
+    name: emcc build
     needs: [detect-code-related-file-changes]
     if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
-    timeout-minutes: 60
+    timeout-minutes: 30
+    runs-on: ubuntu-24.04
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: 'true'
+
+      - name: Set up build environment
+        uses: ./.github/actions/setup-build
+        with:
+          llvm: 'false'
+          # No artifact prefetch: the build steps below open with "make
+          # distclean", which would throw away anything downloaded here.
+
+      - name: Set up emsdk
+        uses: mymindstorm/setup-emsdk@v16
+        with:
+          version: 3.1.51
+          actions-cache-folder: 'emsdk-cache'
+
+      # Note: wasm_defconfig sets CONFIG_BUILD_WASM=y which auto-selects CC=emcc
+      - name: Build user emulation
+        run: |
+              make distclean
+              make wasm_defconfig
+              .ci/emsdk-warm-cache.sh
+              make $PARALLEL
+
+      - name: Build system emulation
+        run: |
+              make distclean
+              make wasm_defconfig
+              make ENABLE_SYSTEM=1 ENABLE_GOLDFISH_RTC=1 $PARALLEL
+
+  host-x64:
+    name: x64 ${{ matrix.compiler }}
+    needs: [detect-code-related-file-changes]
+    if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -56,177 +91,26 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         submodules: 'true'
 
-    - name: Read LLVM Version
-      id: llvm-version
-      run: echo "version=$(cat .ci/llvm-version)" >> $GITHUB_OUTPUT
-
-    - name: Cache LLVM
-      id: cache-llvm
-      uses: actions/cache@v5
-      with:
-        path: /usr/lib/llvm-${{ steps.llvm-version.outputs.version }}
-        key: ${{ runner.os }}-${{ runner.arch }}-llvm-${{ steps.llvm-version.outputs.version }}
-
-    - name: Cache RISC-V Toolchain
-      id: cache-toolchain
-      uses: actions/cache@v5
-      with:
-        path: ${{ github.workspace }}/toolchain
-        key: ${{ runner.os }}-${{ runner.arch }}-riscv-toolchain-${{ hashFiles('.ci/riscv-toolchain-install.sh') }}
-
-    - name: Install dependencies
-      run: |
-            set +e  # Disable errexit
-            # Configure apt to tolerate mirror sync failures
-            sudo tee /etc/apt/apt.conf.d/99-ci-reliability > /dev/null << 'EOF'
-            APT::Update::Error-Mode "any";
-            Acquire::IndexTargets::deb::DEP-11::DefaultEnabled "false";
-            Acquire::IndexTargets::deb::DEP-11-icons::DefaultEnabled "false";
-            Acquire::IndexTargets::deb::DEP-11-icons-hidpi::DefaultEnabled "false";
-            Acquire::Retries "3";
-            Acquire::Check-Valid-Until "false";
-            EOF
-            # Update with error tolerance
-            sudo apt-get update -q=2 2>&1
-            UPDATE_EXIT=$?
-            if [ $UPDATE_EXIT -ne 0 ]; then
-              echo "WARNING: apt update exited with code $UPDATE_EXIT, continuing..."
-            fi
-            sudo apt-get install -q=2 curl wget lsb-release software-properties-common gnupg \
-                 libsdl2-dev libsdl2-mixer-dev device-tree-compiler expect bc p7zip-full
-            set -e  # Re-enable errexit
-      shell: bash
-
-    - name: Install RISC-V Toolchain
-      if: steps.cache-toolchain.outputs.cache-hit != 'true'
-      run: |
-            .ci/riscv-toolchain-install.sh
-
-    - name: Setup RISC-V Toolchain PATH
-      run: echo "${{ github.workspace }}/toolchain/bin" >> $GITHUB_PATH
-
-    - name: Install LLVM
-      if: steps.cache-llvm.outputs.cache-hit != 'true'
-      run: |
-            # LLVM is pinned in .ci/llvm-version. Ubuntu Noble's base repos cap
-            # at llvm-18, so anything newer (the current pin is 20+) requires
-            # apt.llvm.org. .ci/install-llvm.sh adds the apt source after
-            # verifying the signing key fingerprint matches the value pinned
-            # in that script (avoids sudo-executing an unpinned remote script).
-            VER='${{ steps.llvm-version.outputs.version }}'
-            sudo .ci/install-llvm.sh "${VER}"
-            sudo apt-get install -y -q=2 \
-                llvm-${VER} llvm-${VER}-dev llvm-${VER}-runtime \
-                clang-${VER} lld-${VER}
-
-    - name: Setup LLVM PATH
-      run: echo "/usr/lib/llvm-${{ steps.llvm-version.outputs.version }}/bin" >> $GITHUB_PATH
-
-    - name: Install compiler
-      id: install_cc
-      uses: rlalik/setup-cpp-compiler@master
+    - name: Set up build environment
+      id: setup
+      uses: ./.github/actions/setup-build
       with:
         compiler: ${{ matrix.compiler }}
-    - name: Setup emsdk
-      uses: mymindstorm/setup-emsdk@v14
-      with:
-        version: 3.1.51
-        actions-cache-folder: 'emsdk-cache'
-    - name: Set parallel jobs variable
-      run: |
-            echo "PARALLEL=-j$(nproc)" >> "$GITHUB_ENV"
-            echo "BOOT_LINUX_TEST=TMP_FILE=\$(mktemp "$RUNNER_TEMP/tmpfile.XXXXXX"); \
-                                  sudo env TMP_FILE=\${TMP_FILE} .ci/boot-linux-prepare.sh setup; \
-                                  . \${TMP_FILE}; \
-                                  .ci/boot-linux.sh; \
-                                  EXIT_CODE=\$?; \
-                                  sudo env TMP_FILE=\${TMP_FILE} BLK_DEV_EXT4=\${BLK_DEV_EXT4} \
-                                           BLK_DEV_SIMPLEFS=\${BLK_DEV_SIMPLEFS} .ci/boot-linux-prepare.sh cleanup; \
-                                  exit \${EXIT_CODE};" >> "$GITHUB_ENV"
-    - name: Cache build artifacts
-      uses: actions/cache@v5
-      with:
-        path: build/
-        key: rv32emu-artifacts-${{ runner.os }}-${{ hashFiles('mk/artifact.mk', 'mk/external.mk') }}
-        restore-keys: |
-          rv32emu-artifacts-${{ runner.os }}-
-
-    - name: Fetch artifacts
-      env:
-        CC: ${{ steps.install_cc.outputs.cc }}
-      run: |
-            . .ci/common.sh
-            fetch_artifact ELF
-            fetch_artifact Linux-Image ENABLE_SYSTEM=1
-            rm -f build/.config  # Clean config after ENABLE_SYSTEM=1 to prevent contamination
-            fetch_artifact sail ENABLE_ARCH_TEST=1
-            # get from rv32emu-prebuilt
-            .ci/fetch.sh -o build/shareware_doom_iwad.zip "https://raw.githubusercontent.com/sysprog21/rv32emu-prebuilt/doom-artifact/shareware_doom_iwad.zip"
-            unzip -o -d build/ build/shareware_doom_iwad.zip
-
-    # emcc builds run on x64 only - WebAssembly output is platform-independent
-    # This validates Emscripten compatibility without redundant builds on macOS
-    # Note: wasm_defconfig sets CONFIG_BUILD_WASM=y which auto-selects CC=emcc
-    #
-    # Emscripten's first parallel build of the SDL2/SDL2_mixer ports races on
-    # the internal cache lock (one emcc process spawns a child that tries to
-    # take the same lock its parent already holds). Pre-warm the cache with
-    # embuilder so the parallel make doesn't have to build the ports.
-    - name: default build using emcc
-      if: success()
-      run: |
-            make distclean
-            make wasm_defconfig
-            embuilder build sdl2 sdl2_mixer || true
-            make $PARALLEL
-
-    - name: default build for system emulation using emcc
-      if: success()
-      run: |
-            make distclean
-            make wasm_defconfig
-            embuilder build sdl2 sdl2_mixer || true
-            make ENABLE_SYSTEM=1 ENABLE_GOLDFISH_RTC=1 $PARALLEL
-            make distclean
+        riscv-toolchain: 'true'
+        artifacts: elf linux-image doom
+        cache-suffix: host-${{ matrix.compiler }}
 
     - name: Build with various optimization levels
-      if: success()
-      env:
-        CC: ${{ steps.install_cc.outputs.cc }}
-      run: |
-            set -euo pipefail
-            # Test boundary cases: -O0 (unoptimized), -O2 (standard), -Ofast (aggressive)
-            for opt_level in -O0 -O2 -Ofast; do
-              echo "Building with OPT_LEVEL=$opt_level"
-              if ! (make distclean && make defconfig && make OPT_LEVEL=$opt_level $PARALLEL); then
-                echo "ERROR: Build failed with OPT_LEVEL=$opt_level"
-                exit 1
-              fi
-            done
+      run: .ci/build-opt-levels.sh defconfig
 
     - name: Build system emulation with various optimization levels
-      if: success()
-      env:
-        CC: ${{ steps.install_cc.outputs.cc }}
-      run: |
-            set -euo pipefail
-            # Test boundary cases: -O0 (unoptimized), -O2 (standard), -Ofast (aggressive)
-            for opt_level in -O0 -O2 -Ofast; do
-              echo "Building system emulation with OPT_LEVEL=$opt_level"
-              if ! (make distclean && make system_defconfig && make OPT_LEVEL=$opt_level $PARALLEL); then
-                echo "ERROR: System emulation build failed with OPT_LEVEL=$opt_level"
-                exit 1
-              fi
-            done
+      run: .ci/build-opt-levels.sh system_defconfig
 
     - name: check + tests
-      if: success()
-      env:
-        CC: ${{ steps.install_cc.outputs.cc }}
       run: |
             make cleanconfig
             make defconfig
@@ -235,70 +119,26 @@ jobs:
             make misalign $PARALLEL
             make tool $PARALLEL
 
-    - name: core extension disable tests (interpreter + JIT)
-      if: success()
-      env:
-        CC: ${{ steps.install_cc.outputs.cc }}
-      run: |
-            set -euo pipefail
-            # Core extensions + bit manipulation + CSR/fence + performance features
-            # Tests both interpreter and JIT modes (12 × 2 = 24 builds)
-            # Consolidated from 25 separate builds (13 interpreter + 12 JIT)
-            # Use cleanconfig instead of distclean to preserve artifacts across iterations
-            for ext in ENABLE_EXT_M ENABLE_EXT_A ENABLE_EXT_F ENABLE_EXT_C \
-                       ENABLE_Zba ENABLE_Zbb ENABLE_Zbc ENABLE_Zbs \
-                       ENABLE_Zicsr ENABLE_Zifencei \
-                       ENABLE_MOP_FUSION ENABLE_BLOCK_CHAINING; do
-              echo "Testing ${ext}=0 (interpreter)"
-              if ! (make cleanconfig && make defconfig && make ${ext}=0 check $PARALLEL); then
-                echo "ERROR: Interpreter test failed with ${ext}=0"
-                exit 1
-              fi
-              echo "Testing ${ext}=0 (JIT)"
-              if ! (make cleanconfig && make jit_defconfig && make ${ext}=0 check $PARALLEL); then
-                echo "ERROR: JIT test failed with ${ext}=0"
-                exit 1
-              fi
-            done
-
     - name: SDL disable test
-      if: success()
-      env:
-        CC: ${{ steps.install_cc.outputs.cc }}
       run: |
-            # SDL is graphics subsystem, interpreter-only test sufficient
+            # SDL is the graphics subsystem; an interpreter-only test suffices.
             make distclean && make defconfig && make ENABLE_SDL=0 check $PARALLEL
 
     - name: misalignment test in block emulation
-      if: success()
-      env:
-        CC: ${{ steps.install_cc.outputs.cc }}
       run: |
             make -C tests/system/alignment/
             make distclean && make system_defconfig && make ENABLE_ELF_LOADER=1 ENABLE_EXT_C=0 misalign-in-blk-emu $PARALLEL
 
     - name: MMU test
-      if: success()
-      env:
-        CC: ${{ steps.install_cc.outputs.cc }}
       run: |
             make -C tests/system/mmu/
             make distclean && make system_defconfig && make ENABLE_ELF_LOADER=1 mmu-test $PARALLEL
 
     - name: gdbstub test
-      if: success()
-      env:
-        CC: ${{ steps.install_cc.outputs.cc }}
-      run: |
-            make distclean && make defconfig && make ENABLE_GDBSTUB=1 gdbstub-test $PARALLEL
+      run: make distclean && make defconfig && make ENABLE_GDBSTUB=1 gdbstub-test $PARALLEL
 
     - name: JIT base test
-      if: success()
-      env:
-        CC: ${{ steps.install_cc.outputs.cc }}
-      run: |
-            # Base JIT test (extension disable tests handled in consolidated step above)
-            make distclean && make jit_defconfig && make check $PARALLEL
+      run: make distclean && make jit_defconfig && make check $PARALLEL
 
     - name: undefined behavior test
       if: success() || failure()
@@ -306,20 +146,80 @@ jobs:
             make distclean && make defconfig && make ENABLE_UBSAN=1 check $PARALLEL
             make distclean && make jit_defconfig && make ENABLE_UBSAN=1 check $PARALLEL
 
-    # Boot tests moved to boot-tests-x64 job for parallel execution
+  # Each optional feature is independently switchable, so every one of them is
+  # built with the knob off. Split across runners because the serial run of all
+  # 24 builds dominated the job it used to live in.
+  host-x64-feature-disable:
+    name: x64 ${{ matrix.compiler }} feature disable (${{ matrix.group }})
+    needs: [detect-code-related-file-changes]
+    if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [gcc, clang]
+        group: [core, bitmanip-perf]   # .ci/test-ext-disable.sh owns the members
+    runs-on: ubuntu-24.04
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        submodules: 'true'
+
+    - name: Set up build environment
+      id: setup
+      uses: ./.github/actions/setup-build
+      with:
+        compiler: ${{ matrix.compiler }}
+        riscv-toolchain: 'true'
+        artifacts: elf
+        cache-suffix: feature-${{ matrix.compiler }}-${{ matrix.group }}
+
+    - name: Feature disable tests (interpreter + JIT)
+      run: .ci/test-ext-disable.sh ${{ matrix.group }}
+
+  # The architecture test is compiler agnostic: it validates the emulator
+  # against the Sail model, so a second host compiler adds runtime, not
+  # coverage. It is x64 only, since the macOS runners are the scarcest
+  # resource in this workflow and provide nothing the Linux run does not.
+  arch-test-x64:
+    name: RISC-V architecture test
+    needs: [detect-code-related-file-changes]
+    if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
+    timeout-minutes: 45
+    runs-on: ubuntu-24.04
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        submodules: 'true'
+
+    - name: Set up build environment
+      id: setup
+      uses: ./.github/actions/setup-build
+      with:
+        compiler: gcc
+        llvm: 'false'
+        riscv-toolchain: 'true'
+        # No artifact prefetch: riscv-tests.sh starts with "make distclean",
+        # so anything cached under build/ would be thrown away unread.
+
+    - name: Set up Python
+      uses: actions/setup-python@v7
+      with:
+        python-version: '3.12'
+        cache: 'pip'
+        cache-dependency-path: .ci/requirements.txt
 
     - name: Architecture test
-      if: success()
-      env:
-        CC: ${{ steps.install_cc.outputs.cc }}
-      run: |
-            . .ci/common.sh
-            export LATEST_RELEASE=$(fetch_latest_release sail)
-            .ci/riscv-tests.sh
+      run: .ci/riscv-tests.sh
 
-  # Parallel boot tests for x64 - runs interpreter, JIT, and T2C boot tests concurrently
-  # T2C runs only on clang since it uses LLVM
+  # Boot tests are the long pole of the workflow, so each configuration gets
+  # its own runner. T2C is clang only because it goes through LLVM.
   boot-tests-x64:
+    name: x64 ${{ matrix.compiler }} boot (${{ matrix.boot_type }})
     needs: [detect-code-related-file-changes]
     if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
     timeout-minutes: 40  # T2C boot ~30min + build ~3min + setup ~3min
@@ -356,96 +256,35 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         submodules: 'true'
 
-    - name: Read LLVM Version
-      if: matrix.compiler == 'clang'
-      id: llvm-version
-      run: echo "version=$(cat .ci/llvm-version)" >> $GITHUB_OUTPUT
-
-    # LLVM needed for all clang builds (llvm-ar required for LTO)
-    - name: Cache LLVM
-      if: matrix.compiler == 'clang'
-      id: cache-llvm
-      uses: actions/cache@v5
-      with:
-        path: /usr/lib/llvm-${{ steps.llvm-version.outputs.version }}
-        key: ${{ runner.os }}-${{ runner.arch }}-llvm-${{ steps.llvm-version.outputs.version }}
-
-    - name: Install dependencies
-      run: |
-            sudo apt-get update -q=2 || true
-            sudo apt-get install -q=2 curl wget lsb-release software-properties-common gnupg \
-                 libsdl2-dev libsdl2-mixer-dev device-tree-compiler expect bc p7zip-full e2fsprogs
-
-    - name: Install LLVM
-      if: matrix.compiler == 'clang' && steps.cache-llvm.outputs.cache-hit != 'true'
-      run: |
-            VER='${{ steps.llvm-version.outputs.version }}'
-            sudo .ci/install-llvm.sh "${VER}"
-            sudo apt-get install -y -q=2 \
-                llvm-${VER} llvm-${VER}-dev llvm-${VER}-runtime \
-                clang-${VER} lld-${VER}
-
-    - name: Setup LLVM PATH
-      if: matrix.compiler == 'clang'
-      run: echo "/usr/lib/llvm-${{ steps.llvm-version.outputs.version }}/bin" >> $GITHUB_PATH
-
-    - name: Install compiler
-      id: install_cc
-      uses: rlalik/setup-cpp-compiler@master
+    - name: Set up build environment
+      id: setup
+      uses: ./.github/actions/setup-build
       with:
         compiler: ${{ matrix.compiler }}
-
-    - name: Set parallel jobs variable
-      run: |
-            echo "PARALLEL=-j$(nproc)" >> "$GITHUB_ENV"
-            echo "BOOT_LINUX_TEST=TMP_FILE=\$(mktemp \"$RUNNER_TEMP/tmpfile.XXXXXX\"); \
-                                  sudo env TMP_FILE=\${TMP_FILE} .ci/boot-linux-prepare.sh setup; \
-                                  . \${TMP_FILE}; \
-                                  .ci/boot-linux.sh; \
-                                  EXIT_CODE=\$?; \
-                                  sudo env TMP_FILE=\${TMP_FILE} BLK_DEV_EXT4=\${BLK_DEV_EXT4} \
-                                           BLK_DEV_SIMPLEFS=\${BLK_DEV_SIMPLEFS} .ci/boot-linux-prepare.sh cleanup; \
-                                  exit \${EXIT_CODE};" >> "$GITHUB_ENV"
-
-    # Cache key includes matrix variables to prevent cross-contamination between parallel jobs
-    - name: Cache build artifacts
-      uses: actions/cache@v5
-      with:
-        path: build/
-        key: rv32emu-boot-${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.boot_type }}-${{ hashFiles('mk/artifact.mk', 'mk/external.mk') }}
-        restore-keys: |
-          rv32emu-boot-${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.boot_type }}-
-          rv32emu-artifacts-${{ runner.os }}-
-
-    - name: Fetch Linux artifacts
-      env:
-        CC: ${{ steps.install_cc.outputs.cc }}
-      run: |
-            . .ci/common.sh
-            fetch_artifact Linux-Image ENABLE_SYSTEM=1
-            rm -f build/.config
+        llvm: ${{ matrix.compiler == 'clang' }}
+        artifacts: linux-image
+        cache-suffix: boot-${{ matrix.compiler }}-${{ matrix.boot_type }}
 
     - name: boot Linux kernel test (${{ matrix.boot_type }})
       env:
-        CC: ${{ steps.install_cc.outputs.cc }}
         BOOT_TIMEOUT: ${{ matrix.timeout }}
       run: |
-            # For T2C, verify LLVM (pinned to .ci/llvm-version) was detected
-            if [ "${{ matrix.boot_type }}" = "t2c" ]; then
-              rm -f build/t2c.o
-            fi
+            # A stale object would mask a failed LLVM detection below.
+            rm -f build/t2c.o
             make distclean && make ${{ matrix.defconfig }} && make INITRD_SIZE=32 ${{ matrix.make_flags }} $PARALLEL && make artifact $PARALLEL
             if [ "${{ matrix.boot_type }}" = "t2c" ]; then
               test -f build/t2c.o || { echo "ERROR: T2C disabled (build/t2c.o missing) - LLVM $(cat .ci/llvm-version) detection failed"; exit 1; }
             fi
-            bash -c "${BOOT_LINUX_TEST}"
+            .ci/boot-linux-test.sh
 
   # Native AArch64 on GitHub ARM runners - fast, no QEMU overhead
+  # FIXME: gcc build fails on AArch64/Linux hosts, hence clang only
   host-arm64:
+    name: arm64 clang
     needs: [detect-code-related-file-changes]
     if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
     timeout-minutes: 45
@@ -454,79 +293,27 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - name: checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         submodules: 'true'
 
-    - name: Set LLVM version
-      run: echo "LLVM_VERSION=$(cat .ci/llvm-version)" >> $GITHUB_ENV
+    - name: Set up build environment
+      id: setup
+      uses: ./.github/actions/setup-build
+      with:
+        # Plain "clang" resolves through the LLVM bin directory this action
+        # prepends to PATH, so it is the pinned LLVM, not the distro's.
+        cc: clang
+        artifacts: elf linux-image
+        cache-suffix: host
 
-    - name: Install dependencies
-      run: |
-            # Configure apt to tolerate ARM mirror sync failures
-            sudo tee /etc/apt/apt.conf.d/99-ci-reliability > /dev/null << 'EOF'
-            APT::Update::Error-Mode "any";
-            Acquire::IndexTargets::deb::DEP-11::DefaultEnabled "false";
-            Acquire::IndexTargets::deb::DEP-11-icons::DefaultEnabled "false";
-            Acquire::IndexTargets::deb::DEP-11-icons-hidpi::DefaultEnabled "false";
-            Acquire::Retries "3";
-            Acquire::Check-Valid-Until "false";
-            EOF
-            # Update with error tolerance
-            sudo apt-get update -q=2 || {
-              echo "WARNING: apt update failed, continuing with cached indexes..."
-            }
-            # Install packages with retry for critical ones
-            sudo apt-get install -q=2 -y make curl wget libsdl2-dev libsdl2-mixer-dev \
-                 lsb-release software-properties-common gnupg bc device-tree-compiler expect p7zip-full e2fsprogs || {
-              echo "WARNING: Some packages failed, retrying critical ones..."
-              sudo apt-get install -q=2 -y --no-download make curl wget || true
-            }
-
-    - name: Install LLVM
-      run: |
-            sudo .ci/install-llvm.sh "${LLVM_VERSION}"
-            sudo apt-get install -y -q=2 \
-                llvm-${LLVM_VERSION} llvm-${LLVM_VERSION}-dev \
-                llvm-${LLVM_VERSION}-runtime \
-                clang-${LLVM_VERSION} lld-${LLVM_VERSION}
-
-    - name: Setup LLVM PATH
-      run: echo "/usr/lib/llvm-${LLVM_VERSION}/bin" >> $GITHUB_PATH
-
-    - name: Set parallel jobs variable
-      run: |
-            echo "PARALLEL=-j$(nproc)" >> "$GITHUB_ENV"
-            echo "BOOT_LINUX_TEST=TMP_FILE=\$(mktemp \"$RUNNER_TEMP/tmpfile.XXXXXX\"); \
-                                  sudo env TMP_FILE=\${TMP_FILE} .ci/boot-linux-prepare.sh setup; \
-                                  . \${TMP_FILE}; \
-                                  .ci/boot-linux.sh; \
-                                  EXIT_CODE=\$?; \
-                                  sudo env TMP_FILE=\${TMP_FILE} BLK_DEV_EXT4=\${BLK_DEV_EXT4} \
-                                           BLK_DEV_SIMPLEFS=\${BLK_DEV_SIMPLEFS} .ci/boot-linux-prepare.sh cleanup; \
-                                  exit \${EXIT_CODE};" >> "$GITHUB_ENV"
-
-    - name: Fetch artifacts
-      env:
-        CC: clang-${{ env.LLVM_VERSION }}
-      run: |
-            . .ci/common.sh
-            fetch_artifact ELF
-            fetch_artifact Linux-Image ENABLE_SYSTEM=1
-            rm -f build/.config  # Clean config after ENABLE_SYSTEM=1 to prevent contamination
-
-    # FIXME: gcc build fails on AArch64/Linux hosts
     - name: check + tests
-      env:
-        CC: clang-${{ env.LLVM_VERSION }}
       run: |
             make cleanconfig
             make defconfig
             make check $PARALLEL
 
     - name: JIT tests
-      env:
-        CC: clang-${{ env.LLVM_VERSION }}
       run: |
             set -euo pipefail
             make distclean && make jit_defconfig && make check $PARALLEL
@@ -536,24 +323,21 @@ jobs:
             done
 
     - name: boot Linux kernel test (T2C)
-      if: success()
       env:
-        CC: clang-${{ env.LLVM_VERSION }}
         BOOT_TIMEOUT: 120  # T2C with O1 optimization (via defconfig) is faster than O3
       run: |
-            # Remove stale t2c.o before build to ensure fresh detection
+            # A stale object would mask a failed LLVM detection below.
             rm -f build/t2c.o
             # system_jit_defconfig uses T2C_OPT_LEVEL=1 for ~50% faster LLVM compilation
             make distclean && make system_jit_defconfig && make INITRD_SIZE=32 ENABLE_MOP_FUSION=0 $PARALLEL && make artifact $PARALLEL
-            # Verify T2C is actually compiled (build/t2c.o only exists when LLVM (.ci/llvm-version) is detected)
-            test -f build/t2c.o || { echo "ERROR: T2C disabled (build/t2c.o missing) - LLVM ${LLVM_VERSION} detection failed"; exit 1; }
-            bash -c "${BOOT_LINUX_TEST}"
-            make clean
+            test -f build/t2c.o || { echo "ERROR: T2C disabled (build/t2c.o missing) - LLVM ${{ steps.setup.outputs.llvm-version }} detection failed"; exit 1; }
+            .ci/boot-linux-test.sh
 
   macOS-arm64:
+    name: macOS ${{ matrix.compiler }}
     needs: [detect-code-related-file-changes]
     if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
-    timeout-minutes: 80
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -562,97 +346,20 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-     - uses: actions/checkout@v6
+     - uses: actions/checkout@v7
        with:
          submodules: 'true'
 
-     - name: Read LLVM Version
-       id: llvm-version
-       run: echo "version=$(cat .ci/llvm-version)" >> $GITHUB_OUTPUT
-
-     - name: Cache RISC-V Toolchain
-       id: cache-toolchain
-       uses: actions/cache@v5
-       with:
-         path: ${{ github.workspace }}/toolchain
-         key: ${{ runner.os }}-${{ runner.arch }}-riscv-toolchain-${{ hashFiles('.ci/riscv-toolchain-install.sh') }}
-
-     - name: Cache Homebrew packages
-       id: cache-brew
-       uses: actions/cache@v5
-       with:
-         path: |
-           /opt/homebrew/Cellar/llvm@${{ steps.llvm-version.outputs.version }}
-           /opt/homebrew/Cellar/sdl2
-           /opt/homebrew/Cellar/dtc
-         key: ${{ runner.os }}-${{ runner.arch }}-brew-llvm${{ steps.llvm-version.outputs.version }}-${{ hashFiles('.github/workflows/main.yml') }}
-
-     - name: Install dependencies
-       run: |
-             brew install make dtc expect sdl2 bc e2fsprogs p7zip llvm@${{ steps.llvm-version.outputs.version }} dcfldd
-             brew install sdl2_mixer || echo "Warning: sdl2_mixer installation failed, continuing without SDL_MIXER support"
-             # Ensure symlinks exist after cache restore (cached Cellar may lack /opt/homebrew/bin links)
-             brew link dtc --overwrite 2>/dev/null || true
-             command -v dtc || { echo "ERROR: dtc not found in PATH after install"; exit 1; }
-
-     - name: Install RISC-V Toolchain
-       if: steps.cache-toolchain.outputs.cache-hit != 'true'
-       run: |
-             .ci/riscv-toolchain-install.sh
-
-     - name: Setup toolchain paths
-       run: |
-             echo "${{ github.workspace }}/toolchain/bin" >> $GITHUB_PATH
-             echo "$(brew --prefix llvm@${{ steps.llvm-version.outputs.version }})/bin" >> $GITHUB_PATH
-     - name: Set up Python 3.12
-       uses: actions/setup-python@v6
-       with:
-         python-version: '3.12'
-     - name: Install compiler
-       id: install_cc
-       uses: rlalik/setup-cpp-compiler@master
+     - name: Set up build environment
+       id: setup
+       uses: ./.github/actions/setup-build
        with:
          compiler: ${{ matrix.compiler }}
-     # NOTE: emsdk removed - emcc builds run on host-x64 only (WebAssembly is platform-independent)
-     - name: Set parallel jobs variable
-       run: |
-             echo "PARALLEL=-j$(sysctl -n hw.logicalcpu)" >> "$GITHUB_ENV"
-             echo "BOOT_LINUX_TEST=TMP_FILE=\$(mktemp "$RUNNER_TEMP/tmpfile.XXXXXX"); \
-                                   sudo env TMP_FILE=\${TMP_FILE} .ci/boot-linux-prepare.sh setup; \
-                                   . \${TMP_FILE}; \
-                                   .ci/boot-linux.sh; \
-                                   EXIT_CODE=\$?; \
-                                   sudo env TMP_FILE=\${TMP_FILE} BLK_DEV_EXT4=\${BLK_DEV_EXT4} BLK_DEV_SIMPLEFS=\${BLK_DEV_SIMPLEFS} .ci/boot-linux-prepare.sh cleanup; \
-                                   exit \${EXIT_CODE};" >> "$GITHUB_ENV"
-     - name: Symlink gcc-15 due to the default /usr/local/bin/gcc links to system's clang
-       run: |
-             ln -s /opt/homebrew/opt/gcc/bin/gcc-15 /usr/local/bin/gcc-15
-     - name: Cache build artifacts
-       uses: actions/cache@v5
-       with:
-         path: build/
-         key: rv32emu-artifacts-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('mk/artifact.mk', 'mk/external.mk') }}
-         restore-keys: |
-           rv32emu-artifacts-${{ runner.os }}-${{ runner.arch }}-
-     - name: fetch artifact first to reduce HTTP requests
-       env:
-         CC: ${{ steps.install_cc.outputs.cc }}
-       run: |
-             . .ci/common.sh
-             fetch_artifact ELF
-             fetch_artifact Linux-Image ENABLE_SYSTEM=1
-             rm -f build/.config  # Clean config after ENABLE_SYSTEM=1 to prevent contamination
-             fetch_artifact sail ENABLE_ARCH_TEST=1
-             # get from rv32emu-prebuilt
-             .ci/fetch.sh -o build/shareware_doom_iwad.zip "https://raw.githubusercontent.com/sysprog21/rv32emu-prebuilt/doom-artifact/shareware_doom_iwad.zip"
-             unzip -o -d build/ build/shareware_doom_iwad.zip
-
-     # NOTE: emcc builds removed - they run on host-x64 only since WebAssembly output is platform-independent
+         riscv-toolchain: 'true'
+         artifacts: elf linux-image doom
+         cache-suffix: host-${{ matrix.compiler }}
 
      - name: check + tests
-       if: success()
-       env:
-         CC: ${{ steps.install_cc.outputs.cc }}
        run: |
              make cleanconfig
              make defconfig
@@ -661,93 +368,66 @@ jobs:
              make misalign $PARALLEL
              make tool $PARALLEL
 
-     - name: core extension disable tests (interpreter + JIT)
-       if: success()
-       env:
-         CC: ${{ steps.install_cc.outputs.cc }}
-       run: |
-             set -euo pipefail
-             # Core extensions + bit manipulation + CSR/fence + performance features
-             # Tests both interpreter and JIT modes (12 × 2 = 24 builds)
-             # Consolidated from 25 separate builds (13 interpreter + 12 JIT)
-             # Use cleanconfig instead of distclean to preserve artifacts across iterations
-             for ext in ENABLE_EXT_M ENABLE_EXT_A ENABLE_EXT_F ENABLE_EXT_C \
-                        ENABLE_Zba ENABLE_Zbb ENABLE_Zbc ENABLE_Zbs \
-                        ENABLE_Zicsr ENABLE_Zifencei \
-                        ENABLE_MOP_FUSION ENABLE_BLOCK_CHAINING; do
-               echo "Testing ${ext}=0 (interpreter)"
-               if ! (make cleanconfig && make defconfig && make ${ext}=0 check $PARALLEL); then
-                 echo "ERROR: Interpreter test failed with ${ext}=0"
-                 exit 1
-               fi
-               echo "Testing ${ext}=0 (JIT)"
-               if ! (make cleanconfig && make jit_defconfig && make ${ext}=0 check $PARALLEL); then
-                 echo "ERROR: JIT test failed with ${ext}=0"
-                 exit 1
-               fi
-             done
-
      - name: SDL disable test
-       if: success()
-       env:
-         CC: ${{ steps.install_cc.outputs.cc }}
        run: |
-             # SDL is graphics subsystem, interpreter-only test sufficient
+             # SDL is the graphics subsystem; an interpreter-only test suffices.
              make distclean && make defconfig && make ENABLE_SDL=0 check $PARALLEL
 
      - name: gdbstub test, need RV32 toolchain
-       if: success()
-       env:
-         CC: ${{ steps.install_cc.outputs.cc }}
-       run: |
-             make distclean && make defconfig && make ENABLE_GDBSTUB=1 gdbstub-test $PARALLEL
+       run: make distclean && make defconfig && make ENABLE_GDBSTUB=1 gdbstub-test $PARALLEL
 
      - name: JIT base test
-       if: success()
-       env:
-         CC: ${{ steps.install_cc.outputs.cc }}
-       run: |
-             # Base JIT test (extension disable tests handled in consolidated step above)
-             make distclean && make jit_defconfig && make check $PARALLEL
+       run: make distclean && make jit_defconfig && make check $PARALLEL
 
      - name: undefined behavior test
-       if: (success() || failure()) && steps.install_cc.outputs.cc == 'clang'  # gcc on macOS/arm64 does not support sanitizers
-       env:
-         CC: ${{ steps.install_cc.outputs.cc }}
+       # gcc on macOS/arm64 does not support sanitizers
+       if: (success() || failure()) && matrix.compiler == 'clang'
        run: |
              make distclean && make defconfig && make ENABLE_UBSAN=1 check $PARALLEL
              make distclean && make jit_defconfig && make ENABLE_UBSAN=1 check $PARALLEL
 
      - name: boot Linux kernel test
-       if: success()
-       env:
-         CC: ${{ steps.install_cc.outputs.cc }}
        run: |
-             make distclean && make system_defconfig && make INITRD_SIZE=32 $PARALLEL && \
-             make artifact $PARALLEL
-             bash -c "${BOOT_LINUX_TEST}"
+             make distclean && make system_defconfig && make INITRD_SIZE=32 $PARALLEL && make artifact $PARALLEL
+             .ci/boot-linux-test.sh
              make clean
 
      - name: boot Linux kernel test (JIT)
-       if: success()
        env:
-         CC: ${{ steps.install_cc.outputs.cc }}
          BOOT_TIMEOUT: 120  # JIT under macOS load has flaked at 90s
        run: |
              make distclean && make system_defconfig && make INITRD_SIZE=32 ENABLE_JIT=1 ENABLE_MOP_FUSION=0 $PARALLEL && make artifact $PARALLEL
-             bash -c "${BOOT_LINUX_TEST}"
+             .ci/boot-linux-test.sh
              make clean
 
-     - name: Architecture test
-       if: success()
-       env:
-         CC: ${{ steps.install_cc.outputs.cc }}
-       run: |
-             . .ci/common.sh
-             export LATEST_RELEASE=$(fetch_latest_release sail)
-             python3 -m venv venv
-             . venv/bin/activate
-             .ci/riscv-tests.sh
+  macOS-arm64-feature-disable:
+    name: macOS ${{ matrix.compiler }} feature disable
+    needs: [detect-code-related-file-changes]
+    if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [gcc-15, clang]
+    runs-on: macos-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+     - uses: actions/checkout@v7
+       with:
+         submodules: 'true'
+
+     - name: Set up build environment
+       id: setup
+       uses: ./.github/actions/setup-build
+       with:
+         compiler: ${{ matrix.compiler }}
+         riscv-toolchain: 'true'
+         artifacts: elf
+         cache-suffix: feature-${{ matrix.compiler }}
+
+     - name: Feature disable tests (interpreter + JIT)
+       run: .ci/test-ext-disable.sh
 
   coding-style:
     needs: [detect-code-related-file-changes]
@@ -755,18 +435,13 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
+    - name: Install formatters
+      run: .ci/install-formatters.sh
     - name: coding convention
       run: |
-            wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.gpg >/dev/null
-            echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-20 main" | sudo tee /etc/apt/sources.list.d/llvm-20.list
-            sudo apt-get update -q=2
-            sudo apt-get install -q=2 clang-format-20 shfmt python3-pip
-            pip3 install black==25.1.0
-            curl -LSfs https://go.mskelton.dev/dtsfmt/install | sh -s -- -y
             .ci/check-newline.sh
             .ci/check-format.sh
-      shell: bash
 
   static-analysis:
     needs: [detect-code-related-file-changes]
@@ -774,46 +449,23 @@ jobs:
     timeout-minutes: 45
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         submodules: 'true'
-    # LLVM static analysis
-    - name: set up scan-build
+
+    # scan-build lives in clang-tools-<N>, and the analyzer resolves the
+    # versioned clang-<N>/scan-build-<N> names from /usr/bin. Those are apt
+    # symlinks outside /usr/lib/llvm-<N>, so the LLVM cache the other jobs use
+    # would restore the tree without the names this job calls: install fresh.
+    - name: Set up scan-build
       run: |
-            set +e  # Disable errexit
-            # Configure apt to tolerate mirror sync failures
-            sudo tee /etc/apt/apt.conf.d/99-ci-reliability > /dev/null << 'EOF'
-            APT::Update::Error-Mode "any";
-            Acquire::IndexTargets::deb::DEP-11::DefaultEnabled "false";
-            Acquire::IndexTargets::deb::DEP-11-icons::DefaultEnabled "false";
-            Acquire::IndexTargets::deb::DEP-11-icons-hidpi::DefaultEnabled "false";
-            Acquire::Retries "3";
-            Acquire::Check-Valid-Until "false";
-            EOF
-            # Update with error tolerance
-            sudo apt-get update -q=2 2>&1
-            UPDATE_EXIT=$?
-            if [ $UPDATE_EXIT -ne 0 ]; then
-              echo "WARNING: apt update exited with code $UPDATE_EXIT, continuing..."
-            fi
-            sudo apt-get install -q=2 curl libsdl2-dev libsdl2-mixer-dev
             LLVM_VERSION=$(cat .ci/llvm-version)
+            .ci/apt-install.sh curl wget lsb-release gnupg libsdl2-dev libsdl2-mixer-dev
             sudo .ci/install-llvm.sh "${LLVM_VERSION}"
-            sudo apt-get install -q=2 clang-${LLVM_VERSION} clang-tools-${LLVM_VERSION}
-            set -e  # Re-enable errexit
-      shell: bash
-    - name: run scan-build without JIT
-      env:
-        LATEST_RELEASE: dummy
-      run: |
-          LLVM_VERSION=$(cat .ci/llvm-version)
-          make distclean && make defconfig && scan-build-${LLVM_VERSION} -v -o ~/scan-build --status-bugs --use-cc=clang-${LLVM_VERSION} --force-analyze-debug-code --show-description -analyzer-config stable-report-filename=true -enable-checker valist,nullability make ENABLE_EXT_F=0 ENABLE_SDL=0 ENABLE_JIT=0
-    - name: run scan-build with JIT
-      env:
-        LATEST_RELEASE: dummy
-      run: |
-          LLVM_VERSION=$(cat .ci/llvm-version)
-          make distclean && make jit_defconfig && scan-build-${LLVM_VERSION} -v -o ~/scan-build --status-bugs --use-cc=clang-${LLVM_VERSION} --force-analyze-debug-code --show-description -analyzer-config stable-report-filename=true -enable-checker valist,nullability make ENABLE_EXT_F=0 ENABLE_SDL=0 ENABLE_JIT=1
+            sudo apt-get install -y -q=2 "clang-${LLVM_VERSION}" "clang-tools-${LLVM_VERSION}"
+
+    - name: Run scan-build
+      run: .ci/scan-build.sh
 
   # https://docs.docker.com/build/ci/github-actions/multi-platform/
   docker-hub-build-and-publish:
@@ -823,29 +475,29 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: 'true'
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         if: github.event_name == 'push'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
       - name: Get short commit SHA1
         if: github.event_name == 'push'
-        shell: bash
-        run: |
-          echo "short_hash=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
+        run: echo "short_hash=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
       - name: Build and push
         if: github.event_name == 'push'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           context: .
           platforms: linux/amd64,linux/arm64/v8
           tags: sysprog21/rv32emu:latest, sysprog21/rv32emu:${{ env.short_hash }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker/Dockerfile-sail
+++ b/docker/Dockerfile-sail
@@ -14,7 +14,7 @@ RUN opam init --disable-sandboxing -y
 RUN opam switch create ocaml-base-compiler.5.2.0 # opam switch list-available
 RUN opam search sail
 RUN opam install -y sail.0.17.1
-RUN git clone https://github.com/riscv/sail-riscv.git
+RUN git clone https://github.com/riscv/sail-riscv
 RUN cd sail-riscv && \
     git checkout 0e9850fed5bee44346e583f334c6e2a6a25d5cd3 && \
     eval $(opam env) && \

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -64,12 +64,19 @@ error_msg = $(PRINTF) "$(RED)$(strip $1)$(NC)\n"
 # Targets that don't require .config
 # Note: 'artifact' is included because it only downloads prebuilt binaries
 # and determines what to download from ENABLE_* flags (via compat.mk)
+# cleanconfig belongs here for the same reason as clean and distclean: it
+# deletes .config, so demanding one first is backwards, and it made a fresh
+# clone unable to run it at all.
 CONFIG_TARGETS := config menuconfig defconfig oldconfig savedefconfig \
-                  clean distclean env-check artifact fetch-checksum build-linux-image
+                  clean cleanconfig distclean env-check artifact \
+                  fetch-checksum build-linux-image
 
 # Targets where we can skip expensive dependency detection (pkg-config, llvm-config, etc.)
 # This speeds up 'make clean', etc. significantly
-SKIP_DEPS_TARGETS := clean distclean
+# cleanconfig belongs here for the same reason as clean and distclean: it only
+# deletes files, so probing for pkg-config and llvm-config first is wasted
+# work. The feature-disable matrix calls it 24 times per job.
+SKIP_DEPS_TARGETS := clean cleanconfig distclean
 SKIP_DEPS_CHECK := $(filter $(SKIP_DEPS_TARGETS),$(MAKECMDGOALS))
 
 # Targets that generate .config


### PR DESCRIPTION
The x64 host job ran every check serially in one 60 minute job per compiler, and each job repeated the same setup preamble inline in YAML where it cannot be run or linted outside CI.

Split the serial work so it runs concurrently, and move the long command sequences into .ci. The feature disable matrix, which dominated the runtime at 48 builds per platform, now spreads across four runners. The emcc build and the architecture test each ran once per compiler despite being compiler independent, so each becomes a single job. A composite action under .github/actions/setup-build carries the setup every job shared, with caching for LLVM, the cross toolchain, Homebrew and the prebuilt artifacts.

The architecture test no longer runs on macOS: it validates the emulator against the Sail model and finds nothing the Linux run does not, while the macOS runners are the scarcest resource here.

Coverage is otherwise unchanged. The union of the two feature groups is identical to the previous 12 entry list, and every test step on master maps to an equivalent here.

Verified locally: actionlint clean apart from two pre-existing SC2046 warnings and SC2086 on the intentional $PARALLEL splitting; bash -n and shfmt clean across all 24 .ci scripts; every workflow and the composite action parse; the loop scripts dry run against a stubbed make and produce the same 48 builds per platform; the boot cleanup path exits 0 both when no device was attached and when a detach fails; the de-suffixed clone URLs resolve; the pinned dtsfmt release extracts to the expected x86-64 ELF. None of it has run on GitHub's runners yet, which is what this pull request is for.

One behavior change to flag: the macOS undefined behavior test has never actually run. Its condition compared setup-cpp-compiler's cc output, an absolute path, against the literal string clang, so it was always false. It now keys off the matrix value and will execute for the first time, so it may surface pre-existing failures.

Left out, both pre-existing and both needing a decision rather than a mechanical fix: benchmark.yml builds the base branch on fork pull requests, since pull_request_target checks out the base and fixing it means either dropping the secret or skipping forks; and deploy-wasm.yml still duplicates setup across two serialized jobs, when only the push to the demo repository needs serializing.
