### PR TITLE
Fix the cross-EEW overlap rule for widening vector operations

### DIFF
--- a/src/rv32_v_template.c
+++ b/src/rv32_v_template.c
@@ -463,24 +463,71 @@ static inline bool rvv_reg_spans_overlap(uint32_t reg_a,
     return (reg_a < (reg_b + span_b)) && (reg_b < (reg_a + span_a));
 }
 
-/* Cross-EEW overlap rule per V 1.0 §11.2 (widening) and §11.3 (narrowing):
- * a wider register group may not overlap a narrower one EXCEPT when the
- * narrower group occupies the lower portion of the wider group - i.e.,
- * both groups share the same base register. Returns true when the overlap
- * is illegal (caller should raise illegal-instruction).
- *
- * Both widening and narrowing share this predicate because the spec rule
- * is symmetric: overlap is allowed only when the lower-numbered half of
- * the wider group is the narrower group itself (reg_a == reg_b).
+/* Cross-EEW overlap rules per V 1.0 §5.2: a destination vector register
+ * group may overlap a source group only if the destination EEW equals the
+ * source EEW, or one of the two asymmetric cases below holds. The narrowing
+ * and widening directions are NOT mirror images of each other, so they get
+ * separate predicates. Both return true when the overlap is illegal (caller
+ * should raise illegal-instruction).
  */
-static inline bool rvv_cross_eew_overlap_illegal(uint32_t reg_a,
-                                                 uint32_t span_a,
-                                                 uint32_t reg_b,
-                                                 uint32_t span_b)
+
+/* Narrowing (destination EEW < source EEW): the overlap must be in the
+ * lowest-numbered part of the source register group - e.g., at LMUL=1
+ * "vnsrl.wi v0, v0, 3" is legal but a destination of v1 is not. As the
+ * destination is the narrower group here, "lowest part of the source"
+ * reduces to the two groups sharing a base register.
+ */
+static inline bool rvv_narrow_overlap_illegal(uint32_t dest_reg,
+                                              uint32_t dest_span,
+                                              uint32_t src_reg,
+                                              uint32_t src_span)
 {
-    if (!rvv_reg_spans_overlap(reg_a, span_a, reg_b, span_b))
+    if (!rvv_reg_spans_overlap(dest_reg, dest_span, src_reg, src_span))
         return false;
-    return reg_a != reg_b;
+    return dest_reg != src_reg;
+}
+
+/* Widening (destination EEW > source EEW): the source EMUL must be at least
+ * 1 AND the overlap must be in the highest-numbered part of the destination
+ * register group - e.g., at LMUL=8 "vzext.vf4 v0, v6" is legal, but a source
+ * of v0, v2 or v4 is not. "Highest part of the destination" means the source
+ * group ends exactly where the destination group ends.
+ *
+ * src_emul_at_least_1 must be supplied by the caller rather than derived from
+ * src_span: rvv_eew_reg_span() clamps a fractional EMUL up to a span of 1, so
+ * a span of 1 alone cannot distinguish EMUL=1 from EMUL=1/2.
+ */
+static inline bool rvv_widen_overlap_illegal(uint32_t dest_reg,
+                                             uint32_t dest_span,
+                                             uint32_t src_reg,
+                                             uint32_t src_span,
+                                             bool src_emul_at_least_1)
+{
+    if (!rvv_reg_spans_overlap(dest_reg, dest_span, src_reg, src_span))
+        return false;
+    if (!src_emul_at_least_1)
+        return true;
+    return (src_reg + src_span) != (dest_reg + dest_span);
+}
+
+/* True when EMUL for an operand read at eew is at least 1, where
+ * EMUL = (eew / SEW) * LMUL per V 1.0 §7.6.1. The widening overlap rule
+ * needs this separately from rvv_eew_reg_span(), which clamps a fractional
+ * EMUL up to a span of 1 and so cannot express "EMUL < 1".
+ */
+static inline bool rvv_emul_at_least_1(riscv_t *rv, uint32_t eew)
+{
+    uint32_t lmul_num, lmul_den;
+
+    rvv_lmul_ratio(rv->csr_vtype, &lmul_num, &lmul_den);
+    return (uint64_t) lmul_num * eew >=
+           (uint64_t) lmul_den * rvv_sew_bits(rv->csr_vtype);
+}
+
+/* Widening ops read their narrow sources at SEW, for which EMUL == LMUL. */
+static inline bool rvv_sew_emul_at_least_1(riscv_t *rv)
+{
+    return rvv_emul_at_least_1(rv, rvv_sew_bits(rv->csr_vtype));
 }
 
 /* Compute the register-group span for an instruction whose effective
@@ -1167,28 +1214,39 @@ static inline bool rvv_segment_indexed_store(riscv_t *rv,
             return false;                                                   \
     })
 
-#define RVV_SEGMENT_INDEXED_LOAD_OP(name, nf_value)                          \
-    RVOP(name, {                                                             \
-        uint32_t data_span = rvv_group_regs(rv->csr_vtype);                  \
-        uint32_t index_span;                                                 \
-        uint32_t total_dest_span;                                            \
-        if (rvv_require_operable(rv))                                        \
-            return false;                                                    \
-        if (!rvv_validate_segment_reg_group(ir->vd, data_span, nf_value) ||  \
-            !rvv_index_group_span(rv, ir->eew, &index_span) ||               \
-            !rvv_validate_reg_span(ir->vs2, index_span))                     \
-            return rvv_trap_illegal_state(rv, 0);                            \
-        total_dest_span = data_span * (nf_value);                            \
-        if (!ir->vm && rvv_reg_spans_overlap(ir->vd, total_dest_span, 0, 1)) \
-            return rvv_trap_illegal_state(rv, 0);                            \
-        if (data_span != index_span                                          \
-                ? rvv_cross_eew_overlap_illegal(ir->vd, total_dest_span,     \
-                                                ir->vs2, index_span)         \
-                : rvv_reg_spans_overlap(ir->vd, total_dest_span, ir->vs2,    \
-                                        index_span))                         \
-            return rvv_trap_illegal_state(rv, 0);                            \
-        if (!rvv_segment_indexed_load(rv, ir, ir->vd, nf_value))             \
-            return false;                                                    \
+#define RVV_SEGMENT_INDEXED_LOAD_OP(name, nf_value)                            \
+    RVOP(name, {                                                               \
+        uint32_t data_span = rvv_group_regs(rv->csr_vtype);                    \
+        uint32_t index_span;                                                   \
+        uint32_t total_dest_span;                                              \
+        if (rvv_require_operable(rv))                                          \
+            return false;                                                      \
+        if (!rvv_validate_segment_reg_group(ir->vd, data_span, nf_value) ||    \
+            !rvv_index_group_span(rv, ir->eew, &index_span) ||                 \
+            !rvv_validate_reg_span(ir->vs2, index_span))                       \
+            return rvv_trap_illegal_state(rv, 0);                              \
+        total_dest_span = data_span * (nf_value);                              \
+        if (!ir->vm && rvv_reg_spans_overlap(ir->vd, total_dest_span, 0, 1))   \
+            return rvv_trap_illegal_state(rv, 0);                              \
+        /* Destination EEW is SEW; the index source EEW is ir->eew. Per        \
+         * V 1.0 §5.2 the legal-overlap rule differs by direction, so it is   \
+         * selected from the two EEWs themselves. The register spans cannot    \
+         * stand in for that comparison: rvv_eew_reg_span() clamps a           \
+         * fractional EMUL up to a span of one register, so two different      \
+         * EEWs can both arrive as a span of 1.                                \
+         */                                                                    \
+        if (ir->eew < rvv_sew_bits(rv->csr_vtype)                              \
+                ? rvv_widen_overlap_illegal(ir->vd, total_dest_span, ir->vs2,  \
+                                            index_span,                        \
+                                            rvv_emul_at_least_1(rv, ir->eew))  \
+            : ir->eew > rvv_sew_bits(rv->csr_vtype)                            \
+                ? rvv_narrow_overlap_illegal(ir->vd, total_dest_span, ir->vs2, \
+                                             index_span)                       \
+                : rvv_reg_spans_overlap(ir->vd, total_dest_span, ir->vs2,      \
+                                        index_span))                           \
+            return rvv_trap_illegal_state(rv, 0);                              \
+        if (!rvv_segment_indexed_load(rv, ir, ir->vd, nf_value))               \
+            return false;                                                      \
     })
 
 #define RVV_SEGMENT_INDEXED_STORE_OP(name, nf_value)                         \
@@ -5231,7 +5289,7 @@ RVOP(vnsrl_wv, {
         !rvv_validate_wide_reg(rv, ir->vs2) ||
         !rvv_validate_data_reg(rv->csr_vtype, ir->vs1))
         return rvv_trap_illegal_state(rv, 0);
-    if (rvv_cross_eew_overlap_illegal(ir->vd, narrow_span, ir->vs2, wide_span))
+    if (rvv_narrow_overlap_illegal(ir->vd, narrow_span, ir->vs2, wide_span))
         return rvv_trap_illegal_state(rv, 0);
     rvv_exec_narrow_shift_vv(rv, ir, ir->vd, rvv_nop_vnsrl);
 })
@@ -5245,7 +5303,7 @@ RVOP(vnsrl_wx, {
         !rvv_validate_data_reg(rv->csr_vtype, ir->vd) ||
         !rvv_validate_wide_reg(rv, ir->vs2))
         return rvv_trap_illegal_state(rv, 0);
-    if (rvv_cross_eew_overlap_illegal(ir->vd, narrow_span, ir->vs2, wide_span))
+    if (rvv_narrow_overlap_illegal(ir->vd, narrow_span, ir->vs2, wide_span))
         return rvv_trap_illegal_state(rv, 0);
     rvv_exec_narrow_shift_vx(rv, ir, ir->vd, rvv_nop_vnsrl);
 })
@@ -5259,7 +5317,7 @@ RVOP(vnsrl_wi, {
         !rvv_validate_data_reg(rv->csr_vtype, ir->vd) ||
         !rvv_validate_wide_reg(rv, ir->vs2))
         return rvv_trap_illegal_state(rv, 0);
-    if (rvv_cross_eew_overlap_illegal(ir->vd, narrow_span, ir->vs2, wide_span))
+    if (rvv_narrow_overlap_illegal(ir->vd, narrow_span, ir->vs2, wide_span))
         return rvv_trap_illegal_state(rv, 0);
     rvv_exec_narrow_shift_vi(rv, ir, ir->vd, rvv_nop_vnsrl);
 })
@@ -5274,7 +5332,7 @@ RVOP(vnsra_wv, {
         !rvv_validate_wide_reg(rv, ir->vs2) ||
         !rvv_validate_data_reg(rv->csr_vtype, ir->vs1))
         return rvv_trap_illegal_state(rv, 0);
-    if (rvv_cross_eew_overlap_illegal(ir->vd, narrow_span, ir->vs2, wide_span))
+    if (rvv_narrow_overlap_illegal(ir->vd, narrow_span, ir->vs2, wide_span))
         return rvv_trap_illegal_state(rv, 0);
     rvv_exec_narrow_shift_vv(rv, ir, ir->vd, rvv_nop_vnsra);
 })
@@ -5288,7 +5346,7 @@ RVOP(vnsra_wx, {
         !rvv_validate_data_reg(rv->csr_vtype, ir->vd) ||
         !rvv_validate_wide_reg(rv, ir->vs2))
         return rvv_trap_illegal_state(rv, 0);
-    if (rvv_cross_eew_overlap_illegal(ir->vd, narrow_span, ir->vs2, wide_span))
+    if (rvv_narrow_overlap_illegal(ir->vd, narrow_span, ir->vs2, wide_span))
         return rvv_trap_illegal_state(rv, 0);
     rvv_exec_narrow_shift_vx(rv, ir, ir->vd, rvv_nop_vnsra);
 })
@@ -5302,7 +5360,7 @@ RVOP(vnsra_wi, {
         !rvv_validate_data_reg(rv->csr_vtype, ir->vd) ||
         !rvv_validate_wide_reg(rv, ir->vs2))
         return rvv_trap_illegal_state(rv, 0);
-    if (rvv_cross_eew_overlap_illegal(ir->vd, narrow_span, ir->vs2, wide_span))
+    if (rvv_narrow_overlap_illegal(ir->vd, narrow_span, ir->vs2, wide_span))
         return rvv_trap_illegal_state(rv, 0);
     rvv_exec_narrow_shift_vi(rv, ir, ir->vd, rvv_nop_vnsra);
 })
@@ -5317,7 +5375,7 @@ RVOP(vnclipu_wv, {
         !rvv_validate_wide_reg(rv, ir->vs2) ||
         !rvv_validate_data_reg(rv->csr_vtype, ir->vs1))
         return rvv_trap_illegal_state(rv, 0);
-    if (rvv_cross_eew_overlap_illegal(ir->vd, narrow_span, ir->vs2, wide_span))
+    if (rvv_narrow_overlap_illegal(ir->vd, narrow_span, ir->vs2, wide_span))
         return rvv_trap_illegal_state(rv, 0);
     rvv_exec_narrow_shift_vv(rv, ir, ir->vd, rvv_nop_vnclipu);
 })
@@ -5331,7 +5389,7 @@ RVOP(vnclipu_wx, {
         !rvv_validate_data_reg(rv->csr_vtype, ir->vd) ||
         !rvv_validate_wide_reg(rv, ir->vs2))
         return rvv_trap_illegal_state(rv, 0);
-    if (rvv_cross_eew_overlap_illegal(ir->vd, narrow_span, ir->vs2, wide_span))
+    if (rvv_narrow_overlap_illegal(ir->vd, narrow_span, ir->vs2, wide_span))
         return rvv_trap_illegal_state(rv, 0);
     rvv_exec_narrow_shift_vx(rv, ir, ir->vd, rvv_nop_vnclipu);
 })
@@ -5345,7 +5403,7 @@ RVOP(vnclipu_wi, {
         !rvv_validate_data_reg(rv->csr_vtype, ir->vd) ||
         !rvv_validate_wide_reg(rv, ir->vs2))
         return rvv_trap_illegal_state(rv, 0);
-    if (rvv_cross_eew_overlap_illegal(ir->vd, narrow_span, ir->vs2, wide_span))
+    if (rvv_narrow_overlap_illegal(ir->vd, narrow_span, ir->vs2, wide_span))
         return rvv_trap_illegal_state(rv, 0);
     rvv_exec_narrow_shift_vi(rv, ir, ir->vd, rvv_nop_vnclipu);
 })
@@ -5360,7 +5418,7 @@ RVOP(vnclip_wv, {
         !rvv_validate_wide_reg(rv, ir->vs2) ||
         !rvv_validate_data_reg(rv->csr_vtype, ir->vs1))
         return rvv_trap_illegal_state(rv, 0);
-    if (rvv_cross_eew_overlap_illegal(ir->vd, narrow_span, ir->vs2, wide_span))
+    if (rvv_narrow_overlap_illegal(ir->vd, narrow_span, ir->vs2, wide_span))
         return rvv_trap_illegal_state(rv, 0);
     rvv_exec_narrow_shift_vv(rv, ir, ir->vd, rvv_nop_vnclip);
 })
@@ -5374,7 +5432,7 @@ RVOP(vnclip_wx, {
         !rvv_validate_data_reg(rv->csr_vtype, ir->vd) ||
         !rvv_validate_wide_reg(rv, ir->vs2))
         return rvv_trap_illegal_state(rv, 0);
-    if (rvv_cross_eew_overlap_illegal(ir->vd, narrow_span, ir->vs2, wide_span))
+    if (rvv_narrow_overlap_illegal(ir->vd, narrow_span, ir->vs2, wide_span))
         return rvv_trap_illegal_state(rv, 0);
     rvv_exec_narrow_shift_vx(rv, ir, ir->vd, rvv_nop_vnclip);
 })
@@ -5388,7 +5446,7 @@ RVOP(vnclip_wi, {
         !rvv_validate_data_reg(rv->csr_vtype, ir->vd) ||
         !rvv_validate_wide_reg(rv, ir->vs2))
         return rvv_trap_illegal_state(rv, 0);
-    if (rvv_cross_eew_overlap_illegal(ir->vd, narrow_span, ir->vs2, wide_span))
+    if (rvv_narrow_overlap_illegal(ir->vd, narrow_span, ir->vs2, wide_span))
         return rvv_trap_illegal_state(rv, 0);
     rvv_exec_narrow_shift_vi(rv, ir, ir->vd, rvv_nop_vnclip);
 })
@@ -5923,9 +5981,10 @@ RVOP(vwaddu_vv, {
         !rvv_validate_data_reg(rv->csr_vtype, ir->vs1) ||
         !rvv_validate_data_reg(rv->csr_vtype, ir->vs2))
         return rvv_trap_illegal_state(rv, 0);
-    if (rvv_cross_eew_overlap_illegal(ir->vd, wide_span, ir->vs1,
-                                      narrow_span) ||
-        rvv_cross_eew_overlap_illegal(ir->vd, wide_span, ir->vs2, narrow_span))
+    if (rvv_widen_overlap_illegal(ir->vd, wide_span, ir->vs1, narrow_span,
+                                  rvv_sew_emul_at_least_1(rv)) ||
+        rvv_widen_overlap_illegal(ir->vd, wide_span, ir->vs2, narrow_span,
+                                  rvv_sew_emul_at_least_1(rv)))
         return rvv_trap_illegal_state(rv, 0);
     rvv_exec_wide_narrow_vv(rv, ir, ir->vd, rvv_wop_addu);
 })
@@ -5939,7 +5998,8 @@ RVOP(vwaddu_vx, {
         !rvv_validate_wide_reg(rv, ir->vd) ||
         !rvv_validate_data_reg(rv->csr_vtype, ir->vs2))
         return rvv_trap_illegal_state(rv, 0);
-    if (rvv_cross_eew_overlap_illegal(ir->vd, wide_span, ir->vs2, narrow_span))
+    if (rvv_widen_overlap_illegal(ir->vd, wide_span, ir->vs2, narrow_span,
+                                  rvv_sew_emul_at_least_1(rv)))
         return rvv_trap_illegal_state(rv, 0);
     rvv_exec_wide_narrow_vx(rv, ir, ir->vd, rvv_wop_addu);
 })
@@ -5954,9 +6014,10 @@ RVOP(vwadd_vv, {
         !rvv_validate_data_reg(rv->csr_vtype, ir->vs1) ||
         !rvv_validate_data_reg(rv->csr_vtype, ir->vs2))
         return rvv_trap_illegal_state(rv, 0);
-    if (rvv_cross_eew_overlap_illegal(ir->vd, wide_span, ir->vs1,
-                                      narrow_span) ||
-        rvv_cross_eew_overlap_illegal(ir->vd, wide_span, ir->vs2, narrow_span))
+    if (rvv_widen_overlap_illegal(ir->vd, wide_span, ir->vs1, narrow_span,
+                                  rvv_sew_emul_at_least_1(rv)) ||
+        rvv_widen_overlap_illegal(ir->vd, wide_span, ir->vs2, narrow_span,
+                                  rvv_sew_emul_at_least_1(rv)))
         return rvv_trap_illegal_state(rv, 0);
     rvv_exec_wide_narrow_vv(rv, ir, ir->vd, rvv_wop_add);
 })
@@ -5972,8 +6033,9 @@ RVOP(vwadd_vx, {
         uint32_t narrow_span_cx = rvv_group_regs(rv->csr_vtype);
         if (!rvv_wide_group_span(rv, &wide_span_cx))
             return rvv_trap_illegal_state(rv, 0);
-        if (rvv_cross_eew_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
-                                          narrow_span_cx))
+        if (rvv_widen_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
+                                      narrow_span_cx,
+                                      rvv_sew_emul_at_least_1(rv)))
             return rvv_trap_illegal_state(rv, 0);
     }
     rvv_exec_wide_narrow_vx(rv, ir, ir->vd, rvv_wop_add);
@@ -5989,9 +6051,10 @@ RVOP(vwsubu_vv, {
         !rvv_validate_data_reg(rv->csr_vtype, ir->vs1) ||
         !rvv_validate_data_reg(rv->csr_vtype, ir->vs2))
         return rvv_trap_illegal_state(rv, 0);
-    if (rvv_cross_eew_overlap_illegal(ir->vd, wide_span, ir->vs1,
-                                      narrow_span) ||
-        rvv_cross_eew_overlap_illegal(ir->vd, wide_span, ir->vs2, narrow_span))
+    if (rvv_widen_overlap_illegal(ir->vd, wide_span, ir->vs1, narrow_span,
+                                  rvv_sew_emul_at_least_1(rv)) ||
+        rvv_widen_overlap_illegal(ir->vd, wide_span, ir->vs2, narrow_span,
+                                  rvv_sew_emul_at_least_1(rv)))
         return rvv_trap_illegal_state(rv, 0);
     rvv_exec_wide_narrow_vv(rv, ir, ir->vd, rvv_wop_subu);
 })
@@ -6007,8 +6070,9 @@ RVOP(vwsubu_vx, {
         uint32_t narrow_span_cx = rvv_group_regs(rv->csr_vtype);
         if (!rvv_wide_group_span(rv, &wide_span_cx))
             return rvv_trap_illegal_state(rv, 0);
-        if (rvv_cross_eew_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
-                                          narrow_span_cx))
+        if (rvv_widen_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
+                                      narrow_span_cx,
+                                      rvv_sew_emul_at_least_1(rv)))
             return rvv_trap_illegal_state(rv, 0);
     }
     rvv_exec_wide_narrow_vx(rv, ir, ir->vd, rvv_wop_subu);
@@ -6024,9 +6088,10 @@ RVOP(vwsub_vv, {
         !rvv_validate_data_reg(rv->csr_vtype, ir->vs1) ||
         !rvv_validate_data_reg(rv->csr_vtype, ir->vs2))
         return rvv_trap_illegal_state(rv, 0);
-    if (rvv_cross_eew_overlap_illegal(ir->vd, wide_span, ir->vs1,
-                                      narrow_span) ||
-        rvv_cross_eew_overlap_illegal(ir->vd, wide_span, ir->vs2, narrow_span))
+    if (rvv_widen_overlap_illegal(ir->vd, wide_span, ir->vs1, narrow_span,
+                                  rvv_sew_emul_at_least_1(rv)) ||
+        rvv_widen_overlap_illegal(ir->vd, wide_span, ir->vs2, narrow_span,
+                                  rvv_sew_emul_at_least_1(rv)))
         return rvv_trap_illegal_state(rv, 0);
     rvv_exec_wide_narrow_vv(rv, ir, ir->vd, rvv_wop_sub);
 })
@@ -6042,8 +6107,9 @@ RVOP(vwsub_vx, {
         uint32_t narrow_span_cx = rvv_group_regs(rv->csr_vtype);
         if (!rvv_wide_group_span(rv, &wide_span_cx))
             return rvv_trap_illegal_state(rv, 0);
-        if (rvv_cross_eew_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
-                                          narrow_span_cx))
+        if (rvv_widen_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
+                                      narrow_span_cx,
+                                      rvv_sew_emul_at_least_1(rv)))
             return rvv_trap_illegal_state(rv, 0);
     }
     rvv_exec_wide_narrow_vx(rv, ir, ir->vd, rvv_wop_sub);
@@ -6063,8 +6129,9 @@ RVOP(vwaddu_wv, {
             return rvv_trap_illegal_state(rv, 0);
         /* vs2 has the same EEW as vd (both 2*SEW); only vs1 (SEW) is a
          * cross-EEW source for the lower-half overlap rule. */
-        if (rvv_cross_eew_overlap_illegal(ir->vd, wide_span_cx, ir->vs1,
-                                          narrow_span_cx))
+        if (rvv_widen_overlap_illegal(ir->vd, wide_span_cx, ir->vs1,
+                                      narrow_span_cx,
+                                      rvv_sew_emul_at_least_1(rv)))
             return rvv_trap_illegal_state(rv, 0);
     }
     rvv_exec_wide_mixed_vv(rv, ir, ir->vd, rvv_wop_addu_mixed);
@@ -6093,8 +6160,9 @@ RVOP(vwadd_wv, {
             return rvv_trap_illegal_state(rv, 0);
         /* vs2 has the same EEW as vd (both 2*SEW); only vs1 (SEW) is a
          * cross-EEW source for the lower-half overlap rule. */
-        if (rvv_cross_eew_overlap_illegal(ir->vd, wide_span_cx, ir->vs1,
-                                          narrow_span_cx))
+        if (rvv_widen_overlap_illegal(ir->vd, wide_span_cx, ir->vs1,
+                                      narrow_span_cx,
+                                      rvv_sew_emul_at_least_1(rv)))
             return rvv_trap_illegal_state(rv, 0);
     }
     rvv_exec_wide_mixed_vv(rv, ir, ir->vd, rvv_wop_add_mixed);
@@ -6123,8 +6191,9 @@ RVOP(vwsubu_wv, {
             return rvv_trap_illegal_state(rv, 0);
         /* vs2 has the same EEW as vd (both 2*SEW); only vs1 (SEW) is a
          * cross-EEW source for the lower-half overlap rule. */
-        if (rvv_cross_eew_overlap_illegal(ir->vd, wide_span_cx, ir->vs1,
-                                          narrow_span_cx))
+        if (rvv_widen_overlap_illegal(ir->vd, wide_span_cx, ir->vs1,
+                                      narrow_span_cx,
+                                      rvv_sew_emul_at_least_1(rv)))
             return rvv_trap_illegal_state(rv, 0);
     }
     rvv_exec_wide_mixed_vv(rv, ir, ir->vd, rvv_wop_subu_mixed);
@@ -6153,8 +6222,9 @@ RVOP(vwsub_wv, {
             return rvv_trap_illegal_state(rv, 0);
         /* vs2 has the same EEW as vd (both 2*SEW); only vs1 (SEW) is a
          * cross-EEW source for the lower-half overlap rule. */
-        if (rvv_cross_eew_overlap_illegal(ir->vd, wide_span_cx, ir->vs1,
-                                          narrow_span_cx))
+        if (rvv_widen_overlap_illegal(ir->vd, wide_span_cx, ir->vs1,
+                                      narrow_span_cx,
+                                      rvv_sew_emul_at_least_1(rv)))
             return rvv_trap_illegal_state(rv, 0);
     }
     rvv_exec_wide_mixed_vv(rv, ir, ir->vd, rvv_wop_sub_mixed);
@@ -6181,10 +6251,12 @@ RVOP(vwmulu_vv, {
         uint32_t narrow_span_cx = rvv_group_regs(rv->csr_vtype);
         if (!rvv_wide_group_span(rv, &wide_span_cx))
             return rvv_trap_illegal_state(rv, 0);
-        if (rvv_cross_eew_overlap_illegal(ir->vd, wide_span_cx, ir->vs1,
-                                          narrow_span_cx) ||
-            rvv_cross_eew_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
-                                          narrow_span_cx))
+        if (rvv_widen_overlap_illegal(ir->vd, wide_span_cx, ir->vs1,
+                                      narrow_span_cx,
+                                      rvv_sew_emul_at_least_1(rv)) ||
+            rvv_widen_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
+                                      narrow_span_cx,
+                                      rvv_sew_emul_at_least_1(rv)))
             return rvv_trap_illegal_state(rv, 0);
     }
     rvv_exec_wide_narrow_vv(rv, ir, ir->vd, rvv_wop_mulu);
@@ -6201,8 +6273,9 @@ RVOP(vwmulu_vx, {
         uint32_t narrow_span_cx = rvv_group_regs(rv->csr_vtype);
         if (!rvv_wide_group_span(rv, &wide_span_cx))
             return rvv_trap_illegal_state(rv, 0);
-        if (rvv_cross_eew_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
-                                          narrow_span_cx))
+        if (rvv_widen_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
+                                      narrow_span_cx,
+                                      rvv_sew_emul_at_least_1(rv)))
             return rvv_trap_illegal_state(rv, 0);
     }
     rvv_exec_wide_narrow_vx(rv, ir, ir->vd, rvv_wop_mulu);
@@ -6220,10 +6293,12 @@ RVOP(vwmulsu_vv, {
         uint32_t narrow_span_cx = rvv_group_regs(rv->csr_vtype);
         if (!rvv_wide_group_span(rv, &wide_span_cx))
             return rvv_trap_illegal_state(rv, 0);
-        if (rvv_cross_eew_overlap_illegal(ir->vd, wide_span_cx, ir->vs1,
-                                          narrow_span_cx) ||
-            rvv_cross_eew_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
-                                          narrow_span_cx))
+        if (rvv_widen_overlap_illegal(ir->vd, wide_span_cx, ir->vs1,
+                                      narrow_span_cx,
+                                      rvv_sew_emul_at_least_1(rv)) ||
+            rvv_widen_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
+                                      narrow_span_cx,
+                                      rvv_sew_emul_at_least_1(rv)))
             return rvv_trap_illegal_state(rv, 0);
     }
     rvv_exec_wide_narrow_vv(rv, ir, ir->vd, rvv_wop_mulsu);
@@ -6240,8 +6315,9 @@ RVOP(vwmulsu_vx, {
         uint32_t narrow_span_cx = rvv_group_regs(rv->csr_vtype);
         if (!rvv_wide_group_span(rv, &wide_span_cx))
             return rvv_trap_illegal_state(rv, 0);
-        if (rvv_cross_eew_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
-                                          narrow_span_cx))
+        if (rvv_widen_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
+                                      narrow_span_cx,
+                                      rvv_sew_emul_at_least_1(rv)))
             return rvv_trap_illegal_state(rv, 0);
     }
     rvv_exec_wide_narrow_vx(rv, ir, ir->vd, rvv_wop_mulsu);
@@ -6259,10 +6335,12 @@ RVOP(vwmul_vv, {
         uint32_t narrow_span_cx = rvv_group_regs(rv->csr_vtype);
         if (!rvv_wide_group_span(rv, &wide_span_cx))
             return rvv_trap_illegal_state(rv, 0);
-        if (rvv_cross_eew_overlap_illegal(ir->vd, wide_span_cx, ir->vs1,
-                                          narrow_span_cx) ||
-            rvv_cross_eew_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
-                                          narrow_span_cx))
+        if (rvv_widen_overlap_illegal(ir->vd, wide_span_cx, ir->vs1,
+                                      narrow_span_cx,
+                                      rvv_sew_emul_at_least_1(rv)) ||
+            rvv_widen_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
+                                      narrow_span_cx,
+                                      rvv_sew_emul_at_least_1(rv)))
             return rvv_trap_illegal_state(rv, 0);
     }
     rvv_exec_wide_narrow_vv(rv, ir, ir->vd, rvv_wop_mul);
@@ -6279,8 +6357,9 @@ RVOP(vwmul_vx, {
         uint32_t narrow_span_cx = rvv_group_regs(rv->csr_vtype);
         if (!rvv_wide_group_span(rv, &wide_span_cx))
             return rvv_trap_illegal_state(rv, 0);
-        if (rvv_cross_eew_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
-                                          narrow_span_cx))
+        if (rvv_widen_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
+                                      narrow_span_cx,
+                                      rvv_sew_emul_at_least_1(rv)))
             return rvv_trap_illegal_state(rv, 0);
     }
     rvv_exec_wide_narrow_vx(rv, ir, ir->vd, rvv_wop_mul);
@@ -6298,10 +6377,12 @@ RVOP(vwmaccu_vv, {
         uint32_t narrow_span_cx = rvv_group_regs(rv->csr_vtype);
         if (!rvv_wide_group_span(rv, &wide_span_cx))
             return rvv_trap_illegal_state(rv, 0);
-        if (rvv_cross_eew_overlap_illegal(ir->vd, wide_span_cx, ir->vs1,
-                                          narrow_span_cx) ||
-            rvv_cross_eew_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
-                                          narrow_span_cx))
+        if (rvv_widen_overlap_illegal(ir->vd, wide_span_cx, ir->vs1,
+                                      narrow_span_cx,
+                                      rvv_sew_emul_at_least_1(rv)) ||
+            rvv_widen_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
+                                      narrow_span_cx,
+                                      rvv_sew_emul_at_least_1(rv)))
             return rvv_trap_illegal_state(rv, 0);
     }
     rvv_exec_wide_mac_vv(rv, ir, ir->vd, rvv_wop_mulu);
@@ -6318,8 +6399,9 @@ RVOP(vwmaccu_vx, {
         uint32_t narrow_span_cx = rvv_group_regs(rv->csr_vtype);
         if (!rvv_wide_group_span(rv, &wide_span_cx))
             return rvv_trap_illegal_state(rv, 0);
-        if (rvv_cross_eew_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
-                                          narrow_span_cx))
+        if (rvv_widen_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
+                                      narrow_span_cx,
+                                      rvv_sew_emul_at_least_1(rv)))
             return rvv_trap_illegal_state(rv, 0);
     }
     rvv_exec_wide_mac_vx(rv, ir, ir->vd, rvv_wop_mulu);
@@ -6337,10 +6419,12 @@ RVOP(vwmacc_vv, {
         uint32_t narrow_span_cx = rvv_group_regs(rv->csr_vtype);
         if (!rvv_wide_group_span(rv, &wide_span_cx))
             return rvv_trap_illegal_state(rv, 0);
-        if (rvv_cross_eew_overlap_illegal(ir->vd, wide_span_cx, ir->vs1,
-                                          narrow_span_cx) ||
-            rvv_cross_eew_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
-                                          narrow_span_cx))
+        if (rvv_widen_overlap_illegal(ir->vd, wide_span_cx, ir->vs1,
+                                      narrow_span_cx,
+                                      rvv_sew_emul_at_least_1(rv)) ||
+            rvv_widen_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
+                                      narrow_span_cx,
+                                      rvv_sew_emul_at_least_1(rv)))
             return rvv_trap_illegal_state(rv, 0);
     }
     rvv_exec_wide_mac_vv(rv, ir, ir->vd, rvv_wop_mul);
@@ -6357,8 +6441,9 @@ RVOP(vwmacc_vx, {
         uint32_t narrow_span_cx = rvv_group_regs(rv->csr_vtype);
         if (!rvv_wide_group_span(rv, &wide_span_cx))
             return rvv_trap_illegal_state(rv, 0);
-        if (rvv_cross_eew_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
-                                          narrow_span_cx))
+        if (rvv_widen_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
+                                      narrow_span_cx,
+                                      rvv_sew_emul_at_least_1(rv)))
             return rvv_trap_illegal_state(rv, 0);
     }
     rvv_exec_wide_mac_vx(rv, ir, ir->vd, rvv_wop_mul);
@@ -6375,8 +6460,9 @@ RVOP(vwmaccus_vx, {
         uint32_t narrow_span_cx = rvv_group_regs(rv->csr_vtype);
         if (!rvv_wide_group_span(rv, &wide_span_cx))
             return rvv_trap_illegal_state(rv, 0);
-        if (rvv_cross_eew_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
-                                          narrow_span_cx))
+        if (rvv_widen_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
+                                      narrow_span_cx,
+                                      rvv_sew_emul_at_least_1(rv)))
             return rvv_trap_illegal_state(rv, 0);
     }
     rvv_exec_wide_mac_vx(rv, ir, ir->vd, rvv_wop_mulus);
@@ -6394,10 +6480,12 @@ RVOP(vwmaccsu_vv, {
         uint32_t narrow_span_cx = rvv_group_regs(rv->csr_vtype);
         if (!rvv_wide_group_span(rv, &wide_span_cx))
             return rvv_trap_illegal_state(rv, 0);
-        if (rvv_cross_eew_overlap_illegal(ir->vd, wide_span_cx, ir->vs1,
-                                          narrow_span_cx) ||
-            rvv_cross_eew_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
-                                          narrow_span_cx))
+        if (rvv_widen_overlap_illegal(ir->vd, wide_span_cx, ir->vs1,
+                                      narrow_span_cx,
+                                      rvv_sew_emul_at_least_1(rv)) ||
+            rvv_widen_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
+                                      narrow_span_cx,
+                                      rvv_sew_emul_at_least_1(rv)))
             return rvv_trap_illegal_state(rv, 0);
     }
     rvv_exec_wide_mac_vv(rv, ir, ir->vd, rvv_wop_mulsu);
@@ -6414,8 +6502,9 @@ RVOP(vwmaccsu_vx, {
         uint32_t narrow_span_cx = rvv_group_regs(rv->csr_vtype);
         if (!rvv_wide_group_span(rv, &wide_span_cx))
             return rvv_trap_illegal_state(rv, 0);
-        if (rvv_cross_eew_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
-                                          narrow_span_cx))
+        if (rvv_widen_overlap_illegal(ir->vd, wide_span_cx, ir->vs2,
+                                      narrow_span_cx,
+                                      rvv_sew_emul_at_least_1(rv)))
             return rvv_trap_illegal_state(rv, 0);
     }
     rvv_exec_wide_mac_vx(rv, ir, ir->vd, rvv_wop_mulsu);
@@ -7324,43 +7413,43 @@ static inline void rvv_exec_vfmv_v_f(riscv_t *rv,
         set_fflag(rv);                                       \
     })
 
-#define RVV_FP64_WIDEN_VV_OP(name, opfn)                              \
-    RVOP(name, {                                                      \
-        uint32_t wide_span;                                           \
-        uint32_t narrow_span = rvv_group_regs(rv->csr_vtype);         \
-        if (rvv_require_operable(rv))                                 \
-            return false;                                             \
-        if ((rvv_sew_bits(rv->csr_vtype) != 32) ||                    \
-            !rvv_validate_wide_reg(rv, ir->vd) ||                     \
-            !rvv_validate_data_reg(rv->csr_vtype, ir->vs1) ||         \
-            !rvv_validate_data_reg(rv->csr_vtype, ir->vs2) ||         \
-            !rvv_wide_group_span(rv, &wide_span) ||                   \
-            rvv_cross_eew_overlap_illegal(ir->vd, wide_span, ir->vs1, \
-                                          narrow_span) ||             \
-            rvv_cross_eew_overlap_illegal(ir->vd, wide_span, ir->vs2, \
-                                          narrow_span))               \
-            return rvv_trap_illegal_state(rv, 0);                     \
-        rvv_fp_begin_round(rv);                                       \
-        rvv_exec_fp64_widen_vv(rv, ir, ir->vd, opfn);                 \
-        set_fflag(rv);                                                \
+#define RVV_FP64_WIDEN_VV_OP(name, opfn)                                       \
+    RVOP(name, {                                                               \
+        uint32_t wide_span;                                                    \
+        uint32_t narrow_span = rvv_group_regs(rv->csr_vtype);                  \
+        if (rvv_require_operable(rv))                                          \
+            return false;                                                      \
+        if ((rvv_sew_bits(rv->csr_vtype) != 32) ||                             \
+            !rvv_validate_wide_reg(rv, ir->vd) ||                              \
+            !rvv_validate_data_reg(rv->csr_vtype, ir->vs1) ||                  \
+            !rvv_validate_data_reg(rv->csr_vtype, ir->vs2) ||                  \
+            !rvv_wide_group_span(rv, &wide_span) ||                            \
+            rvv_widen_overlap_illegal(ir->vd, wide_span, ir->vs1, narrow_span, \
+                                      rvv_sew_emul_at_least_1(rv)) ||          \
+            rvv_widen_overlap_illegal(ir->vd, wide_span, ir->vs2, narrow_span, \
+                                      rvv_sew_emul_at_least_1(rv)))            \
+            return rvv_trap_illegal_state(rv, 0);                              \
+        rvv_fp_begin_round(rv);                                                \
+        rvv_exec_fp64_widen_vv(rv, ir, ir->vd, opfn);                          \
+        set_fflag(rv);                                                         \
     })
 
-#define RVV_FP64_WIDEN_VF_OP(name, opfn)                              \
-    RVOP(name, {                                                      \
-        uint32_t wide_span;                                           \
-        uint32_t narrow_span = rvv_group_regs(rv->csr_vtype);         \
-        if (rvv_require_operable(rv))                                 \
-            return false;                                             \
-        if ((rvv_sew_bits(rv->csr_vtype) != 32) ||                    \
-            !rvv_validate_wide_reg(rv, ir->vd) ||                     \
-            !rvv_validate_data_reg(rv->csr_vtype, ir->vs2) ||         \
-            !rvv_wide_group_span(rv, &wide_span) ||                   \
-            rvv_cross_eew_overlap_illegal(ir->vd, wide_span, ir->vs2, \
-                                          narrow_span))               \
-            return rvv_trap_illegal_state(rv, 0);                     \
-        rvv_fp_begin_round(rv);                                       \
-        rvv_exec_fp64_widen_vf(rv, ir, ir->vd, opfn);                 \
-        set_fflag(rv);                                                \
+#define RVV_FP64_WIDEN_VF_OP(name, opfn)                                       \
+    RVOP(name, {                                                               \
+        uint32_t wide_span;                                                    \
+        uint32_t narrow_span = rvv_group_regs(rv->csr_vtype);                  \
+        if (rvv_require_operable(rv))                                          \
+            return false;                                                      \
+        if ((rvv_sew_bits(rv->csr_vtype) != 32) ||                             \
+            !rvv_validate_wide_reg(rv, ir->vd) ||                              \
+            !rvv_validate_data_reg(rv->csr_vtype, ir->vs2) ||                  \
+            !rvv_wide_group_span(rv, &wide_span) ||                            \
+            rvv_widen_overlap_illegal(ir->vd, wide_span, ir->vs2, narrow_span, \
+                                      rvv_sew_emul_at_least_1(rv)))            \
+            return rvv_trap_illegal_state(rv, 0);                              \
+        rvv_fp_begin_round(rv);                                                \
+        rvv_exec_fp64_widen_vf(rv, ir, ir->vd, opfn);                          \
+        set_fflag(rv);                                                         \
     })
 
 #define RVV_FP64_RED_OP(name, opfn)                         \
@@ -7377,23 +7466,23 @@ static inline void rvv_exec_vfmv_v_f(riscv_t *rv,
         set_fflag(rv);                                      \
     })
 
-#define RVV_FP64_MIXED_VV_OP(name, opfn)                              \
-    RVOP(name, {                                                      \
-        uint32_t wide_span;                                           \
-        uint32_t narrow_span = rvv_group_regs(rv->csr_vtype);         \
-        if (rvv_require_operable(rv))                                 \
-            return false;                                             \
-        if ((rvv_sew_bits(rv->csr_vtype) != 32) ||                    \
-            !rvv_validate_wide_reg(rv, ir->vd) ||                     \
-            !rvv_validate_wide_reg(rv, ir->vs2) ||                    \
-            !rvv_validate_data_reg(rv->csr_vtype, ir->vs1) ||         \
-            !rvv_wide_group_span(rv, &wide_span) ||                   \
-            rvv_cross_eew_overlap_illegal(ir->vd, wide_span, ir->vs1, \
-                                          narrow_span))               \
-            return rvv_trap_illegal_state(rv, 0);                     \
-        rvv_fp_begin_round(rv);                                       \
-        rvv_exec_fp64_mixed_vv(rv, ir, ir->vd, opfn);                 \
-        set_fflag(rv);                                                \
+#define RVV_FP64_MIXED_VV_OP(name, opfn)                                       \
+    RVOP(name, {                                                               \
+        uint32_t wide_span;                                                    \
+        uint32_t narrow_span = rvv_group_regs(rv->csr_vtype);                  \
+        if (rvv_require_operable(rv))                                          \
+            return false;                                                      \
+        if ((rvv_sew_bits(rv->csr_vtype) != 32) ||                             \
+            !rvv_validate_wide_reg(rv, ir->vd) ||                              \
+            !rvv_validate_wide_reg(rv, ir->vs2) ||                             \
+            !rvv_validate_data_reg(rv->csr_vtype, ir->vs1) ||                  \
+            !rvv_wide_group_span(rv, &wide_span) ||                            \
+            rvv_widen_overlap_illegal(ir->vd, wide_span, ir->vs1, narrow_span, \
+                                      rvv_sew_emul_at_least_1(rv)))            \
+            return rvv_trap_illegal_state(rv, 0);                              \
+        rvv_fp_begin_round(rv);                                                \
+        rvv_exec_fp64_mixed_vv(rv, ir, ir->vd, opfn);                          \
+        set_fflag(rv);                                                         \
     })
 
 #define RVV_FP64_MIXED_VF_OP(name, opfn)              \
@@ -7409,43 +7498,43 @@ static inline void rvv_exec_vfmv_v_f(riscv_t *rv,
         set_fflag(rv);                                \
     })
 
-#define RVV_FP64_MAC_VV_OP(name, opfn)                                \
-    RVOP(name, {                                                      \
-        uint32_t wide_span;                                           \
-        uint32_t narrow_span = rvv_group_regs(rv->csr_vtype);         \
-        if (rvv_require_operable(rv))                                 \
-            return false;                                             \
-        if ((rvv_sew_bits(rv->csr_vtype) != 32) ||                    \
-            !rvv_validate_wide_reg(rv, ir->vd) ||                     \
-            !rvv_validate_data_reg(rv->csr_vtype, ir->vs1) ||         \
-            !rvv_validate_data_reg(rv->csr_vtype, ir->vs2) ||         \
-            !rvv_wide_group_span(rv, &wide_span) ||                   \
-            rvv_cross_eew_overlap_illegal(ir->vd, wide_span, ir->vs1, \
-                                          narrow_span) ||             \
-            rvv_cross_eew_overlap_illegal(ir->vd, wide_span, ir->vs2, \
-                                          narrow_span))               \
-            return rvv_trap_illegal_state(rv, 0);                     \
-        rvv_fp_begin_round(rv);                                       \
-        rvv_exec_fp64_mac_vv(rv, ir, ir->vd, opfn);                   \
-        set_fflag(rv);                                                \
+#define RVV_FP64_MAC_VV_OP(name, opfn)                                         \
+    RVOP(name, {                                                               \
+        uint32_t wide_span;                                                    \
+        uint32_t narrow_span = rvv_group_regs(rv->csr_vtype);                  \
+        if (rvv_require_operable(rv))                                          \
+            return false;                                                      \
+        if ((rvv_sew_bits(rv->csr_vtype) != 32) ||                             \
+            !rvv_validate_wide_reg(rv, ir->vd) ||                              \
+            !rvv_validate_data_reg(rv->csr_vtype, ir->vs1) ||                  \
+            !rvv_validate_data_reg(rv->csr_vtype, ir->vs2) ||                  \
+            !rvv_wide_group_span(rv, &wide_span) ||                            \
+            rvv_widen_overlap_illegal(ir->vd, wide_span, ir->vs1, narrow_span, \
+                                      rvv_sew_emul_at_least_1(rv)) ||          \
+            rvv_widen_overlap_illegal(ir->vd, wide_span, ir->vs2, narrow_span, \
+                                      rvv_sew_emul_at_least_1(rv)))            \
+            return rvv_trap_illegal_state(rv, 0);                              \
+        rvv_fp_begin_round(rv);                                                \
+        rvv_exec_fp64_mac_vv(rv, ir, ir->vd, opfn);                            \
+        set_fflag(rv);                                                         \
     })
 
-#define RVV_FP64_MAC_VF_OP(name, opfn)                                \
-    RVOP(name, {                                                      \
-        uint32_t wide_span;                                           \
-        uint32_t narrow_span = rvv_group_regs(rv->csr_vtype);         \
-        if (rvv_require_operable(rv))                                 \
-            return false;                                             \
-        if ((rvv_sew_bits(rv->csr_vtype) != 32) ||                    \
-            !rvv_validate_wide_reg(rv, ir->vd) ||                     \
-            !rvv_validate_data_reg(rv->csr_vtype, ir->vs2) ||         \
-            !rvv_wide_group_span(rv, &wide_span) ||                   \
-            rvv_cross_eew_overlap_illegal(ir->vd, wide_span, ir->vs2, \
-                                          narrow_span))               \
-            return rvv_trap_illegal_state(rv, 0);                     \
-        rvv_fp_begin_round(rv);                                       \
-        rvv_exec_fp64_mac_vf(rv, ir, ir->vd, opfn);                   \
-        set_fflag(rv);                                                \
+#define RVV_FP64_MAC_VF_OP(name, opfn)                                         \
+    RVOP(name, {                                                               \
+        uint32_t wide_span;                                                    \
+        uint32_t narrow_span = rvv_group_regs(rv->csr_vtype);                  \
+        if (rvv_require_operable(rv))                                          \
+            return false;                                                      \
+        if ((rvv_sew_bits(rv->csr_vtype) != 32) ||                             \
+            !rvv_validate_wide_reg(rv, ir->vd) ||                              \
+            !rvv_validate_data_reg(rv->csr_vtype, ir->vs2) ||                  \
+            !rvv_wide_group_span(rv, &wide_span) ||                            \
+            rvv_widen_overlap_illegal(ir->vd, wide_span, ir->vs2, narrow_span, \
+                                      rvv_sew_emul_at_least_1(rv)))            \
+            return rvv_trap_illegal_state(rv, 0);                              \
+        rvv_fp_begin_round(rv);                                                \
+        rvv_exec_fp64_mac_vf(rv, ir, ir->vd, opfn);                            \
+        set_fflag(rv);                                                         \
     })
 
 RVV_FP32_VV_OP(vfadd_vv, rvv_fp_add32, true);

--- a/tests/rvv-smoke.S
+++ b/tests/rvv-smoke.S
@@ -44,6 +44,9 @@ cmp_src:
 cmp_init:
     .byte 0x0a, 0x00, 0x00, 0x00
 
+widen_overlap_src:
+    .short 3, 4, 5, 6
+
 mask_prefix_src:
     .byte 0x14, 0x00, 0x00, 0x00
 
@@ -1813,6 +1816,30 @@ _start:
     csrr t1, vl
     assert_reg_imm t1, 4, fail_fractional
 
+    /*
+     * Cross-EEW overlap, widening direction (V 1.0 5.2): a destination
+     * group whose EEW exceeds the source EEW may overlap the source when
+     * the source EMUL is at least 1 and the overlap sits in the HIGHEST-
+     * numbered part of the destination group. At SEW=16/LMUL=1 the dest
+     * group of vwadd.vv v0 is {v0,v1}, so a source of v1 is legal and must
+     * execute rather than trap. (The reserved cases - e.g. a source of v0,
+     * sharing the base register - raise an illegal instruction, which this
+     * harness cannot observe in user mode; see issue #735.)
+     */
+    li a0, 4
+    vsetvli t0, a0, e16, m1, tu, mu
+    la a1, widen_overlap_src
+    vle16.v v1, (a1)
+    vwadd.vv v0, v1, v1
+    li a0, 4
+    vsetvli t0, a0, e32, m2, tu, mu
+    la a1, fp32_out
+    vse32.v v0, (a1)
+    lw t1, 0(a1)
+    assert_reg_imm t1, 6, fail_widen_overlap
+    lw t1, 12(a1)
+    assert_reg_imm t1, 12, fail_widen_overlap
+
     la a1, ok_msg
     li a2, ok_msg_len
     j write_and_exit_ok
@@ -2042,6 +2069,9 @@ fail_vfwredusumf:
     j write_and_exit_fail
 fail_fractional:
     li a3, 0xf0
+    j write_and_exit_fail
+fail_widen_overlap:
+    li a3, 0xf1
     j write_and_exit_fail
 
 write_and_exit_fail:


### PR DESCRIPTION
Fixes the cross-EEW overlap bug I mentioned in #734.

`rvv_cross_eew_overlap_illegal()` applies one condition to both the widening
and the narrowing direction, and its comment says the spec rule is symmetric.
V 1.0 §5.2 gives two different conditions. A destination group may overlap a
source group when the destination EEW is smaller and the overlap is in the
lowest-numbered part of the source group, or when the destination EEW is
greater, the source EMUL is at least 1, and the overlap is in the
highest-numbered part of the destination group.

Narrowing takes the destination as the narrower group, so "lowest part of the
source" collapses to the shared-base-register test the helper implements and
is correct there. Widening is the wrong end of the wrong group: a shared base
register is accepted where the spec reserves it, and an overlap at the top of
the destination group is rejected where the spec allows it.

At SEW=16/LMUL=1 the destination group of `vwadd.vv v0` is {v0,v1}, so
`vwadd.vv v0, v1, v1` is spec-legal and raised an illegal instruction, while
the reserved `vwadd.vv v2, v2, v2` was accepted. The spec's own widening
example, `vzext.vf4 v0, v6` at LMUL=8, is inverted the same way.

The predicate is split in two, keeping the existing test for narrowing and
adding the top-of-destination test for widening, and the `vw*` integer ops,
the `vwadd`/`vwsub` `.w` forms and the `RVV_FP64_WIDEN_*` macros move onto
the latter.

Two things worth flagging for review:

Source EMUL cannot be read back from the register span, since
`rvv_eew_reg_span()` clamps a fractional EMUL up to a span of one register
and leaves EMUL=1 and EMUL=1/2 indistinguishable, so it comes from
`rvv_lmul_ratio()` instead. This is the same reasoning as in #767.

Segment indexed loads are not a widening site at all. The destination EEW is
SEW and the source EEW is the index EEW, with neither fixed relative to the
other, so they pick the direction by comparing the two spans and keep the
plain overlap check when the EEWs agree.

`tests/rvv-smoke.S` covers the legal direction, which fails without this
change. The reserved cases stay uncovered: an illegal instruction in user
mode reaches `__trap_handler` and the run still exits 0, which is the
scaffolding #735 item 1 asks for.

`make check` passes with `EXT_V` enabled; clang-format 20.1.7 clean.

Note on ordering: #771 carries a private copy of this rule under the same
name, added because the shared helper was wrong. If this lands first, that
copy should be dropped in favour of the shared predicate when #771 rebases —
git merges the two without reporting a conflict, but the result has two
definitions of `rvv_widen_overlap_illegal()` and does not compile.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the cross-EEW overlap check for widening vector ops so it matches V 1.0 §5.2. Widening and narrowing now use separate predicates; the old shared rule wrongly accepted reserved overlaps and rejected legal ones. For example, `vwadd.vv v0, v1, v1` at SEW=16/LMUL=1 now executes, while `vwadd.vv v2, v2, v2` now traps.

**Details**
- Splits `rvv_cross_eew_overlap_illegal()` into `rvv_narrow_overlap_illegal()` (unchanged behavior) and `rvv_widen_overlap_illegal()`, which requires source EMUL >= 1 and overlap at the highest-numbered destination part.
- Derives source EMUL from `rvv_lmul_ratio()` because `rvv_eew_reg_span()` cannot distinguish EMUL=1 from fractional EMUL.
- Segment indexed loads pick direction by comparing EEWs and keep the plain overlap check when EEWs are equal.
- Adds a smoke test for the legal widening overlap; reserved cases can't be observed in user mode (issue #735).
- `#771` carries a private copy of this helper; when it rebases, drop that copy to avoid duplicate `rvv_widen_overlap_illegal()` definitions.

<sup>Written for commit 9cfd5c0e45438749d6ea42b51b5e9751175c21b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/rv32emu/pull/774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

