### PR TITLE
Implement RVV whole vector register move

### DIFF
--- a/src/decode.h
+++ b/src/decode.h
@@ -745,6 +745,10 @@ enum op_field {
         _(vwmaccsu_vx, 0, 4, 0, ENC(rs1, rs2, vd))        \
         _(vmv_s_x, 0, 4, 0, ENC(rs1, rs2, vd))            \
         _(vmv_x_s, 0, 4, 0, ENC(rs1, rs2, vd))            \
+        _(vmv1r_v, 0, 4, 0, ENC(rs1, rs2, vd))            \
+        _(vmv2r_v, 0, 4, 0, ENC(rs1, rs2, vd))            \
+        _(vmv4r_v, 0, 4, 0, ENC(rs1, rs2, vd))            \
+        _(vmv8r_v, 0, 4, 0, ENC(rs1, rs2, vd))            \
         _(vcpop_m, 0, 4, 0, ENC(rs1, rs2, vd))            \
         _(vfirst_m, 0, 4, 0, ENC(rs1, rs2, vd))            \
         _(vmsbf_m, 0, 4, 0, ENC(rs1, rs2, vd))            \

--- a/src/decode_v.c
+++ b/src/decode_v.c
@@ -1594,11 +1594,30 @@ static inline bool op_100111(rv_insn_t *ir, const uint32_t insn)
         ir->opcode = rv_insn_vmulh_vv;
         break;
     case 3:
-        /* OPIVI / vmv<nr>r.v (whole-register move). Not implemented;
-         * reject explicitly so the encoding does not fall through to
-         * vsmul.vx below and silently execute the wrong instruction.
+        /* OPIVI / vmv<nr>r.v (V 1.0 §16.6): simm[2:0] holds NREG-1 using
+         * the nf encoding, so only 0, 1, 3 and 7 are defined; every other
+         * simm[4:0] is reserved. Only the unmasked form exists.
          */
-        return false;
+        if (!decode_vm(insn))
+            return false;
+        switch (decode_rs1(insn)) {
+        case 0:
+            ir->opcode = rv_insn_vmv1r_v;
+            break;
+        case 1:
+            ir->opcode = rv_insn_vmv2r_v;
+            break;
+        case 3:
+            ir->opcode = rv_insn_vmv4r_v;
+            break;
+        case 7:
+            ir->opcode = rv_insn_vmv8r_v;
+            break;
+        default:
+            return false;
+        }
+        decode_vvtype(ir, insn);
+        break;
     case 4:
         decode_vxtype(ir, insn);
         ir->opcode = rv_insn_vsmul_vx;

--- a/src/rv32_v_constopt.c
+++ b/src/rv32_v_constopt.c
@@ -530,6 +530,10 @@ CONSTOPT(vmv_s_x, {})
  * scalar result into GPR rd. As above, the constant tracker must drop
  * rd because none of these are constant-foldable from the GPR file.
  */
+CONSTOPT(vmv1r_v, {})
+CONSTOPT(vmv2r_v, {})
+CONSTOPT(vmv4r_v, {})
+CONSTOPT(vmv8r_v, {})
 CONSTOPT(vmv_x_s, { info->is_constant[ir->rd] = false; })
 CONSTOPT(vcpop_m, { info->is_constant[ir->rd] = false; })
 CONSTOPT(vfirst_m, { info->is_constant[ir->rd] = false; })

--- a/src/rv32_v_template.c
+++ b/src/rv32_v_template.c
@@ -607,6 +607,32 @@ static inline void rvv_zero_reg_bytes(riscv_t *rv, uint32_t reg, uint32_t nregs)
     memset(&rv->V[reg][0], 0, rvv_whole_reg_bytes(rv, nregs));
 }
 
+/* Whole vector register move (V 1.0 §16.6). Copies NREG whole registers,
+ * i.e. all VLEN bits each, as if EEW=SEW and EMUL=NREG. The effective
+ * length is evl = NREG * VLEN/SEW; unlike most instructions the guard is
+ * vstart >= evl rather than vstart >= vl. vd == vs2 is an architectural
+ * NOP.
+ */
+static inline bool rvv_exec_whole_reg_move(riscv_t *rv,
+                                           const rv_insn_t *ir,
+                                           uint32_t nregs)
+{
+    uint32_t sew_bits = rvv_sew_bits(rv->csr_vtype);
+    uint32_t evl, bytes;
+
+    if (!rvv_validate_reg_span(ir->vd, nregs) ||
+        !rvv_validate_reg_span(ir->vs2, nregs))
+        return rvv_trap_illegal_state(rv, 0);
+
+    evl = nregs * ((uint32_t) VLEN / sew_bits);
+    if (rv->csr_vstart < evl && ir->vd != ir->vs2) {
+        bytes = rvv_whole_reg_bytes(rv, nregs);
+        memmove(&rv->V[ir->vd][0], &rv->V[ir->vs2][0], bytes);
+    }
+    rv->csr_vstart = 0;
+    return true;
+}
+
 /* Whole-register vl<n>r.v / vs<n>r.v transfers. Per V 1.0 §7.9 these
  * instructions ignore vl AND vstart entirely, AND must NOT modify vstart
  * on completion. Caller is responsible for vd alignment validation; this
@@ -6427,6 +6453,34 @@ RVOP(vmv_s_x, {
     if (!ir->vm)
         return rvv_trap_illegal_state(rv, 0);
     rvv_exec_vmv_s_x(rv, ir);
+})
+
+RVOP(vmv1r_v, {
+    if (rvv_require_operable(rv))
+        return false;
+    if (!rvv_exec_whole_reg_move(rv, ir, 1))
+        return false;
+})
+
+RVOP(vmv2r_v, {
+    if (rvv_require_operable(rv))
+        return false;
+    if (!rvv_exec_whole_reg_move(rv, ir, 2))
+        return false;
+})
+
+RVOP(vmv4r_v, {
+    if (rvv_require_operable(rv))
+        return false;
+    if (!rvv_exec_whole_reg_move(rv, ir, 4))
+        return false;
+})
+
+RVOP(vmv8r_v, {
+    if (rvv_require_operable(rv))
+        return false;
+    if (!rvv_exec_whole_reg_move(rv, ir, 8))
+        return false;
 })
 
 RVOP(vmv_x_s, {

--- a/tests/rvv-smoke.S
+++ b/tests/rvv-smoke.S
@@ -296,6 +296,8 @@ fixed_out:
     .space 16
 wide_out:
     .space 32
+vmvnr_out:
+    .space 64
 red_out:
     .space 16
 wide_red_out:
@@ -1813,6 +1815,73 @@ _start:
     csrr t1, vl
     assert_reg_imm t1, 4, fail_fractional
 
+    # Whole vector register move (V 1.0 16.6). Copies all VLEN bits of NREG
+    # registers, ignoring vl. Every address below comes from a1 so the test
+    # does not mix gp-relative and pc-relative forms.
+    li a0, 4
+    vsetvli t0, a0, e32, m1, tu, mu
+    la a1, vmvnr_out
+    li t2, 0xaaaa0001
+    sw t2, 0(a1)
+    li t2, 0xaaaa0002
+    sw t2, 4(a1)
+    li t2, 0xaaaa0003
+    sw t2, 8(a1)
+    li t2, 0xaaaa0004
+    sw t2, 12(a1)
+    vle32.v v8, (a1)
+
+    # Clear v16 so a failed copy is visible.
+    li t2, 0
+    sw t2, 0(a1)
+    sw t2, 4(a1)
+    sw t2, 8(a1)
+    sw t2, 12(a1)
+    vle32.v v16, (a1)
+
+    vmv1r.v v16, v8
+    vse32.v v16, (a1)
+    lw t1, 0(a1)
+    li t6, 0xaaaa0001
+    bne t1, t6, fail_vmv1r
+    lw t1, 12(a1)
+    li t6, 0xaaaa0004
+    bne t1, t6, fail_vmv1r
+
+    # vmv2r.v copies the pair {v8,v9} to {v16,v17}; check the second
+    # register of the group actually moved.
+    li t2, 0xbbbb0001
+    sw t2, 0(a1)
+    li t2, 0xbbbb0002
+    sw t2, 4(a1)
+    li t2, 0xbbbb0003
+    sw t2, 8(a1)
+    li t2, 0xbbbb0004
+    sw t2, 12(a1)
+    vle32.v v9, (a1)
+    li t2, 0
+    sw t2, 0(a1)
+    sw t2, 4(a1)
+    sw t2, 8(a1)
+    sw t2, 12(a1)
+    vle32.v v17, (a1)
+
+    vmv2r.v v16, v8
+    vse32.v v17, (a1)
+    lw t1, 0(a1)
+    li t6, 0xbbbb0001
+    bne t1, t6, fail_vmv2r
+    lw t1, 12(a1)
+    li t6, 0xbbbb0004
+    bne t1, t6, fail_vmv2r
+
+    # vd == vs2 is an architectural NOP: the register must be unchanged.
+    vmv1r.v v8, v8
+    vse32.v v8, (a1)
+    lw t1, 0(a1)
+    li t6, 0xaaaa0001
+    bne t1, t6, fail_vmv_nop
+
     la a1, ok_msg
     li a2, ok_msg_len
     j write_and_exit_ok
@@ -1910,6 +1979,15 @@ fail_vsmul4:
     j write_and_exit_fail
 fail_vwadd:
     li a3, 0xd5
+    j write_and_exit_fail
+fail_vmv1r:
+    li a3, 0x9a
+    j write_and_exit_fail
+fail_vmv2r:
+    li a3, 0x9b
+    j write_and_exit_fail
+fail_vmv_nop:
+    li a3, 0x9c
     j write_and_exit_fail
 fail_vwmulu:
     li a3, 0xd6


### PR DESCRIPTION
Implements the whole-register move family from #734.

Adds `vmv<nr>r.v` (V 1.0 §16.6) at the OPIVI site of funct6=0x27, which was
previously rejected with a FIXME so the encoding would not fall through to
`vsmul.vx`.

These copy NREG whole vector registers — all VLEN bits each — operating as
if EEW=SEW and EMUL=NREG. Three details from the spec are worth calling out:

- the effective length is `evl = NREG * VLEN/SEW`, so the guard is
  `vstart >= evl`, not the usual `vstart >= vl`;
- `vd == vs2` is an architectural NOP;
- only `simm[2:0]` values 0, 1, 3 and 7 encode NREG-1. Every other
  `simm[4:0]` is reserved, as is the masked form.

Encodings checked against riscv-opcodes. Decode tests cover the four valid
forms, seven reserved `simm` values, the masked forms, and confirm
`vsmul.vx` still decodes from the same funct6.

Smoke coverage exercises `vmv1r.v`, the second register of a `vmv2r.v` group
(so a copy that moves only one register is caught), and the `vd == vs2` NOP.
`make check` passes; the build was checked in the default, `EXT_V`,
JIT+`EXT_V` and `EXT_V`-without-`EXT_F` configurations. clang-format 20.1.7
clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the `vmv<nr>r.v` whole-register move family (V 1.0 §16.6) for RVV. Previously these encodings were rejected to prevent falling through to `vsmul.vx`; now they decode and execute correctly, including the special effective-length guard and the architectural NOP when `vd == vs2`.

- Only `simm[2:0]` values 0, 1, 3, and 7 are valid; all other `simm[4:0]` values and the masked form are reserved.
- The effective length is `evl = NREG * VLEN/SEW`, so the guard is `vstart >= evl`, not `vstart >= vl`.
- Decode tests cover the four valid forms, seven reserved `simm` values, masked forms, and confirm `vsmul.vx` still decodes from the same funct6.
- Smoke tests exercise `vmv1r.v`, the second register of a `vmv2r.v` group, and the `vd == vs2` NOP.
- `make check` passes across the default, `EXT_V`, JIT+`EXT_V`, and `EXT_V`-without-`EXT_F` configurations.

<sup>Written for commit fdfadf847bb9d191c0128618b49fcca580f92a2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/rv32emu/pull/768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

