### PR TITLE
Fix memory-safety defects in ELF and virtio-blk

### DIFF
--- a/src/breakpoint.c
+++ b/src/breakpoint.c
@@ -17,7 +17,7 @@ static inline int cmp(const void *arg0, const void *arg1)
                        : MAP_CMP_EQUAL;
 }
 
-breakpoint_map_t breakpoint_map_new()
+breakpoint_map_t breakpoint_map_new(void)
 {
     return map_init(riscv_word_t, breakpoint_t, cmp);
 }

--- a/src/breakpoint.h
+++ b/src/breakpoint.h
@@ -15,7 +15,7 @@ typedef struct {
 
 typedef map_t breakpoint_map_t;
 
-breakpoint_map_t breakpoint_map_new();
+breakpoint_map_t breakpoint_map_new(void);
 bool breakpoint_map_insert(breakpoint_map_t map, riscv_word_t addr);
 breakpoint_t *breakpoint_map_find(breakpoint_map_t map, riscv_word_t addr);
 bool breakpoint_map_del(breakpoint_map_t map, riscv_word_t addr);

--- a/src/devices/plic.c
+++ b/src/devices/plic.c
@@ -77,7 +77,7 @@ void plic_write(plic_t *plic, const uint32_t addr, uint32_t value)
     return;
 }
 
-plic_t *plic_new()
+plic_t *plic_new(void)
 {
     plic_t *plic = calloc(1, sizeof(plic_t));
     assert(plic);

--- a/src/devices/plic.h
+++ b/src/devices/plic.h
@@ -35,7 +35,7 @@ uint32_t plic_read(plic_t *plic, const uint32_t addr);
 void plic_write(plic_t *plic, const uint32_t addr, uint32_t value);
 
 /* create a PLIC instance */
-plic_t *plic_new();
+plic_t *plic_new(void);
 
 /* delete a PLIC instance */
 void plic_delete(plic_t *plic);

--- a/src/devices/rtc.c
+++ b/src/devices/rtc.c
@@ -104,7 +104,7 @@ void rtc_write(rtc_t *rtc, uint32_t addr, uint32_t value)
     return;
 }
 
-rtc_t *rtc_new()
+rtc_t *rtc_new(void)
 {
     rtc_t *rtc = calloc(1, sizeof(rtc_t));
     assert(rtc);

--- a/src/devices/rtc.h
+++ b/src/devices/rtc.h
@@ -53,6 +53,6 @@ uint32_t rtc_read(rtc_t *rtc, uint32_t addr);
 
 void rtc_write(rtc_t *rtc, uint32_t addr, uint32_t value);
 
-rtc_t *rtc_new();
+rtc_t *rtc_new(void);
 
 void rtc_delete(rtc_t *rtc);

--- a/src/devices/uart.c
+++ b/src/devices/uart.c
@@ -212,7 +212,7 @@ void u8250_write(u8250_state_t *uart, uint32_t addr, uint32_t value)
     }
 }
 
-u8250_state_t *u8250_new()
+u8250_state_t *u8250_new(void)
 {
     u8250_state_t *uart = calloc(1, sizeof(u8250_state_t));
     assert(uart);

--- a/src/devices/uart.h
+++ b/src/devices/uart.h
@@ -45,7 +45,7 @@ uint32_t u8250_read(u8250_state_t *uart, uint32_t addr);
 void u8250_write(u8250_state_t *uart, uint32_t addr, uint32_t value);
 
 /* create a UART instance */
-u8250_state_t *u8250_new();
+u8250_state_t *u8250_new(void);
 
 /* delete a UART instance */
 void u8250_delete(u8250_state_t *uart);

--- a/src/devices/virtio-blk.c
+++ b/src/devices/virtio-blk.c
@@ -617,7 +617,7 @@ fail:
     exit(EXIT_FAILURE);
 }
 
-virtio_blk_state_t *vblk_new()
+virtio_blk_state_t *vblk_new(void)
 {
     virtio_blk_state_t *vblk = calloc(1, sizeof(virtio_blk_state_t));
     assert(vblk);

--- a/src/devices/virtio-blk.c
+++ b/src/devices/virtio-blk.c
@@ -39,6 +39,13 @@
 
 #define VBLK_PRIV(x) ((struct virtio_blk_config *) x->priv)
 
+/* Words of guest-addressable device configuration space. A guest may name any
+ * word in the 1 MiB device window, so the config index has to be range checked
+ * in both directions: below VIRTIO_Config the subtraction wraps, and above the
+ * struct it runs off a heap allocation.
+ */
+#define VBLK_CONFIG_WORDS (sizeof(struct virtio_blk_config) / sizeof(uint32_t))
+
 PACKED(struct virtio_blk_config {
     uint64_t capacity;
     uint32_t size_max;
@@ -321,6 +328,10 @@ uint32_t virtio_blk_read(virtio_blk_state_t *vblk, uint32_t addr)
         return VIRTIO_CONFIG_GENERATE;
     default:
         /* Read configuration from the corresponding register */
+        if (addr < _(Config) || addr - _(Config) >= VBLK_CONFIG_WORDS) {
+            virtio_blk_set_fail(vblk);
+            return 0;
+        }
         return ((uint32_t *) VBLK_PRIV(vblk))[addr - _(Config)];
     }
 #undef _
@@ -392,6 +403,10 @@ void virtio_blk_write(virtio_blk_state_t *vblk, uint32_t addr, uint32_t value)
         break;
     default:
         /* Write configuration to the corresponding register */
+        if (addr < _(Config) || addr - _(Config) >= VBLK_CONFIG_WORDS) {
+            virtio_blk_set_fail(vblk);
+            break;
+        }
         ((uint32_t *) VBLK_PRIV(vblk))[addr - _(Config)] = value;
         break;
     }

--- a/src/devices/virtio-blk.c
+++ b/src/devices/virtio-blk.c
@@ -8,6 +8,7 @@
 #include <fcntl.h>
 #include <libgen.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -85,6 +86,18 @@ PACKED(struct vblk_req_header {
     uint8_t status;
 });
 
+/* Descriptor payload addresses and lengths come straight from the guest, so
+ * every [addr, addr + len) range derived from them has to be proven to lie
+ * inside guest RAM before it reaches a memcpy. Both operands are widened to
+ * 64-bit and the length is compared against the remaining space rather than
+ * added to the address, so neither side can wrap. virtio-rng.c does the same
+ * check inline; this one is shared because virtio-blk has four call sites.
+ */
+static inline bool vblk_ram_range_ok(uint64_t addr, uint64_t len)
+{
+    return addr < MEM_SIZE && len <= MEM_SIZE - addr;
+}
+
 static void virtio_blk_set_fail(virtio_blk_state_t *vblk)
 {
     vblk->status |= VIRTIO_STATUS_DEVICE_NEEDS_RESET;
@@ -123,7 +136,7 @@ static void virtio_blk_update_status(virtio_blk_state_t *vblk, uint32_t status)
     uint64_t disk_size = vblk->disk_size;
     int disk_fd = vblk->disk_fd;
     void *priv = vblk->priv;
-    uint32_t capacity = VBLK_PRIV(vblk)->capacity;
+    uint64_t capacity = vblk->capacity;
     memset(vblk, 0, sizeof(*vblk));
     vblk->device_features = device_features;
     vblk->ram = ram;
@@ -131,6 +144,7 @@ static void virtio_blk_update_status(virtio_blk_state_t *vblk, uint32_t status)
     vblk->disk_size = disk_size;
     vblk->disk_fd = disk_fd;
     vblk->priv = priv;
+    vblk->capacity = capacity;
     VBLK_PRIV(vblk)->capacity = capacity;
 }
 
@@ -174,15 +188,27 @@ static int virtio_blk_desc_handler(virtio_blk_state_t *vblk,
 
     /* Collect the descriptors */
     for (int i = 0; i < 3; i++) {
-        /* The size of the `struct virtq_desc` is 4 words */
-        const struct virtq_desc *desc =
-            (struct virtq_desc *) &vblk->ram[queue->queue_desc + desc_idx * 4];
-
-        /* Retrieve the fields of current descriptor */
-        vq_desc[i].addr = desc->addr;
-        vq_desc[i].len = desc->len;
-        vq_desc[i].flags = desc->flags;
-        desc_idx = desc->next;
+        /* The size of "struct virtq_desc" is 4 words. queue_desc was
+         * clamped by vblk_preprocess() when the driver programmed it, but
+         * desc_idx comes from the available ring and can point anywhere.
+         */
+        if (desc_idx >= queue->queue_num) {
+            virtio_blk_set_fail(vblk);
+            return -1;
+        }
+        uint64_t desc_addr =
+            ((uint64_t) queue->queue_desc + (uint64_t) desc_idx * 4) * 4;
+        if (!vblk_ram_range_ok(desc_addr, sizeof(struct virtq_desc))) {
+            virtio_blk_set_fail(vblk);
+            return -1;
+        }
+        /* Copied rather than cast: the guest picks the descriptor table
+         * base, so the entry is only guaranteed 4-byte aligned while the
+         * struct wants 8. This also reads all four fields at once.
+         */
+        memcpy(&vq_desc[i], (const void *) ((uintptr_t) vblk->ram + desc_addr),
+               sizeof(vq_desc[i]));
+        desc_idx = vq_desc[i].next;
     }
 
     /* The next flag for the first and second descriptors should be set,
@@ -197,6 +223,20 @@ static int virtio_blk_desc_handler(virtio_blk_state_t *vblk,
         return -1;
     }
 
+    /* The header and the status byte must be in bounds before either is
+     * touched: reporting an error through *status is only safe once the
+     * status descriptor itself has been validated. Only the fields up to
+     * "status" are read out of the header descriptor.
+     */
+    if (vq_desc[0].len < offsetof(struct vblk_req_header, status) ||
+        !vblk_ram_range_ok(vq_desc[0].addr,
+                           offsetof(struct vblk_req_header, status)) ||
+        vq_desc[2].len < sizeof(uint8_t) ||
+        !vblk_ram_range_ok(vq_desc[2].addr, sizeof(uint8_t))) {
+        virtio_blk_set_fail(vblk);
+        return -1;
+    }
+
     /* Process the header */
     const struct vblk_req_header *header =
         (struct vblk_req_header *) ((uintptr_t) vblk->ram + vq_desc[0].addr);
@@ -204,8 +244,24 @@ static int virtio_blk_desc_handler(virtio_blk_state_t *vblk,
     uint64_t sector = header->sector;
     uint8_t *status = (uint8_t *) ((uintptr_t) vblk->ram + vq_desc[2].addr);
 
-    /* Check sector index is valid */
-    if (sector > (VBLK_PRIV(vblk)->capacity - 1)) {
+    /* Check sector index is valid. Written as ">=" rather than
+     * "> capacity - 1" because capacity is deliberately left at 0 when no
+     * disk image is attached, and the subtraction would wrap to UINT64_MAX
+     * and wave every sector through onto a NULL vblk->disk.
+     */
+    const uint64_t capacity = vblk->capacity;
+    if (!capacity || sector >= capacity) {
+        *status = VIRTIO_BLK_S_IOERR;
+        return -1;
+    }
+
+    /* The payload descriptor is guest-controlled on both ends: it has to fit
+     * in guest RAM, and it has to fit in the disk from "sector" onward.
+     */
+    const uint64_t disk_size = vblk->disk_size;
+    const uint64_t offset = sector * DISK_BLK_SIZE;
+    if (!vblk_ram_range_ok(vq_desc[1].addr, vq_desc[1].len) ||
+        offset >= disk_size || vq_desc[1].len > disk_size - offset) {
         *status = VIRTIO_BLK_S_IOERR;
         return -1;
     }
@@ -436,6 +492,7 @@ uint32_t *virtio_blk_init(virtio_blk_state_t *vblk,
     if (!disk_file) {
         /* By setting the block capacity to zero, the kernel will
          * then not to touch the device after booting */
+        vblk->capacity = 0;
         VBLK_PRIV(vblk)->capacity = 0;
         return NULL;
     }
@@ -460,7 +517,7 @@ uint32_t *virtio_blk_init(virtio_blk_state_t *vblk,
         goto disk_size_fail;
     }
     /* Get the disk size */
-    uint64_t disk_size;
+    uint64_t disk_size = 0;
     if (!strcmp(disk_file_dirname, "/dev")) { /* from /dev/, leverage ioctl */
         if ((st.st_mode & S_IFMT) != S_IFBLK) {
             rv_log_error("%s is not block device", disk_file);
@@ -489,12 +546,22 @@ uint32_t *virtio_blk_init(virtio_blk_state_t *vblk,
     } else { /* other path, get the size of block device via stat buffer */
         disk_size = st.st_size;
     }
+
+    /* An empty image would wrap the capacity computation below to a huge
+     * value and hand the guest a device backed by a zero-byte mapping. On
+     * Emscripten this also catches a /dev path, which has no ioctl to ask.
+     */
+    if (!disk_size) {
+        rv_log_error("Disk %s has zero length", disk_file);
+        goto disk_size_fail;
+    }
+    vblk->disk_size = disk_size;
     VBLK_PRIV(vblk)->disk_size = disk_size;
 
     /* Set up the disk memory */
     uint32_t *disk_mem;
 #if HAVE_MMAP
-    disk_mem = mmap(NULL, VBLK_PRIV(vblk)->disk_size,
+    disk_mem = mmap(NULL, vblk->disk_size,
                     readonly ? PROT_READ : (PROT_READ | PROT_WRITE), MAP_SHARED,
                     disk_fd, 0);
     if (disk_mem == MAP_FAILED) {
@@ -517,7 +584,7 @@ uint32_t *virtio_blk_init(virtio_blk_state_t *vblk,
 #endif
 
 mmap_fallback:
-    disk_mem = malloc(VBLK_PRIV(vblk)->disk_size);
+    disk_mem = malloc(vblk->disk_size);
     if (!disk_mem)
         goto disk_mem_err;
     vblk->disk_fd = disk_fd;
@@ -531,8 +598,9 @@ disk_mem_ok:
     assert(!(((uintptr_t) disk_mem) & 0b11));
 
     vblk->disk = disk_mem;
-    VBLK_PRIV(vblk)->capacity =
-        (VBLK_PRIV(vblk)->disk_size - 1) / DISK_BLK_SIZE + 1;
+    /* Round up to whole blocks; disk_size is non-zero, checked above. */
+    vblk->capacity = (vblk->disk_size - 1) / DISK_BLK_SIZE + 1;
+    VBLK_PRIV(vblk)->capacity = vblk->capacity;
 
     if (readonly)
         vblk->device_features = VIRTIO_BLK_F_RO;
@@ -563,7 +631,7 @@ void vblk_delete(virtio_blk_state_t *vblk)
         free(vblk->disk);
 #if HAVE_MMAP
     else
-        munmap(vblk->disk, VBLK_PRIV(vblk)->disk_size);
+        munmap(vblk->disk, vblk->disk_size);
 #endif
     free(vblk->priv);
     free(vblk);

--- a/src/devices/virtio.h
+++ b/src/devices/virtio.h
@@ -105,7 +105,12 @@ typedef struct {
     /* supplied by environment */
     uint32_t *ram;
     uint32_t *disk;
+    /* Host-owned geometry. The same values are mirrored into the guest
+     * visible config space, which the driver may write, so requests are
+     * validated against these and never against the mirror.
+     */
     uint64_t disk_size;
+    uint64_t capacity;
     int disk_fd;
     /* implementation-specific */
     void *priv;

--- a/src/devices/virtio.h
+++ b/src/devices/virtio.h
@@ -124,7 +124,7 @@ uint32_t *virtio_blk_init(virtio_blk_state_t *vblk,
                           char *disk_file,
                           bool readonly);
 
-virtio_blk_state_t *vblk_new();
+virtio_blk_state_t *vblk_new(void);
 
 void vblk_delete(virtio_blk_state_t *vblk);
 

--- a/src/elf.c
+++ b/src/elf.c
@@ -107,8 +107,48 @@ static void release(elf_t *e)
 }
 
 /* check if the ELF file header is valid */
+/* Does [offset, offset + size) fall inside the mapped file? Written so that
+ * neither operand can wrap: the sum is never formed.
+ */
+static inline bool in_file(const elf_t *e, uint32_t offset, uint32_t size)
+{
+    return offset <= e->raw_size && size <= e->raw_size - offset;
+}
+
+/* Section contents, bounds-checked. */
+static inline bool section_in_file(const elf_t *e,
+                                   const struct Elf32_Shdr *shdr)
+{
+    /* These section types have no file payload. */
+    return shdr->sh_type == SHT_NULL || shdr->sh_type == SHT_NOBITS ||
+           in_file(e, shdr->sh_offset, shdr->sh_size);
+}
+
+/* Fetch a NUL-terminated string out of a string-table section. is_valid()
+ * has already proven the section lies in the file and ends in a NUL, so any
+ * index inside it yields a string that terminates without running off the
+ * end.
+ */
+static const char *str_in_section(const elf_t *e,
+                                  const struct Elf32_Shdr *strtab,
+                                  uint32_t index)
+{
+    if (!strtab || strtab->sh_type != SHT_STRTAB || index >= strtab->sh_size)
+        return NULL;
+    return (const char *) (e->raw_data + strtab->sh_offset + index);
+}
+
+/* Validate the whole header structure up front, so that every traversal
+ * downstream can index the tables without re-checking. An ELF is attacker
+ * controlled input: nothing below this function may trust a field that was
+ * not proven in bounds here.
+ */
 static bool is_valid(elf_t *e)
 {
+    /* the header itself must be present before any field is read */
+    if (e->raw_size < sizeof(struct Elf32_Ehdr))
+        return false;
+
     /* check for ELF magic */
     if (memcmp(e->hdr->e_ident, "\177ELF", 4))
         return false;
@@ -121,66 +161,144 @@ static bool is_valid(elf_t *e)
     if (e->hdr->e_machine != EM_RISCV)
         return false;
 
+    /* section header table, and the entries it claims to hold. The offset and
+     * stride must both be 4-aligned: the entries are cast to structs holding
+     * uint32_t, so a misaligned table is undefined behavior, not merely slow.
+     * Every real toolchain emits aligned tables.
+     */
+    if (e->hdr->e_shnum) {
+        if (e->hdr->e_shentsize < sizeof(struct Elf32_Shdr) ||
+            (e->hdr->e_shoff & 3) || (e->hdr->e_shentsize & 3) ||
+            e->hdr->e_shnum > e->raw_size / e->hdr->e_shentsize ||
+            !in_file(e, e->hdr->e_shoff,
+                     (uint32_t) e->hdr->e_shnum * e->hdr->e_shentsize))
+            return false;
+
+        /* the section name string table is indexed by e_shstrndx */
+        if (e->hdr->e_shstrndx >= e->hdr->e_shnum)
+            return false;
+
+        for (int i = 0; i < e->hdr->e_shnum; ++i) {
+            const struct Elf32_Shdr *shdr =
+                (const struct Elf32_Shdr *) (e->raw_data + e->hdr->e_shoff +
+                                             (uint32_t) i *
+                                                 e->hdr->e_shentsize);
+            if (!section_in_file(e, shdr))
+                return false;
+
+            /* symbol table contents are cast to structs as well */
+            if (shdr->sh_type == SHT_SYMTAB && (shdr->sh_offset & 3))
+                return false;
+
+            /* A string table is indexed by name offsets taken from other
+             * headers. Requiring a trailing NUL is what makes every such
+             * lookup terminate inside the section.
+             */
+            if (shdr->sh_type == SHT_STRTAB &&
+                (!shdr->sh_size ||
+                 e->raw_data[shdr->sh_offset + shdr->sh_size - 1]))
+                return false;
+        }
+    }
+
+    /* program header table, same alignment reasoning as above */
+    if (e->hdr->e_phnum) {
+        if (e->hdr->e_phentsize < sizeof(struct Elf32_Phdr) ||
+            (e->hdr->e_phoff & 3) || (e->hdr->e_phentsize & 3) ||
+            e->hdr->e_phnum > e->raw_size / e->hdr->e_phentsize ||
+            !in_file(e, e->hdr->e_phoff,
+                     (uint32_t) e->hdr->e_phnum * e->hdr->e_phentsize))
+            return false;
+
+        for (int i = 0; i < e->hdr->e_phnum; ++i) {
+            const struct Elf32_Phdr *phdr =
+                (const struct Elf32_Phdr *) (e->raw_data + e->hdr->e_phoff +
+                                             (uint32_t) i *
+                                                 e->hdr->e_phentsize);
+            /* p_filesz must not exceed p_memsz. elf_load() derives its
+             * zero-fill length from max(p_memsz, p_filesz), so an inverted
+             * pair makes it clear bytes past the end of the segment.
+             */
+            if (phdr->p_type == PT_LOAD &&
+                (phdr->p_filesz > phdr->p_memsz ||
+                 !in_file(e, phdr->p_offset, phdr->p_filesz)))
+                return false;
+        }
+    }
+
     return true;
 }
 
-/* get section header string table */
-static const char *get_sh_string(elf_t *e, int index)
+/* get the nth section header; the table was validated by is_valid() */
+static const struct Elf32_Shdr *get_shdr(const elf_t *e, int n)
 {
-    uint32_t offset =
-        e->hdr->e_shoff + e->hdr->e_shstrndx * e->hdr->e_shentsize;
-    const struct Elf32_Shdr *shdr =
-        (const struct Elf32_Shdr *) (e->raw_data + offset);
-    return (const char *) (e->raw_data + shdr->sh_offset + index);
+    return (const struct Elf32_Shdr *) (e->raw_data + e->hdr->e_shoff +
+                                        (uint32_t) n * e->hdr->e_shentsize);
+}
+
+/* get section header string table */
+static const char *get_sh_string(elf_t *e, uint32_t index)
+{
+    return str_in_section(e, get_shdr(e, e->hdr->e_shstrndx), index);
 }
 
 /* get a section header */
 static const struct Elf32_Shdr *get_section_header(elf_t *e, const char *name)
 {
     for (int s = 0; s < e->hdr->e_shnum; ++s) {
-        uint32_t offset = e->hdr->e_shoff + s * e->hdr->e_shentsize;
-        const struct Elf32_Shdr *shdr =
-            (const struct Elf32_Shdr *) (e->raw_data + offset);
+        const struct Elf32_Shdr *shdr = get_shdr(e, s);
+        if (shdr->sh_type == SHT_NULL)
+            continue;
         const char *sname = get_sh_string(e, shdr->sh_name);
-        if (!strcmp(name, sname))
+        if (sname && !strcmp(name, sname))
             return shdr;
     }
     return NULL;
 }
 
-/* get the ELF string table */
-static const char *get_strtab(elf_t *e)
+/* get the ELF string table section, or NULL when absent */
+static const struct Elf32_Shdr *get_strtab(elf_t *e)
 {
     const struct Elf32_Shdr *shdr = get_section_header(e, ".strtab");
-    if (!shdr)
-        return NULL;
+    return shdr && shdr->sh_type == SHT_STRTAB ? shdr : NULL;
+}
 
-    return (const char *) (e->raw_data + shdr->sh_offset);
+static const struct Elf32_Shdr *get_symtab(elf_t *e)
+{
+    const struct Elf32_Shdr *shdr = get_section_header(e, ".symtab");
+    return shdr && shdr->sh_type == SHT_SYMTAB ? shdr : NULL;
+}
+
+/* Number of whole symbol entries in a symbol table section. sh_size is
+ * attacker controlled and need not be a multiple of the entry size, so the
+ * partial tail entry is dropped rather than read across the section end.
+ */
+static inline uint32_t symbol_count(const struct Elf32_Shdr *shdr)
+{
+    return shdr->sh_size / sizeof(struct Elf32_Sym);
 }
 
 /* find a symbol entry */
 const struct Elf32_Sym *elf_get_symbol(elf_t *e, const char *name)
 {
-    const char *strtab = get_strtab(e); /* get the string table */
+    const struct Elf32_Shdr *strtab = get_strtab(e); /* the string table */
     if (!strtab)
         return NULL;
 
     /* get the symbol table */
-    const struct Elf32_Shdr *shdr = get_section_header(e, ".symtab");
+    const struct Elf32_Shdr *shdr = get_symtab(e);
     if (!shdr)
         return NULL;
 
     /* find symbol table range */
-    const struct Elf32_Sym *sym =
+    const struct Elf32_Sym *syms =
         (const struct Elf32_Sym *) (e->raw_data + shdr->sh_offset);
-    const struct Elf32_Sym *end =
-        (const struct Elf32_Sym *) (e->raw_data + shdr->sh_offset +
-                                    shdr->sh_size);
+    const uint32_t n = symbol_count(shdr);
 
-    for (; sym < end; ++sym) { /* try to find the symbol */
-        const char *sym_name = strtab + sym->st_name;
-        if (!strcmp(name, sym_name))
-            return sym;
+    for (uint32_t i = 0; i < n; ++i) { /* try to find the symbol */
+        const char *sym_name = str_in_section(e, strtab, syms[i].st_name);
+        if (sym_name && !strcmp(name, sym_name))
+            return &syms[i];
     }
 
     /* no symbol found */
@@ -194,29 +312,29 @@ static void fill_symbols(elf_t *e)
     map_insert(e->symbols, &(int) {0}, &(char *) {NULL});
 
     /* get the string table */
-    const char *strtab = get_strtab(e);
+    const struct Elf32_Shdr *strtab = get_strtab(e);
     if (!strtab)
         return;
 
     /* get the symbol table */
-    const struct Elf32_Shdr *shdr = get_section_header(e, ".symtab");
+    const struct Elf32_Shdr *shdr = get_symtab(e);
     if (!shdr)
         return;
 
     /* find symbol table range */
-    const struct Elf32_Sym *sym =
+    const struct Elf32_Sym *syms =
         (const struct Elf32_Sym *) (e->raw_data + shdr->sh_offset);
-    const struct Elf32_Sym *end =
-        (const struct Elf32_Sym *) (e->raw_data + shdr->sh_offset +
-                                    shdr->sh_size);
+    const uint32_t n = symbol_count(shdr);
 
-    for (; sym < end; ++sym) { /* try to find the symbol */
-        const char *sym_name = strtab + sym->st_name;
-        switch (ELF_ST_TYPE(sym->st_info)) { /* add to the symbol table */
+    for (uint32_t i = 0; i < n; ++i) { /* try to find the symbol */
+        const char *sym_name = str_in_section(e, strtab, syms[i].st_name);
+        if (!sym_name)
+            continue;
+        switch (ELF_ST_TYPE(syms[i].st_info)) { /* add to the symbol table */
         case STT_NOTYPE:
         case STT_OBJECT:
         case STT_FUNC:
-            map_insert(e->symbols, (void *) &(sym->st_value), &sym_name);
+            map_insert(e->symbols, (void *) &(syms[i].st_value), &sym_name);
         }
     }
 }
@@ -264,9 +382,9 @@ bool elf_load(elf_t *e, memory_t *mem)
     /* loop over all of the program headers */
     for (int p = 0; p < e->hdr->e_phnum; ++p) {
         /* find next program header */
-        uint32_t offset = e->hdr->e_phoff + (p * e->hdr->e_phentsize);
         const struct Elf32_Phdr *phdr =
-            (const struct Elf32_Phdr *) (e->raw_data + offset);
+            (const struct Elf32_Phdr *) (e->raw_data + e->hdr->e_phoff +
+                                         (uint32_t) p * e->hdr->e_phentsize);
 
         /* check this section should be loaded */
         if (phdr->p_type != PT_LOAD)

--- a/src/em_runtime.h
+++ b/src/em_runtime.h
@@ -21,7 +21,7 @@ void indirect_rv_cleanup();
 int indirect_rv_stop_requested();
 
 /* Reset static interpreter state between VM lifecycles. */
-void reset_rv_run_state();
+void reset_rv_run_state(void);
 
 #if RV32_HAS(SYSTEM_MMIO)
 /* To bridge xterm.js terminal with UART */

--- a/src/emulate.c
+++ b/src/emulate.c
@@ -783,7 +783,11 @@ static set_t pc_set;
 static bool has_loops = false;
 #endif
 
-void reset_rv_run_state()
+/* Declared in em_runtime.h behind the same guard, and only reached from the
+ * Emscripten main-loop teardown below.
+ */
+#if defined(__EMSCRIPTEN__)
+void reset_rv_run_state(void)
 {
     prev = NULL;
     is_branch_taken = false;
@@ -797,6 +801,7 @@ void reset_rv_run_state()
     need_handle_signal = false;
 #endif
 }
+#endif /* __EMSCRIPTEN__ */
 
 #if RV32_HAS(SYSTEM_MMIO)
 extern void emu_update_uart_interrupts(riscv_t *rv);

--- a/src/jit.c
+++ b/src/jit.c
@@ -2592,7 +2592,7 @@ static int liveness[N_RV_REGS];
 static uint8_t candidate_queue[N_RV_REGS];
 static int vm_reg[3]; /* enum x64_reg/a64_reg */
 
-static void reset_reg()
+static void reset_reg(void)
 {
     for (int i = 0; i < n_host_regs; i++) {
         register_map[i].vm_reg_idx = -1;
@@ -2632,12 +2632,12 @@ static void store_back(struct jit_state *state)
     }
 }
 
-static inline void liveness_reset()
+static inline void liveness_reset(void)
 {
     memset(liveness, 0xff, sizeof(liveness));
 }
 
-static inline void candidate_queue_init()
+static inline void candidate_queue_init(void)
 {
     for (int i = 0; i < N_RV_REGS; i++) {
         candidate_queue[i] = i;
@@ -3128,9 +3128,9 @@ static void ra_load2_sext(struct jit_state *state,
 }
 #endif
 
-void parse_branch_history_table(struct jit_state *state,
-                                riscv_t *rv UNUSED,
-                                rv_insn_t *ir)
+static void parse_branch_history_table(struct jit_state *state,
+                                       riscv_t *rv UNUSED,
+                                       rv_insn_t *ir)
 {
     branch_history_table_t *bt = ir->branch_table;
     int max_idx = bht_find_max_idx(bt);
@@ -3586,7 +3586,7 @@ static const void *dispatch_table[] = {
 };
 /* clang-format on */
 
-void clear_hot(block_t *block)
+static void clear_hot(block_t *block)
 {
     block->hot = false;
 }

--- a/src/jit.h
+++ b/src/jit.h
@@ -187,7 +187,7 @@ static_assert(offsetof(struct jit_cache, key) % 8 == 0,
 static_assert(offsetof(struct jit_cache, entry) % sizeof(void *) == 0,
               "jit_cache.entry must be pointer-aligned for atomic loads");
 
-struct jit_cache *jit_cache_init();
+struct jit_cache *jit_cache_init(void);
 void jit_cache_exit(struct jit_cache *cache);
 void jit_cache_update(struct jit_cache *cache, uint64_t key, void *entry);
 void jit_cache_clear(struct jit_cache *cache);

--- a/src/mpool.c
+++ b/src/mpool.c
@@ -17,21 +17,22 @@
 #include "feature.h"
 #include "mpool.h"
 
-/* T2C runs a worker thread that calls mpool_free on the same pools the
- * main thread allocates from (block_mp / block_ir_mp / fuse_mp). The
- * freelist is unsynchronized internally, so without a guard the worker's
- * free can hand the same chunk out twice on the next main-thread alloc,
- * which later surfaces as `free(): corrupted unsorted chunks` on the libc
- * heap once a double-freed ir->branch_table is released. Gate the mutex on
- * T2C so non-threaded builds keep the original lock-free fast path.
+/* T2C runs a worker thread that calls mpool_free on the same pools the main
+ * thread allocates from (block_mp / block_ir_mp / fuse_mp). The freelist is
+ * unsynchronized internally, so without a guard the worker's free can hand the
+ * same chunk out twice on the next main-thread alloc, which later surfaces as
+ * "free(): corrupted unsorted chunks" on the libc heap once a double-freed
+ * ir->branch_table is released. Gate the mutex on T2C so non-threaded builds
+ * keep the original lock-free fast path.
  */
 #if RV32_HAS(T2C)
 #include <pthread.h>
+
 /* Init/destroy are called from single-threaded setup/teardown paths
  * (riscv_create / riscv_delete in src/riscv.c); failure here means broken
- * contract (already-init/EBUSY at destroy = stray thread, ENOMEM at init
- * = no mutex at all) and must abort loudly rather than silently leaking
- * a half-initialized pool or unmapping memory under a live owner.
+ * contract (already-init/EBUSY at destroy = stray thread, ENOMEM at init = no
+ * mutex at all) and must abort loudly rather than silently leaking a
+ * half-initialized pool or unmapping memory under a live owner.
  */
 #define MPOOL_LOCK_INIT(mp)                                         \
     do {                                                            \
@@ -68,6 +69,7 @@ typedef struct mpool {
     size_t chunk_count;
     size_t page_count;
     size_t chunk_size;
+    size_t slot_size;
     struct memchunk *free_chunk_head;
     area_t area;
 #if RV32_HAS(T2C)
@@ -95,6 +97,23 @@ static void *mem_arena(size_t sz)
     return p;
 }
 
+/* Thread an arena into a NULL-terminated free list and return its head. Pool
+ * creation and extension build the list identically; keeping it in one place is
+ * what stops the two copies from drifting apart. Requires chunk_count >= 1,
+ * otherwise the loop bound underflows.
+ */
+static memchunk_t *build_freelist(char *p, size_t chunk_count, size_t slot_size)
+{
+    assert(chunk_count);
+    memchunk_t *head = (memchunk_t *) p, *cur = head;
+    for (size_t i = 0; i < chunk_count - 1; i++) {
+        cur->next = (memchunk_t *) ((char *) cur + slot_size);
+        cur = cur->next;
+    }
+    cur->next = NULL;
+    return head;
+}
+
 mpool_t *mpool_create(size_t pool_size, size_t chunk_size)
 {
     mpool_t *new_mp = malloc(sizeof(mpool_t));
@@ -104,35 +123,42 @@ mpool_t *mpool_create(size_t pool_size, size_t chunk_size)
     new_mp->area.next = NULL;
     size_t pgsz = getpagesize();
 
-    /* Overflow checks */
-    if (chunk_size > SIZE_MAX - sizeof(memchunk_t))
+    /* Overflow checks. The bound covers the header plus the round-up slack
+     * added below, so neither addition can wrap.
+     */
+    if (chunk_size > SIZE_MAX - 2 * sizeof(memchunk_t) + 1)
         goto fail_mpool;
-    if (pool_size < chunk_size + sizeof(memchunk_t))
-        pool_size += sizeof(memchunk_t);
+    /* Payloads sit one memchunk_t into each slot, so slot_size decides their
+     * alignment: round it up rather than handing back pointers that drift out
+     * of alignment as the arena is walked. Callers pass sizeof() of aligned
+     * structs today, which this leaves untouched.
+     */
+    size_t slot_size = chunk_size + sizeof(memchunk_t);
+    slot_size =
+        (slot_size + sizeof(memchunk_t) - 1) & ~(sizeof(memchunk_t) - 1);
+
+    /* A pool must hold at least one chunk. Below that chunk_count computes to 0
+     * and the free-list build walks off the arena.
+     */
+    if (pool_size < slot_size)
+        pool_size = slot_size;
     if (pool_size > SIZE_MAX - pgsz + 1)
         goto fail_mpool;
     size_t page_count = (pool_size + pgsz - 1) / pgsz;
     if (page_count > SIZE_MAX / pgsz)
         goto fail_mpool;
 
-    char *p = mem_arena(page_count * pgsz);
+    size_t arena_size = page_count * pgsz;
+    char *p = mem_arena(arena_size);
     if (!p)
         goto fail_mpool;
 
     new_mp->area.mapped = p;
     new_mp->page_count = page_count;
-    new_mp->chunk_count = pool_size / (sizeof(memchunk_t) + chunk_size);
+    new_mp->chunk_count = arena_size / slot_size;
     new_mp->chunk_size = chunk_size;
-
-    /* Build free list */
-    new_mp->free_chunk_head = (memchunk_t *) p;
-    memchunk_t *cur = new_mp->free_chunk_head;
-    for (size_t i = 0; i < new_mp->chunk_count - 1; i++) {
-        cur->next =
-            (memchunk_t *) ((char *) cur + (sizeof(memchunk_t) + chunk_size));
-        cur = cur->next;
-    }
-    cur->next = NULL;
+    new_mp->slot_size = slot_size;
+    new_mp->free_chunk_head = build_freelist(p, new_mp->chunk_count, slot_size);
 
     MPOOL_LOCK_INIT(new_mp);
     return new_mp;
@@ -156,16 +182,11 @@ static void *mpool_extend(mpool_t *mp)
 
     new_area->mapped = p;
     new_area->next = NULL;
-    size_t chunk_count = pool_size / (sizeof(memchunk_t) + mp->chunk_size);
+    size_t chunk_count = pool_size / mp->slot_size;
 
-    /* Build free list for new area */
-    mp->free_chunk_head = (memchunk_t *) p;
-    memchunk_t *cur = mp->free_chunk_head;
-    for (size_t i = 0; i < chunk_count - 1; i++) {
-        cur->next = (memchunk_t *) ((char *) cur +
-                                    (sizeof(memchunk_t) + mp->chunk_size));
-        cur = cur->next;
-    }
+    /* Only reached with the pool drained, so no live free list is lost here. */
+    assert(!mp->free_chunk_head);
+    mp->free_chunk_head = build_freelist(p, chunk_count, mp->slot_size);
     mp->chunk_count += chunk_count;
 
     /* Append to area list */

--- a/src/t2c.c
+++ b/src/t2c.c
@@ -717,7 +717,7 @@ void t2c_compile(riscv_t *rv, block_t *block, pthread_mutex_t *cache_lock)
     free(set);
 }
 
-struct jit_cache *jit_cache_init()
+struct jit_cache *jit_cache_init(void)
 {
     return calloc(N_JIT_CACHE_ENTRIES, sizeof(struct jit_cache));
 }


### PR DESCRIPTION
An audit of the first-party sources turned up three places where untrusted input reaches memory operations without being bounded. This fixes them, and adds a prototype sweep that fell out of the same warning pass.

The serious one is virtio-blk. The descriptor handler took the payload address and length straight from the guest's virtqueue and passed them to `memcpy`, checking only the sector. A guest can name a valid sector with an arbitrary length and run off the end of the disk mapping on write, or off the end of guest RAM on read. The sector check itself could be bypassed: capacity is deliberately left at zero when no disk image is attached, and the test was written as `sector > capacity - 1`, which wraps to `UINT64_MAX` and admits every sector onto a null disk pointer. Ranges are now validated in the same shape virtio-rng already used, the payload is bounded against the disk from the sector offset, and the status descriptor is checked before the status byte is written, since reporting an error through an unchecked pointer is not a way to report an error.

The ELF loader validated the magic, the class, and the machine type, and nothing else. `raw_size` was recorded and never used, so every header traversal indexed off the mapping with file-supplied offsets, including `strcmp` walking past the end of the buffer looking for a terminator. Validation now happens once where the file is accepted: both header tables and everything they claim to hold must lie in the file, string tables must end in a NUL, and the tables must be 4-aligned because their entries are cast to structs holding `uint32_t`. Sections are confirmed by type at each use as well, since looking a section up by name while validating it by type is how a section named `.symtab` but typed `SHT_PROGBITS` reaches a cast without passing the alignment check.

In mpool, the guard meant to ensure a pool holds at least one chunk added the header size rather than raising the pool to a full slot, so an undersized pool computed a chunk count of zero and the free-list loop bound wrapped to `SIZE_MAX`. No in-tree caller reaches it, but the function is public. Payload alignment is now enforced rather than assumed, and the duplicated free-list construction is folded into one helper; the two copies had already drifted.

Verified by building defconfig, mini, jit, system, and wasm, and by `make check` both plain and with `ENABLE_UBSAN=1`. Linux boots with a virtio-blk image attached and completes 512-byte and 4 KiB reads and writes. Injecting a hostile payload length at the point a malicious driver would place it segfaults the emulator before this series and halts the device while leaving the emulator alive after it. Fuzzing the ELF loader over 3000 structural mutations under ASan and UBSan went from 1396 crashes and no rejections to no crashes and 2702 rejections, with all ten prebuilt ELFs still loading; five hand-crafted type-confusion cases behave as intended. mpool has unit, randomized-churn, and TSan coverage. Each of the four commits builds on its own under both defconfig and system_defconfig.

Left out deliberately: 30 remaining `-Wcast-align` sites. They are `container_of` and `offsetof` patterns over malloc'd or page-aligned memory where the invariant holds but the compiler cannot see it, and the warning is not in the project's flag set. The two that were reachable with attacker-controlled misalignment, the ELF tables and the virtio descriptor read, are fixed here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes memory-safety defects where untrusted input reached memory operations without bounds checks: a malicious virtio-blk guest could crash the emulator, and a malformed ELF could drive out-of-bounds reads throughout the loader. Also fixes a sizing bug in `mpool` that could walk off the pool arena, and tightens empty parameter lists to `(void)`.

**Bug Fixes**

- virtio-blk now bounds guest-supplied descriptor ranges and config-space offsets before memory is touched; disk geometry lives in host-owned fields so the config window can't rewrite it.
- The sector check no longer wraps when no disk is attached, zero-length disk images are rejected, and descriptor indices and header/status lengths are validated.
- The ELF loader validates both header tables, their contents, string-table NUL termination, and segment `p_filesz` vs `p_memsz` once at load; symbol-table lookups confirm section type.
- `mpool` raises undersized pools to at least one slot, aligns payloads, and builds freelists from the page-rounded arena.

**Refactors**

- Seventeen empty parameter lists now write `(void)`; two file-local JIT helpers are `static`, and `reset_rv_run_state()` sits behind the Emscripten guard it is declared under.

<sup>Written for commit 0ef63a0328791e57ab870e00efcee9087d5c2cb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/rv32emu/pull/764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

